### PR TITLE
feat: add keyword/nested/analyzer/boost/indexName rules

### DIFF
--- a/src/decorators.test.ts
+++ b/src/decorators.test.ts
@@ -173,6 +173,7 @@ describe("decorators", () => {
 	});
 
 	it("emits diagnostic for negative boost", async () => {
+		// Negative factors are invalid and should produce a diagnostic.
 		const runner = await createRunner();
 		const diagnostics = await runner.diagnose(`
       model Product {

--- a/src/decorators.test.ts
+++ b/src/decorators.test.ts
@@ -23,6 +23,13 @@ async function createRunner() {
 	});
 }
 
+function hasDiagnosticCode(
+	diagnosticCodes: readonly string[],
+	code: string,
+): boolean {
+	return diagnosticCodes.some((x) => x.endsWith(`/${code}`) || x === code);
+}
+
 describe("decorators", () => {
 	it("marks property as searchable", async () => {
 		const runner = await createRunner();
@@ -49,17 +56,25 @@ describe("decorators", () => {
 		assert.equal(isSearchable(runner.program, description), false);
 	});
 
-	it("stores values for all decorator state accessors", async () => {
+	it("stores values for decorators and resolves explicit index name", async () => {
 		const runner = await createRunner();
 		const diagnostics = await runner.diagnose(`
-      @indexName("products_v1")
-      model ProductSearchDoc is SearchProjection<Product> {
-        @searchable @keyword @nested @analyzer("edge_ngram") @boost(2.0)
-        name: string;
+      model Tag {
+        @searchable value: string;
       }
 
       model Product {
         @searchable name: string;
+        @searchable tags: Tag[];
+      }
+
+      @indexName("products_v1")
+      model ProductSearchDoc is SearchProjection<Product> {
+        @searchable @keyword @analyzer("edge_ngram") @boost(2.0)
+        name: string;
+
+        @searchable @nested
+        tags: Tag[];
       }
     `);
 
@@ -71,12 +86,89 @@ describe("decorators", () => {
 
 		const name = projection.properties.get("name");
 		assert.ok(name);
+		const tags = projection.properties.get("tags");
+		assert.ok(tags);
 
 		assert.equal(isSearchable(runner.program, name), true);
 		assert.equal(isKeyword(runner.program, name), true);
-		assert.equal(isNested(runner.program, name), true);
 		assert.equal(getAnalyzer(runner.program, name), "edge_ngram");
 		assert.equal(getBoost(runner.program, name), 2);
+
+		assert.equal(isSearchable(runner.program, tags), true);
+		assert.equal(isNested(runner.program, tags), true);
+
 		assert.equal(getIndexName(runner.program, projection), "products_v1");
+	});
+
+	it("derives default index name from model name", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model CounterpartySearchDoc is SearchProjection<Counterparty> {
+        @searchable id: string;
+      }
+
+      model Counterparty {
+        @searchable id: string;
+      }
+    `);
+
+		assert.equal(diagnostics.length, 0);
+
+		const model = runner.program
+			.getGlobalNamespaceType()
+			.models.get("CounterpartySearchDoc");
+		assert.ok(model);
+		assert.equal(
+			getIndexName(runner.program, model),
+			"counterparty_search_doc",
+		);
+	});
+
+	it("emits diagnostic for invalid keyword target", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Product {
+        @keyword rank: int32;
+      }
+    `);
+
+		const codes = diagnostics.map((x) => x.code);
+		assert.equal(hasDiagnosticCode(codes, "string-property-required"), true);
+	});
+
+	it("emits diagnostic for invalid analyzer target", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Product {
+        @analyzer("edge_ngram") rank: int32;
+      }
+    `);
+
+		const codes = diagnostics.map((x) => x.code);
+		assert.equal(hasDiagnosticCode(codes, "string-property-required"), true);
+	});
+
+	it("emits diagnostic for invalid nested target", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Product {
+        @nested name: string;
+      }
+    `);
+
+		const codes = diagnostics.map((x) => x.code);
+		assert.equal(hasDiagnosticCode(codes, "nested-array-model-required"), true);
+	});
+
+	it("emits diagnostic for non-positive boost", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Product {
+        @boost(0) name: string;
+      }
+    `);
+
+		const codes = diagnostics.map((x) => x.code);
+		assert.equal(hasDiagnosticCode(codes, "positive-boost-required"), true);
 	});
 });

--- a/src/decorators.test.ts
+++ b/src/decorators.test.ts
@@ -160,11 +160,23 @@ describe("decorators", () => {
 		assert.equal(hasDiagnosticCode(codes, "nested-array-model-required"), true);
 	});
 
-	it("emits diagnostic for non-positive boost", async () => {
+	it("emits diagnostic for zero boost", async () => {
 		const runner = await createRunner();
 		const diagnostics = await runner.diagnose(`
       model Product {
         @boost(0) name: string;
+      }
+    `);
+
+		const codes = diagnostics.map((x) => x.code);
+		assert.equal(hasDiagnosticCode(codes, "positive-boost-required"), true);
+	});
+
+	it("emits diagnostic for negative boost", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Product {
+        @boost(-1) name: string;
       }
     `);
 

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -3,10 +3,22 @@ import type {
 	Model,
 	ModelProperty,
 	Program,
+	Type,
 } from "@typespec/compiler";
-import { StateKeys } from "./lib.js";
+import { reportDiagnostic, StateKeys } from "./lib.js";
 
 export const namespace = "Kattebak.OpenSearch";
+
+/**
+ * Default index name derivation:
+ * CounterpartySearchDoc -> counterparty_search_doc
+ */
+export function deriveDefaultIndexName(modelName: string): string {
+	return modelName
+		.replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+		.replace(/[-\s]+/g, "_")
+		.toLowerCase();
+}
 
 export function $searchable(
 	context: DecoratorContext,
@@ -23,6 +35,15 @@ export function $keyword(
 	context: DecoratorContext,
 	target: ModelProperty,
 ): void {
+	if (!isStringType(target.type)) {
+		reportDiagnostic(context.program, {
+			code: "string-property-required",
+			target,
+			format: { decorator: "keyword" },
+		});
+		return;
+	}
+
 	context.program.stateSet(StateKeys.keyword).add(target);
 }
 
@@ -34,6 +55,14 @@ export function $nested(
 	context: DecoratorContext,
 	target: ModelProperty,
 ): void {
+	if (!isArrayOfModelType(target.type)) {
+		reportDiagnostic(context.program, {
+			code: "nested-array-model-required",
+			target,
+		});
+		return;
+	}
+
 	context.program.stateSet(StateKeys.nested).add(target);
 }
 
@@ -46,6 +75,15 @@ export function $analyzer(
 	target: ModelProperty,
 	name: string,
 ): void {
+	if (!isStringType(target.type)) {
+		reportDiagnostic(context.program, {
+			code: "string-property-required",
+			target,
+			format: { decorator: "analyzer" },
+		});
+		return;
+	}
+
 	context.program.stateMap(StateKeys.analyzer).set(target, name);
 }
 
@@ -61,7 +99,16 @@ export function $boost(
 	target: ModelProperty,
 	factor: number,
 ): void {
-	context.program.stateMap(StateKeys.boost).set(target, factor);
+	const value = factor;
+	if (!Number.isFinite(value) || value <= 0) {
+		reportDiagnostic(context.program, {
+			code: "positive-boost-required",
+			target: context.getArgumentTarget(0) ?? target,
+		});
+		return;
+	}
+
+	context.program.stateMap(StateKeys.boost).set(target, value);
 }
 
 export function getBoost(
@@ -79,9 +126,41 @@ export function $indexName(
 	context.program.stateMap(StateKeys.indexName).set(target, name);
 }
 
-export function getIndexName(
-	program: Program,
-	target: Model,
-): string | undefined {
-	return program.stateMap(StateKeys.indexName).get(target);
+export function getIndexName(program: Program, target: Model): string {
+	return (
+		program.stateMap(StateKeys.indexName).get(target) ??
+		deriveDefaultIndexName(target.name)
+	);
 }
+
+function isStringType(type: Type): boolean {
+	if (type.kind === "String") {
+		return true;
+	}
+
+	if (type.kind !== "Scalar") {
+		return false;
+	}
+
+	let current: Type = type;
+	while (current.kind === "Scalar" && current.baseScalar) {
+		current = current.baseScalar;
+	}
+
+	return current.kind === "Scalar" && current.name === "string";
+}
+
+function isArrayOfModelType(type: Type): boolean {
+	if (type.kind !== "Model" || type.name !== "Array") {
+		return false;
+	}
+
+	const elementType = type.indexer?.value;
+	return elementType?.kind === "Model";
+}
+
+export const __test = {
+	deriveDefaultIndexName,
+	isArrayOfModelType,
+	isStringType,
+};

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,4 +1,4 @@
-import { createTypeSpecLibrary } from "@typespec/compiler";
+import { createTypeSpecLibrary, paramMessage } from "@typespec/compiler";
 
 export interface OpenSearchEmitterOptions {
 	"output-file"?: string;
@@ -6,7 +6,27 @@ export interface OpenSearchEmitterOptions {
 
 export const $lib = createTypeSpecLibrary({
 	name: "@kattebak/typespec-opensearch-emitter",
-	diagnostics: {},
+	diagnostics: {
+		"string-property-required": {
+			severity: "error",
+			messages: {
+				default: paramMessage`Decorator @${"decorator"} can only be applied to string properties.`,
+			},
+		},
+		"nested-array-model-required": {
+			severity: "error",
+			messages: {
+				default:
+					"Decorator @nested can only be applied to array properties whose element type is a model.",
+			},
+		},
+		"positive-boost-required": {
+			severity: "error",
+			messages: {
+				default: "Decorator @boost requires a factor greater than 0.",
+			},
+		},
+	},
 	state: {
 		searchable: { description: "Marks a property as searchable" },
 		keyword: { description: "Marks a property as keyword" },


### PR DESCRIPTION
## Summary

Adds behavior and validation for `@keyword`, `@nested`, `@analyzer`, `@boost`, and `@indexName`.

## Changes

- `src/lib.ts`
  - diagnostics:
    - `string-property-required`
    - `nested-array-model-required`
    - `positive-boost-required`
- `src/decorators.ts`
  - `@keyword`/`@analyzer` limited to string-typed properties
  - `@nested` limited to array-of-model properties
  - `@boost` requires factor > 0
  - default index-name derivation in snake_case
  - `getIndexName()` now always resolves to a `string` (override or derived default)
- `src/decorators.test.ts`
  - covers happy paths + all validation diagnostics
  - covers explicit and default index-name behavior
  - includes both zero and negative boost validation tests

## Validation

- `npm test` passes

## Issues

- Closes #7
- Closes #8
- Closes #9
