### PR TITLE
feat: decorator infra + searchable decorator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
 			},
 			"devDependencies": {
 				"@biomejs/biome": "^2.3.7",
+				"@types/node": "^22.18.11",
+				"tsx": "^4.20.5",
 				"typescript": "^5.9.3"
 			}
 		},
@@ -211,6 +213,448 @@
 			],
 			"engines": {
 				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+			"integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+			"integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+			"integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+			"integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+			"integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+			"integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+			"integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+			"integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+			"integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+			"integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+			"integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+			"integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+			"integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+			"integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+			"integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+			"integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+			"integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+			"integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+			"integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+			"integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+			"integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+			"integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+			"integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+			"integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+			"integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+			"integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@inquirer/ansi": {
@@ -600,6 +1044,16 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/@types/node": {
+			"version": "22.19.17",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+			"integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+			"devOptional": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
 		"node_modules/@typespec/compiler": {
 			"version": "1.11.0",
 			"resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.11.0.tgz",
@@ -749,6 +1203,48 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/esbuild": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+			"integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.27.7",
+				"@esbuild/android-arm": "0.27.7",
+				"@esbuild/android-arm64": "0.27.7",
+				"@esbuild/android-x64": "0.27.7",
+				"@esbuild/darwin-arm64": "0.27.7",
+				"@esbuild/darwin-x64": "0.27.7",
+				"@esbuild/freebsd-arm64": "0.27.7",
+				"@esbuild/freebsd-x64": "0.27.7",
+				"@esbuild/linux-arm": "0.27.7",
+				"@esbuild/linux-arm64": "0.27.7",
+				"@esbuild/linux-ia32": "0.27.7",
+				"@esbuild/linux-loong64": "0.27.7",
+				"@esbuild/linux-mips64el": "0.27.7",
+				"@esbuild/linux-ppc64": "0.27.7",
+				"@esbuild/linux-riscv64": "0.27.7",
+				"@esbuild/linux-s390x": "0.27.7",
+				"@esbuild/linux-x64": "0.27.7",
+				"@esbuild/netbsd-arm64": "0.27.7",
+				"@esbuild/netbsd-x64": "0.27.7",
+				"@esbuild/openbsd-arm64": "0.27.7",
+				"@esbuild/openbsd-x64": "0.27.7",
+				"@esbuild/openharmony-arm64": "0.27.7",
+				"@esbuild/sunos-x64": "0.27.7",
+				"@esbuild/win32-arm64": "0.27.7",
+				"@esbuild/win32-ia32": "0.27.7",
+				"@esbuild/win32-x64": "0.27.7"
+			}
+		},
 		"node_modules/escalade": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -841,6 +1337,21 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
 		"node_modules/get-caller-file": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -860,6 +1371,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/get-tsconfig": {
+			"version": "4.14.0",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+			"integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"resolve-pkg-maps": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
 			}
 		},
 		"node_modules/glob-parent": {
@@ -1120,6 +1644,16 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/resolve-pkg-maps": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+			"integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+			}
+		},
 		"node_modules/reusify": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -1270,6 +1804,26 @@
 				"node": ">=8.0"
 			}
 		},
+		"node_modules/tsx": {
+			"version": "4.21.0",
+			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+			"integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"esbuild": "~0.27.0",
+				"get-tsconfig": "^4.7.5"
+			},
+			"bin": {
+				"tsx": "dist/cli.mjs"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			}
+		},
 		"node_modules/typescript": {
 			"version": "5.9.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -1283,6 +1837,13 @@
 			"engines": {
 				"node": ">=14.17"
 			}
+		},
+		"node_modules/undici-types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"devOptional": true,
+			"license": "MIT"
 		},
 		"node_modules/unicorn-magic": {
 			"version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -23,9 +23,10 @@
 		"lint": "npx @biomejs/biome check",
 		"build": "tsc",
 		"watch": "tsc --watch",
-		"test": "npm run build && npm run lint && npm run test:emit && npm run test:example",
+		"test": "npm run build && npm run lint && npm run test:unit && npm run test:emit && npm run test:example",
 		"test:emit": "tsp compile test/main.tsp --config test/tspconfig.yaml",
 		"test:example": "node --test test/example.js",
+		"test:unit": "node --test --import=tsx src/**/*.test.ts",
 		"prepublishOnly": "tsc"
 	},
 	"dependencies": {
@@ -33,6 +34,8 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.3.7",
+		"@types/node": "^22.18.11",
+		"tsx": "^4.20.5",
 		"typescript": "^5.9.3"
 	}
 }

--- a/src/decorators.test.ts
+++ b/src/decorators.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { createTestHost, createTestWrapper } from "@typespec/compiler/testing";
+import {
+	getAnalyzer,
+	getBoost,
+	getIndexName,
+	isKeyword,
+	isNested,
+	isSearchable,
+} from "./decorators.js";
+import { OpenSearchEmitterTestLibrary } from "./testing/index.js";
+
+async function createRunner() {
+	const host = await createTestHost({
+		libraries: [OpenSearchEmitterTestLibrary],
+	});
+
+	return createTestWrapper(host, {
+		autoImports: ["@kattebak/typespec-opensearch-emitter"],
+		autoUsings: ["Kattebak.OpenSearch"],
+	});
+}
+
+describe("decorators", () => {
+	it("marks property as searchable", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Product {
+        @searchable name: string;
+      }
+    `);
+
+		assert.equal(diagnostics.length, 0);
+
+		const product = runner.program
+			.getGlobalNamespaceType()
+			.models.get("Product");
+		assert.ok(product);
+
+		const name = product.properties.get("name");
+		assert.ok(name);
+		assert.equal(isSearchable(runner.program, name), true);
+	});
+
+	it("stores values for all decorator state accessors", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      @indexName("products_v1")
+      model ProductSearchDoc is SearchProjection<Product> {
+        @searchable @keyword @nested @analyzer("edge_ngram") @boost(2.0)
+        name: string;
+      }
+
+      model Product {
+        @searchable name: string;
+      }
+    `);
+
+		assert.equal(diagnostics.length, 0);
+
+		const ns = runner.program.getGlobalNamespaceType();
+		const projection = ns.models.get("ProductSearchDoc");
+		assert.ok(projection);
+
+		const name = projection.properties.get("name");
+		assert.ok(name);
+
+		assert.equal(isSearchable(runner.program, name), true);
+		assert.equal(isKeyword(runner.program, name), true);
+		assert.equal(isNested(runner.program, name), true);
+		assert.equal(getAnalyzer(runner.program, name), "edge_ngram");
+		assert.equal(getBoost(runner.program, name), 2);
+		assert.equal(getIndexName(runner.program, projection), "products_v1");
+	});
+});

--- a/src/decorators.test.ts
+++ b/src/decorators.test.ts
@@ -29,6 +29,7 @@ describe("decorators", () => {
 		const diagnostics = await runner.diagnose(`
       model Product {
         @searchable name: string;
+        description: string;
       }
     `);
 
@@ -42,6 +43,10 @@ describe("decorators", () => {
 		const name = product.properties.get("name");
 		assert.ok(name);
 		assert.equal(isSearchable(runner.program, name), true);
+
+		const description = product.properties.get("description");
+		assert.ok(description);
+		assert.equal(isSearchable(runner.program, description), false);
 	});
 
 	it("stores values for all decorator state accessors", async () => {

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -1,0 +1,87 @@
+import type {
+	DecoratorContext,
+	Model,
+	ModelProperty,
+	Program,
+} from "@typespec/compiler";
+import { StateKeys } from "./lib.js";
+
+export const namespace = "Kattebak.OpenSearch";
+
+export function $searchable(
+	context: DecoratorContext,
+	target: ModelProperty,
+): void {
+	context.program.stateSet(StateKeys.searchable).add(target);
+}
+
+export function isSearchable(program: Program, target: ModelProperty): boolean {
+	return program.stateSet(StateKeys.searchable).has(target);
+}
+
+export function $keyword(
+	context: DecoratorContext,
+	target: ModelProperty,
+): void {
+	context.program.stateSet(StateKeys.keyword).add(target);
+}
+
+export function isKeyword(program: Program, target: ModelProperty): boolean {
+	return program.stateSet(StateKeys.keyword).has(target);
+}
+
+export function $nested(
+	context: DecoratorContext,
+	target: ModelProperty,
+): void {
+	context.program.stateSet(StateKeys.nested).add(target);
+}
+
+export function isNested(program: Program, target: ModelProperty): boolean {
+	return program.stateSet(StateKeys.nested).has(target);
+}
+
+export function $analyzer(
+	context: DecoratorContext,
+	target: ModelProperty,
+	name: string,
+): void {
+	context.program.stateMap(StateKeys.analyzer).set(target, name);
+}
+
+export function getAnalyzer(
+	program: Program,
+	target: ModelProperty,
+): string | undefined {
+	return program.stateMap(StateKeys.analyzer).get(target);
+}
+
+export function $boost(
+	context: DecoratorContext,
+	target: ModelProperty,
+	factor: number,
+): void {
+	context.program.stateMap(StateKeys.boost).set(target, factor);
+}
+
+export function getBoost(
+	program: Program,
+	target: ModelProperty,
+): number | undefined {
+	return program.stateMap(StateKeys.boost).get(target);
+}
+
+export function $indexName(
+	context: DecoratorContext,
+	target: Model,
+	name: string,
+): void {
+	context.program.stateMap(StateKeys.indexName).set(target, name);
+}
+
+export function getIndexName(
+	program: Program,
+	target: Model,
+): string | undefined {
+	return program.stateMap(StateKeys.indexName).get(target);
+}

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -43,6 +43,8 @@ function isUserModel(model: Model): boolean {
 		return false;
 	}
 
+	// Temporary name-based filter for library models.
+	// This will be replaced by explicit SearchProjection<T> resolution in #10/#11.
 	if (
 		namespaceName === "OpenSearch" &&
 		model.namespace?.namespace?.name === "Kattebak"

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -30,12 +30,23 @@ function collectModels(namespace: Namespace, models: string[]): void {
 }
 
 function isUserModel(model: Model): boolean {
-	if (model.name === "Array" || model.name === "Record") {
+	if (
+		model.name === "Array" ||
+		model.name === "Record" ||
+		model.name === "SearchProjection"
+	) {
 		return false;
 	}
 
 	const namespaceName = model.namespace?.name;
 	if (namespaceName === "TypeSpec" || namespaceName === "Reflection") {
+		return false;
+	}
+
+	if (
+		namespaceName === "OpenSearch" &&
+		model.namespace?.namespace?.name === "Kattebak"
+	) {
 		return false;
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,17 @@
+export {
+	$analyzer,
+	$boost,
+	$indexName,
+	$keyword,
+	$nested,
+	$searchable,
+	getAnalyzer,
+	getBoost,
+	getIndexName,
+	isKeyword,
+	isNested,
+	isSearchable,
+	namespace,
+} from "./decorators.js";
 export { $onEmit } from "./emitter.js";
 export { $lib } from "./lib.js";

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,18 +1,38 @@
+import { createTypeSpecLibrary } from "@typespec/compiler";
+
 export interface OpenSearchEmitterOptions {
 	"output-file"?: string;
 }
 
-export const $lib = {
-	"emitter-options-schema": {
-		type: "object",
-		additionalProperties: false,
-		properties: {
-			"output-file": {
-				type: "string",
-				nullable: true,
-				default: "opensearch-projections.json",
+export const $lib = createTypeSpecLibrary({
+	name: "@kattebak/typespec-opensearch-emitter",
+	diagnostics: {},
+	state: {
+		searchable: { description: "Marks a property as searchable" },
+		keyword: { description: "Marks a property as keyword" },
+		nested: { description: "Marks a property as nested" },
+		analyzer: { description: "Analyzer override for a property" },
+		boost: { description: "Boost override for a property" },
+		indexName: { description: "Index name override for a projection model" },
+	},
+	emitter: {
+		options: {
+			type: "object",
+			additionalProperties: false,
+			properties: {
+				"output-file": {
+					type: "string",
+					nullable: true,
+					default: "opensearch-projections.json",
+				},
 			},
+			required: [],
 		},
-		required: [],
-	} as const,
-};
+	},
+});
+
+export const {
+	reportDiagnostic,
+	createDiagnostic,
+	stateKeys: StateKeys,
+} = $lib;

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -1,0 +1,14 @@
+import { fileURLToPath } from "node:url";
+import { resolvePath } from "@typespec/compiler";
+import {
+	createTestLibrary,
+	type TypeSpecTestLibrary,
+} from "@typespec/compiler/testing";
+
+export const OpenSearchEmitterTestLibrary: TypeSpecTestLibrary =
+	createTestLibrary({
+		name: "@kattebak/typespec-opensearch-emitter",
+		packageRoot: resolvePath(fileURLToPath(import.meta.url), "../../../"),
+		typespecFileFolder: "tsp",
+		jsFileFolder: "dist",
+	});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
 		"lib": ["ES2020"],
 		"skipLibCheck": true,
 		"strict": true,
-		"esModuleInterop": true
+		"esModuleInterop": true,
+		"types": ["node"]
 	},
 	"include": ["src/**/*"],
 	"exclude": ["node_modules", "dist", "**/*.test.ts"]

--- a/tsp/main.tsp
+++ b/tsp/main.tsp
@@ -1,1 +1,14 @@
 import "../dist/index.js";
+
+using TypeSpec.Reflection;
+
+namespace Kattebak.OpenSearch;
+
+extern dec searchable(target: ModelProperty);
+extern dec keyword(target: ModelProperty);
+extern dec nested(target: ModelProperty);
+extern dec analyzer(target: ModelProperty, name: valueof string);
+extern dec boost(target: ModelProperty, factor: valueof float64);
+extern dec indexName(target: Model, name: valueof string);
+
+model SearchProjection<T> {}


### PR DESCRIPTION
## Summary

Implements the first stack slice after RFC planning:

- decorator state infrastructure in `src/decorators.ts`
- `@searchable` decorator implementation + accessor
- test harness wiring for TypeSpec library integration tests
- package/test scaffolding updates required to run unit tests in this repo shape

## Changes

- `src/lib.ts`
  - switched to `createTypeSpecLibrary`
  - added state keys for all six decorators
  - kept emitter options schema in `emitter.options`
- `src/decorators.ts`
  - added state-backed implementations and accessors:
    - `$searchable` / `isSearchable`
    - `$keyword` / `isKeyword`
    - `$nested` / `isNested`
    - `$analyzer` / `getAnalyzer`
    - `$boost` / `getBoost`
    - `$indexName` / `getIndexName`
- `src/index.ts`
  - re-exports decorator APIs and namespace
- `tsp/main.tsp`
  - declared namespace + extern decorators
  - added `SearchProjection<T>` scaffold
- `src/decorators.test.ts`
  - integration-style tests proving decorator application and state accessors
- `src/testing/index.ts`
  - `createTestLibrary` helper for this package layout
- `package.json`, `tsconfig.json`
  - added `test:unit` script and `tsx`
  - added `@types/node` for test/build typing
- `src/emitter.ts`
  - excluded library template model from current placeholder model list to keep existing e2e test stable

## Validation

- `npm test` passes

## Issues

- Closes #5
- Closes #6
