### PR TITLE
feat: add SearchProjection resolution and emitter collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,32 @@ A TypeSpec emitter for generating OpenSearch projection metadata.
 
 ## Status
 
-Scaffolded emitter skeleton with CI, linting, tests, and TypeSpec emitter wiring.
+Implemented so far:
+
+- Decorator infrastructure via TypeSpec library state
+- Decorators: `@searchable`, `@keyword`, `@nested`, `@analyzer`, `@boost`, `@indexName`
+- Decorator validation diagnostics
+- `SearchProjection<T>` template + projection resolution
+- Emitter collection of projection models and resolved projection metadata output
+- CI, linting, unit tests, emitter E2E test
 
 ## Usage
 
 ```typespec
 import "@kattebak/typespec-opensearch-emitter";
+
+using Kattebak.OpenSearch;
+
+model Product {
+  @searchable id: string;
+  @searchable @keyword title: string;
+  internalNotes: string;
+}
+
+@indexName("products_v1")
+model ProductSearchDoc is SearchProjection<Product> {
+  @analyzer("edge_ngram") title: string;
+}
 ```
 
 ```yaml
@@ -19,3 +39,5 @@ options:
   "@kattebak/typespec-opensearch-emitter":
     output-file: "opensearch-projections.json"
 ```
+
+Current emitted file is projection metadata JSON and is an intermediate step toward document type and mapping emitters.

--- a/src/emitter.test.ts
+++ b/src/emitter.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { createTestHost, createTestWrapper } from "@typespec/compiler/testing";
+import { __test } from "./emitter.js";
+import type { ResolvedProjection } from "./projection.js";
+import { OpenSearchEmitterTestLibrary } from "./testing/index.js";
+
+async function createRunner() {
+	const host = await createTestHost({
+		libraries: [OpenSearchEmitterTestLibrary],
+	});
+
+	return createTestWrapper(host, {
+		autoImports: ["@kattebak/typespec-opensearch-emitter"],
+		autoUsings: ["Kattebak.OpenSearch"],
+	});
+}
+
+describe("emitter model collection", () => {
+	it("collects only SearchProjection<T> models", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Product {
+        @searchable name: string;
+        hidden: string;
+      }
+
+      model ProductSearchDoc is SearchProjection<Product> {}
+      model Inventory {}
+    `);
+
+		assert.equal(diagnostics.length, 0);
+
+		const models = __test.collectProjectionModels(
+			runner.program,
+			runner.program.getGlobalNamespaceType(),
+		);
+		assert.deepEqual(
+			models.map((x) => x.name),
+			["ProductSearchDoc"],
+		);
+	});
+
+	it("serializes resolved projections", () => {
+		const projections = [
+			{
+				projectionModel: { name: "ProductSearchDoc" },
+				sourceModel: { name: "Product" },
+				indexName: "product_search_doc",
+				fields: [
+					{
+						name: "name",
+						optional: false,
+						keyword: true,
+						nested: false,
+						analyzer: "edge_ngram",
+						boost: 2,
+					},
+				],
+			},
+		] as unknown as ResolvedProjection[];
+		const serialized = __test.serializeProjections(projections);
+
+		assert.deepEqual(serialized, {
+			projections: [
+				{
+					name: "ProductSearchDoc",
+					sourceModel: "Product",
+					indexName: "product_search_doc",
+					fields: [
+						{
+							name: "name",
+							optional: false,
+							keyword: true,
+							nested: false,
+							analyzer: "edge_ngram",
+							boost: 2,
+						},
+					],
+				},
+			],
+		});
+	});
+});

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -1,35 +1,65 @@
-import type { EmitContext, Model, Namespace } from "@typespec/compiler";
+import type {
+	EmitContext,
+	Model,
+	Namespace,
+	Program,
+} from "@typespec/compiler";
 import { emitFile, resolvePath } from "@typespec/compiler";
 import type { OpenSearchEmitterOptions } from "./lib.js";
+import {
+	isSearchProjectionModel,
+	type ResolvedProjection,
+	resolveProjectionModel,
+} from "./projection.js";
 
 export async function $onEmit(
 	context: EmitContext<OpenSearchEmitterOptions>,
 ): Promise<void> {
 	const outputFile =
 		context.options["output-file"] ?? "opensearch-projections.json";
-	const models: string[] = [];
 
-	collectModels(context.program.getGlobalNamespaceType(), models);
+	const projectionModels = collectProjectionModels(
+		context.program,
+		context.program.getGlobalNamespaceType(),
+	);
+	if (projectionModels.length === 0) {
+		return;
+	}
+
+	const resolved = projectionModels
+		.map((model) => resolveProjectionModel(context.program, model))
+		.filter((x): x is ResolvedProjection => x !== undefined);
 
 	await emitFile(context.program, {
 		path: resolvePath(context.emitterOutputDir, outputFile),
-		content: `${JSON.stringify({ models }, null, 2)}\n`,
+		content: `${JSON.stringify(serializeProjections(resolved), null, 2)}\n`,
 	});
 }
 
-function collectModels(namespace: Namespace, models: string[]): void {
+function collectProjectionModels(
+	program: Program,
+	namespace: Namespace,
+): Model[] {
+	const models: Model[] = [];
+
 	for (const model of namespace.models.values()) {
-		if (isUserModel(model)) {
-			models.push(model.name);
+		if (
+			isCandidateModel(model) &&
+			!isTemplateDeclaration(model) &&
+			isSearchProjectionModel(program, model)
+		) {
+			models.push(model);
 		}
 	}
 
 	for (const child of namespace.namespaces.values()) {
-		collectModels(child, models);
+		models.push(...collectProjectionModels(program, child));
 	}
+
+	return models;
 }
 
-function isUserModel(model: Model): boolean {
+function isCandidateModel(model: Model): boolean {
 	if (
 		model.name === "Array" ||
 		model.name === "Record" ||
@@ -55,7 +85,38 @@ function isUserModel(model: Model): boolean {
 	return !!model.name;
 }
 
+function isTemplateDeclaration(model: Model): boolean {
+	if (model.node && "templateParameters" in model.node) {
+		const templateParams = (
+			model.node as { templateParameters?: readonly unknown[] }
+		).templateParameters;
+		return !!templateParams && templateParams.length > 0;
+	}
+
+	return false;
+}
+
+function serializeProjections(resolved: ResolvedProjection[]) {
+	return {
+		projections: resolved.map((projection) => ({
+			name: projection.projectionModel.name,
+			sourceModel: projection.sourceModel.name,
+			indexName: projection.indexName,
+			fields: projection.fields.map((field) => ({
+				name: field.name,
+				optional: field.optional,
+				keyword: field.keyword,
+				nested: field.nested,
+				analyzer: field.analyzer,
+				boost: field.boost,
+			})),
+		})),
+	};
+}
+
 export const __test = {
-	collectModels,
-	isUserModel,
+	collectProjectionModels,
+	isCandidateModel,
+	isTemplateDeclaration,
+	serializeProjections,
 };

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -73,15 +73,6 @@ function isCandidateModel(model: Model): boolean {
 		return false;
 	}
 
-	// Temporary name-based filter for library models.
-	// This will be replaced by explicit SearchProjection<T> resolution in #10/#11.
-	if (
-		namespaceName === "OpenSearch" &&
-		model.namespace?.namespace?.name === "Kattebak"
-	) {
-		return false;
-	}
-
 	return !!model.name;
 }
 

--- a/src/projection.test.ts
+++ b/src/projection.test.ts
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { createTestHost, createTestWrapper } from "@typespec/compiler/testing";
+import { isSearchable } from "./decorators.js";
+import { resolveProjectionModel } from "./projection.js";
+import { OpenSearchEmitterTestLibrary } from "./testing/index.js";
+
+async function createRunner() {
+	const host = await createTestHost({
+		libraries: [OpenSearchEmitterTestLibrary],
+	});
+
+	return createTestWrapper(host, {
+		autoImports: ["@kattebak/typespec-opensearch-emitter"],
+		autoUsings: ["Kattebak.OpenSearch"],
+	});
+}
+
+describe("projection resolution", () => {
+	it("resolves only searchable fields and merges projection overrides", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Tag {
+        @searchable label: string;
+        hidden: string;
+      }
+
+      model Product {
+        @searchable @keyword name: string;
+        @searchable tags: Tag[];
+        hidden: string;
+      }
+
+      @indexName("products_v1")
+      model ProductSearchDoc is SearchProjection<Product> {
+        @analyzer("edge_ngram") @boost(2.0)
+        name: string;
+
+        @nested
+        tags: Tag[];
+      }
+    `);
+
+		assert.equal(diagnostics.length, 0);
+
+		const projectionModel = runner.program
+			.getGlobalNamespaceType()
+			.models.get("ProductSearchDoc");
+		assert.ok(projectionModel);
+
+		const resolved = resolveProjectionModel(runner.program, projectionModel);
+		assert.ok(resolved);
+
+		assert.equal(resolved.sourceModel.name, "Product");
+		assert.equal(resolved.indexName, "products_v1");
+		assert.deepEqual(
+			resolved.fields.map((x) => x.name),
+			["name", "tags"],
+		);
+
+		const nameField = resolved.fields.find((x) => x.name === "name");
+		assert.ok(nameField);
+		assert.equal(nameField.keyword, true);
+		assert.equal(nameField.analyzer, "edge_ngram");
+		assert.equal(nameField.boost, 2);
+
+		const tagsField = resolved.fields.find((x) => x.name === "tags");
+		assert.ok(tagsField);
+		assert.equal(tagsField.nested, true);
+	});
+
+	it("returns undefined for non projection model", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Product {
+        @searchable name: string;
+      }
+    `);
+		assert.equal(diagnostics.length, 0);
+
+		const model = runner.program.getGlobalNamespaceType().models.get("Product");
+		assert.ok(model);
+		assert.equal(resolveProjectionModel(runner.program, model), undefined);
+	});
+
+	it("keeps non-searchable source fields excluded", async () => {
+		const runner = await createRunner();
+		await runner.compile(`
+      model Product {
+        @searchable name: string;
+        hidden: string;
+      }
+
+      model ProductSearchDoc is SearchProjection<Product> {}
+    `);
+
+		const source = runner.program
+			.getGlobalNamespaceType()
+			.models.get("Product");
+		assert.ok(source);
+		const hidden = source.properties.get("hidden");
+		assert.ok(hidden);
+		assert.equal(isSearchable(runner.program, hidden), false);
+
+		const projection = runner.program
+			.getGlobalNamespaceType()
+			.models.get("ProductSearchDoc");
+		assert.ok(projection);
+		const resolved = resolveProjectionModel(runner.program, projection);
+		assert.ok(resolved);
+		assert.deepEqual(
+			resolved.fields.map((x) => x.name),
+			["name"],
+		);
+	});
+});

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -1,0 +1,130 @@
+import type { Model, ModelProperty, Program, Type } from "@typespec/compiler";
+import {
+	getAnalyzer,
+	getBoost,
+	getIndexName,
+	isKeyword,
+	isNested,
+	isSearchable,
+} from "./decorators.js";
+
+export interface ResolvedProjectionField {
+	name: string;
+	type: Type;
+	optional: boolean;
+	sourceProperty: ModelProperty;
+	projectionProperty?: ModelProperty;
+	searchable: boolean;
+	keyword: boolean;
+	nested: boolean;
+	analyzer?: string;
+	boost?: number;
+}
+
+export interface ResolvedProjection {
+	projectionModel: Model;
+	sourceModel: Model;
+	indexName: string;
+	fields: ResolvedProjectionField[];
+}
+
+export function isSearchProjectionModel(
+	program: Program,
+	model: Model,
+): boolean {
+	return !!getProjectionSourceModel(program, model);
+}
+
+export function getProjectionSourceModel(
+	program: Program,
+	projectionModel: Model,
+): Model | undefined {
+	if (projectionModel.name === "SearchProjection") {
+		return undefined;
+	}
+
+	if (projectionModel.sourceModel?.name !== "SearchProjection") {
+		return undefined;
+	}
+
+	const isExpression =
+		projectionModel.node && "is" in projectionModel.node
+			? (projectionModel.node.is as
+					| { arguments?: readonly unknown[] }
+					| undefined)
+			: undefined;
+	const arg = isExpression?.arguments?.[0];
+	if (!arg) {
+		return undefined;
+	}
+
+	const sourceType = program.checker.getTypeForNode(arg as never);
+	return sourceType.kind === "Model" ? sourceType : undefined;
+}
+
+export function resolveProjectionModel(
+	program: Program,
+	projectionModel: Model,
+): ResolvedProjection | undefined {
+	const sourceModel = getProjectionSourceModel(program, projectionModel);
+	if (!sourceModel) {
+		return undefined;
+	}
+
+	const fields: ResolvedProjectionField[] = [];
+	for (const sourceProperty of sourceModel.properties.values()) {
+		if (!isSearchable(program, sourceProperty)) {
+			continue;
+		}
+
+		const projectionProperty = projectionModel.properties.get(
+			sourceProperty.name,
+		);
+		fields.push(
+			resolveProjectionField(program, sourceProperty, projectionProperty),
+		);
+	}
+
+	return {
+		projectionModel,
+		sourceModel,
+		indexName: getIndexName(program, projectionModel),
+		fields,
+	};
+}
+
+function resolveProjectionField(
+	program: Program,
+	sourceProperty: ModelProperty,
+	projectionProperty?: ModelProperty,
+): ResolvedProjectionField {
+	const analyzer =
+		(projectionProperty && getAnalyzer(program, projectionProperty)) ??
+		getAnalyzer(program, sourceProperty);
+	const boost =
+		(projectionProperty && getBoost(program, projectionProperty)) ??
+		getBoost(program, sourceProperty);
+
+	return {
+		name: sourceProperty.name,
+		type: projectionProperty?.type ?? sourceProperty.type,
+		optional: projectionProperty?.optional ?? sourceProperty.optional,
+		sourceProperty,
+		projectionProperty,
+		searchable: true,
+		keyword:
+			(projectionProperty && isKeyword(program, projectionProperty)) ||
+			isKeyword(program, sourceProperty),
+		nested:
+			(projectionProperty && isNested(program, projectionProperty)) ||
+			isNested(program, sourceProperty),
+		analyzer,
+		boost,
+	};
+}
+
+export const __test = {
+	getProjectionSourceModel,
+	isSearchProjectionModel,
+	resolveProjectionField,
+};

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -43,22 +43,21 @@ export function getProjectionSourceModel(
 		return undefined;
 	}
 
-	if (projectionModel.sourceModel?.name !== "SearchProjection") {
+	const isSource = projectionModel.sourceModels.find(
+		(x) => x.usage === "is" && x.model.name === "SearchProjection",
+	);
+	if (!isSource?.node) {
 		return undefined;
 	}
 
-	const isExpression =
-		projectionModel.node && "is" in projectionModel.node
-			? (projectionModel.node.is as
-					| { arguments?: readonly unknown[] }
-					| undefined)
-			: undefined;
-	const arg = isExpression?.arguments?.[0];
+	const node = isSource.node as { arguments?: readonly unknown[] };
+	const arg = node.arguments?.[0];
 	if (!arg) {
 		return undefined;
 	}
 
-	const sourceType = program.checker.getTypeForNode(arg as never);
+	type TypeForNodeInput = Parameters<Program["checker"]["getTypeForNode"]>[0];
+	const sourceType = program.checker.getTypeForNode(arg as TypeForNodeInput);
 	return sourceType.kind === "Model" ? sourceType : undefined;
 }
 

--- a/test/example.js
+++ b/test/example.js
@@ -2,12 +2,35 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 
-test("emits OpenSearch projection file", async () => {
+test("emits resolved search projections", async () => {
 	const content = await readFile(
 		"build/opensearch/opensearch-projections.json",
 		"utf8",
 	);
 	const parsed = JSON.parse(content);
 
-	assert.deepEqual(parsed.models, ["ProductDocument"]);
+	assert.deepEqual(parsed, {
+		projections: [
+			{
+				name: "ProductSearchDoc",
+				sourceModel: "Product",
+				indexName: "products_v1",
+				fields: [
+					{
+						name: "id",
+						optional: false,
+						keyword: false,
+						nested: false,
+					},
+					{
+						name: "title",
+						optional: false,
+						keyword: true,
+						nested: false,
+						analyzer: "edge_ngram",
+					},
+				],
+			},
+		],
+	});
 });

--- a/test/main.tsp
+++ b/test/main.tsp
@@ -1,7 +1,14 @@
 import "@kattebak/typespec-opensearch-emitter";
 
-model ProductDocument {
-	id: string;
-	title: string;
-	price: float64;
+using Kattebak.OpenSearch;
+
+model Product {
+	@searchable id: string;
+	@searchable @keyword title: string;
+	internalNotes: string;
+}
+
+@indexName("products_v1")
+model ProductSearchDoc is SearchProjection<Product> {
+	@analyzer("edge_ngram") title: string;
 }


### PR DESCRIPTION
## Summary

Implements the projection resolution layer and wires emitter collection around `SearchProjection<T>` models.

## Changes

- `src/projection.ts`
  - `isSearchProjectionModel(program, model)`
  - `getProjectionSourceModel(program, projectionModel)`
  - `resolveProjectionModel(program, projectionModel)`
  - searchable-only field inclusion
  - projection-side override merge for decorator metadata (`keyword`, `nested`, `analyzer`, `boost`)
- `src/emitter.ts`
  - collects projection models from program namespaces
  - filters intrinsics/template declarations/library template model
  - resolves projections and emits metadata JSON
  - no-op when no projection models found
- tests
  - `src/projection.test.ts`
  - `src/emitter.test.ts`
  - updated `test/main.tsp` and `test/example.js` E2E fixture
- docs
  - README status and usage updated with current behavior

## Validation

- `npm test` passes

## Issues

- Closes #10
- Closes #11

## Stack

- Parent: #19
