### PR TITLE
feat: emit index barrel with per-projection index constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Implemented so far:
 - Decorator validation diagnostics
 - `SearchProjection<T>` template + projection resolution
 - Emitter collection of projection models and resolved projection metadata output
+- TypeScript document type emission per projection (`*-search-doc.ts`)
 - CI, linting, unit tests, emitter E2E test
 
 ## Usage
@@ -40,4 +41,4 @@ options:
     output-file: "opensearch-projections.json"
 ```
 
-Current emitted file is projection metadata JSON and is an intermediate step toward document type and mapping emitters.
+Current outputs include projection metadata JSON and generated TypeScript document interfaces. OpenSearch mapping JSON emission is next.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Implemented so far:
 - Emitter collection of projection models and resolved projection metadata output
 - TypeScript document type emission per projection (`*-search-doc.ts`)
 - OpenSearch mapping JSON emission per projection (`*-search-mapping.json`)
+- Generated index barrel (`index.ts`) with doc type exports and index-name constants
 - CI, linting, unit tests, emitter E2E test
 
 ## Usage
@@ -42,4 +43,4 @@ options:
     output-file: "opensearch-projections.json"
 ```
 
-Current outputs include projection metadata JSON, generated TypeScript document interfaces, and OpenSearch mapping JSON files.
+Current outputs include projection metadata JSON, generated TypeScript document interfaces, OpenSearch mapping JSON files, and `index.ts` re-exports/constants.

--- a/README.md
+++ b/README.md
@@ -4,12 +4,32 @@ A TypeSpec emitter for generating OpenSearch projection metadata.
 
 ## Status
 
-Scaffolded emitter skeleton with CI, linting, tests, and TypeSpec emitter wiring.
+Implemented so far:
+
+- Decorator infrastructure via TypeSpec library state
+- Decorators: `@searchable`, `@keyword`, `@nested`, `@analyzer`, `@boost`, `@indexName`
+- Decorator validation diagnostics
+- `SearchProjection<T>` template + projection resolution
+- Emitter collection of projection models and resolved projection metadata output
+- CI, linting, unit tests, emitter E2E test
 
 ## Usage
 
 ```typespec
 import "@kattebak/typespec-opensearch-emitter";
+
+using Kattebak.OpenSearch;
+
+model Product {
+  @searchable id: string;
+  @searchable @keyword title: string;
+  internalNotes: string;
+}
+
+@indexName("products_v1")
+model ProductSearchDoc is SearchProjection<Product> {
+  @analyzer("edge_ngram") title: string;
+}
 ```
 
 ```yaml
@@ -19,3 +39,5 @@ options:
   "@kattebak/typespec-opensearch-emitter":
     output-file: "opensearch-projections.json"
 ```
+
+Current emitted file is projection metadata JSON and is an intermediate step toward document type and mapping emitters.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Implemented so far:
 - `SearchProjection<T>` template + projection resolution
 - Emitter collection of projection models and resolved projection metadata output
 - TypeScript document type emission per projection (`*-search-doc.ts`)
+- OpenSearch mapping JSON emission per projection (`*-search-mapping.json`)
 - CI, linting, unit tests, emitter E2E test
 
 ## Usage
@@ -41,4 +42,4 @@ options:
     output-file: "opensearch-projections.json"
 ```
 
-Current outputs include projection metadata JSON and generated TypeScript document interfaces. OpenSearch mapping JSON emission is next.
+Current outputs include projection metadata JSON, generated TypeScript document interfaces, and OpenSearch mapping JSON files.

--- a/src/decorators.test.ts
+++ b/src/decorators.test.ts
@@ -23,6 +23,13 @@ async function createRunner() {
 	});
 }
 
+function hasDiagnosticCode(
+	diagnosticCodes: readonly string[],
+	code: string,
+): boolean {
+	return diagnosticCodes.some((x) => x.endsWith(`/${code}`) || x === code);
+}
+
 describe("decorators", () => {
 	it("marks property as searchable", async () => {
 		const runner = await createRunner();
@@ -49,17 +56,25 @@ describe("decorators", () => {
 		assert.equal(isSearchable(runner.program, description), false);
 	});
 
-	it("stores values for all decorator state accessors", async () => {
+	it("stores values for decorators and resolves explicit index name", async () => {
 		const runner = await createRunner();
 		const diagnostics = await runner.diagnose(`
-      @indexName("products_v1")
-      model ProductSearchDoc is SearchProjection<Product> {
-        @searchable @keyword @nested @analyzer("edge_ngram") @boost(2.0)
-        name: string;
+      model Tag {
+        @searchable value: string;
       }
 
       model Product {
         @searchable name: string;
+        @searchable tags: Tag[];
+      }
+
+      @indexName("products_v1")
+      model ProductSearchDoc is SearchProjection<Product> {
+        @searchable @keyword @analyzer("edge_ngram") @boost(2.0)
+        name: string;
+
+        @searchable @nested
+        tags: Tag[];
       }
     `);
 
@@ -71,12 +86,89 @@ describe("decorators", () => {
 
 		const name = projection.properties.get("name");
 		assert.ok(name);
+		const tags = projection.properties.get("tags");
+		assert.ok(tags);
 
 		assert.equal(isSearchable(runner.program, name), true);
 		assert.equal(isKeyword(runner.program, name), true);
-		assert.equal(isNested(runner.program, name), true);
 		assert.equal(getAnalyzer(runner.program, name), "edge_ngram");
 		assert.equal(getBoost(runner.program, name), 2);
+
+		assert.equal(isSearchable(runner.program, tags), true);
+		assert.equal(isNested(runner.program, tags), true);
+
 		assert.equal(getIndexName(runner.program, projection), "products_v1");
+	});
+
+	it("derives default index name from model name", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model CounterpartySearchDoc is SearchProjection<Counterparty> {
+        @searchable id: string;
+      }
+
+      model Counterparty {
+        @searchable id: string;
+      }
+    `);
+
+		assert.equal(diagnostics.length, 0);
+
+		const model = runner.program
+			.getGlobalNamespaceType()
+			.models.get("CounterpartySearchDoc");
+		assert.ok(model);
+		assert.equal(
+			getIndexName(runner.program, model),
+			"counterparty_search_doc",
+		);
+	});
+
+	it("emits diagnostic for invalid keyword target", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Product {
+        @keyword rank: int32;
+      }
+    `);
+
+		const codes = diagnostics.map((x) => x.code);
+		assert.equal(hasDiagnosticCode(codes, "string-property-required"), true);
+	});
+
+	it("emits diagnostic for invalid analyzer target", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Product {
+        @analyzer("edge_ngram") rank: int32;
+      }
+    `);
+
+		const codes = diagnostics.map((x) => x.code);
+		assert.equal(hasDiagnosticCode(codes, "string-property-required"), true);
+	});
+
+	it("emits diagnostic for invalid nested target", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Product {
+        @nested name: string;
+      }
+    `);
+
+		const codes = diagnostics.map((x) => x.code);
+		assert.equal(hasDiagnosticCode(codes, "nested-array-model-required"), true);
+	});
+
+	it("emits diagnostic for non-positive boost", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Product {
+        @boost(0) name: string;
+      }
+    `);
+
+		const codes = diagnostics.map((x) => x.code);
+		assert.equal(hasDiagnosticCode(codes, "positive-boost-required"), true);
 	});
 });

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -3,10 +3,22 @@ import type {
 	Model,
 	ModelProperty,
 	Program,
+	Type,
 } from "@typespec/compiler";
-import { StateKeys } from "./lib.js";
+import { reportDiagnostic, StateKeys } from "./lib.js";
 
 export const namespace = "Kattebak.OpenSearch";
+
+/**
+ * Default index name derivation:
+ * CounterpartySearchDoc -> counterparty_search_doc
+ */
+export function deriveDefaultIndexName(modelName: string): string {
+	return modelName
+		.replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+		.replace(/[-\s]+/g, "_")
+		.toLowerCase();
+}
 
 export function $searchable(
 	context: DecoratorContext,
@@ -23,6 +35,15 @@ export function $keyword(
 	context: DecoratorContext,
 	target: ModelProperty,
 ): void {
+	if (!isStringType(target.type)) {
+		reportDiagnostic(context.program, {
+			code: "string-property-required",
+			target,
+			format: { decorator: "keyword" },
+		});
+		return;
+	}
+
 	context.program.stateSet(StateKeys.keyword).add(target);
 }
 
@@ -34,6 +55,14 @@ export function $nested(
 	context: DecoratorContext,
 	target: ModelProperty,
 ): void {
+	if (!isArrayOfModelType(target.type)) {
+		reportDiagnostic(context.program, {
+			code: "nested-array-model-required",
+			target,
+		});
+		return;
+	}
+
 	context.program.stateSet(StateKeys.nested).add(target);
 }
 
@@ -46,6 +75,15 @@ export function $analyzer(
 	target: ModelProperty,
 	name: string,
 ): void {
+	if (!isStringType(target.type)) {
+		reportDiagnostic(context.program, {
+			code: "string-property-required",
+			target,
+			format: { decorator: "analyzer" },
+		});
+		return;
+	}
+
 	context.program.stateMap(StateKeys.analyzer).set(target, name);
 }
 
@@ -61,7 +99,16 @@ export function $boost(
 	target: ModelProperty,
 	factor: number,
 ): void {
-	context.program.stateMap(StateKeys.boost).set(target, factor);
+	const value = factor;
+	if (!Number.isFinite(value) || value <= 0) {
+		reportDiagnostic(context.program, {
+			code: "positive-boost-required",
+			target: context.getArgumentTarget(0) ?? target,
+		});
+		return;
+	}
+
+	context.program.stateMap(StateKeys.boost).set(target, value);
 }
 
 export function getBoost(
@@ -79,9 +126,41 @@ export function $indexName(
 	context.program.stateMap(StateKeys.indexName).set(target, name);
 }
 
-export function getIndexName(
-	program: Program,
-	target: Model,
-): string | undefined {
-	return program.stateMap(StateKeys.indexName).get(target);
+export function getIndexName(program: Program, target: Model): string {
+	return (
+		program.stateMap(StateKeys.indexName).get(target) ??
+		deriveDefaultIndexName(target.name)
+	);
 }
+
+function isStringType(type: Type): boolean {
+	if (type.kind === "String") {
+		return true;
+	}
+
+	if (type.kind !== "Scalar") {
+		return false;
+	}
+
+	let current: Type = type;
+	while (current.kind === "Scalar" && current.baseScalar) {
+		current = current.baseScalar;
+	}
+
+	return current.kind === "Scalar" && current.name === "string";
+}
+
+function isArrayOfModelType(type: Type): boolean {
+	if (type.kind !== "Model" || type.name !== "Array") {
+		return false;
+	}
+
+	const elementType = type.indexer?.value;
+	return elementType?.kind === "Model";
+}
+
+export const __test = {
+	deriveDefaultIndexName,
+	isArrayOfModelType,
+	isStringType,
+};

--- a/src/emit-doc-type.test.ts
+++ b/src/emit-doc-type.test.ts
@@ -46,7 +46,7 @@ describe("doc type emitter", () => {
 		assert.ok(resolved);
 
 		const emitted = emitDocType(runner.program, resolved);
-		assert.equal(emitted.fileName, "product-search-doc-search-doc.ts");
+		assert.equal(emitted.fileName, "product-search-doc.ts");
 		assert.equal(
 			emitted.content.includes("export interface ProductSearchDoc"),
 			true,

--- a/src/emit-doc-type.test.ts
+++ b/src/emit-doc-type.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { createTestHost, createTestWrapper } from "@typespec/compiler/testing";
+import { emitDocType } from "./emit-doc-type.js";
+import { resolveProjectionModel } from "./projection.js";
+import { OpenSearchEmitterTestLibrary } from "./testing/index.js";
+
+async function createRunner() {
+	const host = await createTestHost({
+		libraries: [OpenSearchEmitterTestLibrary],
+	});
+
+	return createTestWrapper(host, {
+		autoImports: ["@kattebak/typespec-opensearch-emitter"],
+		autoUsings: ["Kattebak.OpenSearch"],
+	});
+}
+
+describe("doc type emitter", () => {
+	it("emits TypeScript interface for projection model", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Owner {
+        @searchable name: string;
+        email: string;
+      }
+
+      model Product {
+        @searchable id: string;
+        @searchable price: float64;
+        @searchable owner: Owner;
+        @searchable tags: string[];
+      }
+
+      model ProductSearchDoc is SearchProjection<Product> {}
+    `);
+		assert.equal(diagnostics.length, 0);
+
+		const projection = runner.program
+			.getGlobalNamespaceType()
+			.models.get("ProductSearchDoc");
+		assert.ok(projection);
+
+		const resolved = resolveProjectionModel(runner.program, projection);
+		assert.ok(resolved);
+
+		const emitted = emitDocType(runner.program, resolved);
+		assert.equal(emitted.fileName, "product-search-doc-search-doc.ts");
+		assert.equal(
+			emitted.content.includes("export interface ProductSearchDoc"),
+			true,
+		);
+		assert.equal(emitted.content.includes("\tid: string;"), true);
+		assert.equal(emitted.content.includes("\tprice: number;"), true);
+		assert.equal(emitted.content.includes("\towner:"), true);
+		assert.equal(emitted.content.includes("\ttags: string[];"), true);
+		assert.equal(emitted.content.includes("email"), false);
+	});
+});

--- a/src/emit-doc-type.ts
+++ b/src/emit-doc-type.ts
@@ -11,7 +11,7 @@ export function emitDocType(
 	program: Program,
 	projection: ResolvedProjection,
 ): EmittedDocTypeFile {
-	const fileName = `${toKebabCase(projection.projectionModel.name)}-search-doc.ts`;
+	const fileName = toDocTypeFileName(projection.projectionModel.name);
 	const body = renderInterfaceBody(
 		program,
 		projection.fields.map((x) => ({
@@ -143,10 +143,19 @@ export function toKebabCase(name: string): string {
 		.toLowerCase();
 }
 
+export function toDocTypeFileName(projectionModelName: string): string {
+	const kebab = toKebabCase(projectionModelName);
+	const base = kebab.endsWith("-search-doc")
+		? kebab.slice(0, -"-search-doc".length)
+		: kebab;
+	return `${base}-search-doc.ts`;
+}
+
 export const __test = {
 	renderModel,
 	renderScalar,
 	renderType,
 	renderUnion,
+	toDocTypeFileName,
 	toKebabCase,
 };

--- a/src/emit-doc-type.ts
+++ b/src/emit-doc-type.ts
@@ -1,0 +1,152 @@
+import type { Model, Program, Scalar, Type, Union } from "@typespec/compiler";
+import { isSearchable } from "./decorators.js";
+import type { ResolvedProjection } from "./projection.js";
+
+export interface EmittedDocTypeFile {
+	fileName: string;
+	content: string;
+}
+
+export function emitDocType(
+	program: Program,
+	projection: ResolvedProjection,
+): EmittedDocTypeFile {
+	const fileName = `${toKebabCase(projection.projectionModel.name)}-search-doc.ts`;
+	const body = renderInterfaceBody(
+		program,
+		projection.fields.map((x) => ({
+			name: x.name,
+			type: x.type,
+			optional: x.optional,
+		})),
+	);
+
+	return {
+		fileName,
+		content: `export interface ${projection.projectionModel.name} ${body}\n`,
+	};
+}
+
+function renderInterfaceBody(
+	program: Program,
+	fields: ReadonlyArray<{ name: string; type: Type; optional: boolean }>,
+): string {
+	if (fields.length === 0) {
+		return "{}";
+	}
+
+	const lines = fields.map((field) => {
+		const optional = field.optional ? "?" : "";
+		const type = renderType(program, field.type);
+		return `\t${field.name}${optional}: ${type};`;
+	});
+
+	return `\n{\n${lines.join("\n")}\n}`;
+}
+
+function renderType(program: Program, type: Type): string {
+	switch (type.kind) {
+		case "Scalar":
+			return renderScalar(type);
+		case "Model":
+			return renderModel(program, type);
+		case "String":
+			return "string";
+		case "Number":
+			return "number";
+		case "Boolean":
+			return "boolean";
+		case "Union":
+			return renderUnion(program, type);
+		default:
+			return "unknown";
+	}
+}
+
+function renderScalar(scalar: Scalar): string {
+	let base = scalar;
+	while (base.baseScalar) {
+		base = base.baseScalar;
+	}
+
+	switch (base.name) {
+		case "string":
+		case "plainDate":
+		case "utcDateTime":
+			return "string";
+		case "int32":
+		case "int64":
+		case "float":
+		case "float32":
+		case "float64":
+		case "decimal":
+		case "numeric":
+		case "integer":
+		case "safeint":
+		case "uint8":
+		case "uint16":
+		case "uint32":
+		case "uint64":
+		case "int8":
+		case "int16":
+		case "number":
+			return "number";
+		case "boolean":
+			return "boolean";
+		default:
+			return "unknown";
+	}
+}
+
+function renderModel(program: Program, model: Model): string {
+	if (model.name === "Array" && model.indexer?.value) {
+		return `${renderType(program, model.indexer.value)}[]`;
+	}
+
+	if (model.name === "Record" && model.indexer?.value) {
+		return `Record<string, ${renderType(program, model.indexer.value)}>`;
+	}
+
+	const searchableFields = Array.from(model.properties.values())
+		.filter((prop) => isSearchable(program, prop))
+		.map((prop) => ({
+			name: prop.name,
+			type: prop.type,
+			optional: prop.optional,
+		}));
+
+	if (searchableFields.length === 0) {
+		return "{}";
+	}
+
+	const lines = searchableFields.map((field) => {
+		const optional = field.optional ? "?" : "";
+		return `\t${field.name}${optional}: ${renderType(program, field.type)};`;
+	});
+
+	return `{\n${lines.join("\n")}\n}`;
+}
+
+function renderUnion(program: Program, union: Union): string {
+	const variants = Array.from(union.variants.values());
+	if (variants.length === 0) {
+		return "never";
+	}
+
+	return variants.map((x) => renderType(program, x.type)).join(" | ");
+}
+
+export function toKebabCase(name: string): string {
+	return name
+		.replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+		.replace(/[-\s]+/g, "-")
+		.toLowerCase();
+}
+
+export const __test = {
+	renderModel,
+	renderScalar,
+	renderType,
+	renderUnion,
+	toKebabCase,
+};

--- a/src/emit-index.test.ts
+++ b/src/emit-index.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { emitIndex, toIndexConstantName } from "./emit-index.js";
+import type { ResolvedProjection } from "./projection.js";
+
+describe("index emitter", () => {
+	it("emits index.ts with type exports and index constants", () => {
+		const projections = [
+			{
+				projectionModel: { name: "ProductSearchDoc" },
+				sourceModel: { name: "Product" },
+				indexName: "products_v1",
+				fields: [],
+			},
+			{
+				projectionModel: { name: "AccountSearchDoc" },
+				sourceModel: { name: "Account" },
+				indexName: "accounts_v1",
+				fields: [],
+			},
+		] as unknown as ResolvedProjection[];
+
+		const emitted = emitIndex(projections);
+		assert.equal(emitted.fileName, "index.ts");
+		assert.equal(
+			emitted.content.includes(
+				'export type { AccountSearchDoc } from "./account-search-doc-search-doc.js";',
+			),
+			true,
+		);
+		assert.equal(
+			emitted.content.includes(
+				'export const ACCOUNT_INDEX_NAME = "accounts_v1";',
+			),
+			true,
+		);
+		assert.equal(
+			emitted.content.includes(
+				'export type { ProductSearchDoc } from "./product-search-doc-search-doc.js";',
+			),
+			true,
+		);
+		assert.equal(
+			emitted.content.includes(
+				'export const PRODUCT_INDEX_NAME = "products_v1";',
+			),
+			true,
+		);
+	});
+
+	it("derives constant names from source model names", () => {
+		assert.equal(
+			toIndexConstantName("Counterparty"),
+			"COUNTERPARTY_INDEX_NAME",
+		);
+		assert.equal(toIndexConstantName("PetStore"), "PET_STORE_INDEX_NAME");
+	});
+});

--- a/src/emit-index.test.ts
+++ b/src/emit-index.test.ts
@@ -25,35 +25,69 @@ describe("index emitter", () => {
 		assert.equal(emitted.fileName, "index.ts");
 		assert.equal(
 			emitted.content.includes(
-				'export type { AccountSearchDoc } from "./account-search-doc-search-doc.js";',
+				'export type { AccountSearchDoc } from "./account-search-doc.js";',
 			),
 			true,
 		);
 		assert.equal(
 			emitted.content.includes(
-				'export const ACCOUNT_INDEX_NAME = "accounts_v1";',
+				'export const ACCOUNT_SEARCH_DOC_INDEX_NAME = "accounts_v1";',
 			),
 			true,
 		);
 		assert.equal(
 			emitted.content.includes(
-				'export type { ProductSearchDoc } from "./product-search-doc-search-doc.js";',
+				'export type { ProductSearchDoc } from "./product-search-doc.js";',
 			),
 			true,
 		);
 		assert.equal(
 			emitted.content.includes(
-				'export const PRODUCT_INDEX_NAME = "products_v1";',
+				'export const PRODUCT_SEARCH_DOC_INDEX_NAME = "products_v1";',
 			),
 			true,
 		);
 	});
 
-	it("derives constant names from source model names", () => {
+	it("derives constant names from projection model names", () => {
 		assert.equal(
-			toIndexConstantName("Counterparty"),
-			"COUNTERPARTY_INDEX_NAME",
+			toIndexConstantName("CounterpartySearchDoc"),
+			"COUNTERPARTY_SEARCH_DOC_INDEX_NAME",
 		);
-		assert.equal(toIndexConstantName("PetStore"), "PET_STORE_INDEX_NAME");
+		assert.equal(
+			toIndexConstantName("PetStoreSearchDoc"),
+			"PET_STORE_SEARCH_DOC_INDEX_NAME",
+		);
+	});
+
+	it("avoids collisions for multiple projections of same source model", () => {
+		const projections = [
+			{
+				projectionModel: { name: "AccountSearchDoc" },
+				sourceModel: { name: "Account" },
+				indexName: "accounts_v1",
+				fields: [],
+			},
+			{
+				projectionModel: { name: "AccountSummarySearchDoc" },
+				sourceModel: { name: "Account" },
+				indexName: "accounts_summary_v1",
+				fields: [],
+			},
+		] as unknown as ResolvedProjection[];
+
+		const emitted = emitIndex(projections);
+		assert.equal(
+			emitted.content.includes(
+				'export const ACCOUNT_SEARCH_DOC_INDEX_NAME = "accounts_v1";',
+			),
+			true,
+		);
+		assert.equal(
+			emitted.content.includes(
+				'export const ACCOUNT_SUMMARY_SEARCH_DOC_INDEX_NAME = "accounts_summary_v1";',
+			),
+			true,
+		);
 	});
 });

--- a/src/emit-index.ts
+++ b/src/emit-index.ts
@@ -1,4 +1,4 @@
-import { toKebabCase } from "./emit-doc-type.js";
+import { toDocTypeFileName } from "./emit-doc-type.js";
 import type { ResolvedProjection } from "./projection.js";
 
 export interface EmittedIndexFile {
@@ -13,12 +13,14 @@ export function emitIndex(projections: ResolvedProjection[]): EmittedIndexFile {
 
 	const lines: string[] = [];
 	for (const projection of sorted) {
-		const docTypeFile = `${toKebabCase(projection.projectionModel.name)}-search-doc.js`;
+		const docTypeFile = toDocTypeFileName(
+			projection.projectionModel.name,
+		).replace(/\.ts$/, ".js");
 		lines.push(
 			`export type { ${projection.projectionModel.name} } from "./${docTypeFile}";`,
 		);
 		lines.push(
-			`export const ${toIndexConstantName(projection.sourceModel.name)} = "${projection.indexName}";`,
+			`export const ${toIndexConstantName(projection.projectionModel.name)} = "${projection.indexName}";`,
 		);
 	}
 
@@ -28,8 +30,8 @@ export function emitIndex(projections: ResolvedProjection[]): EmittedIndexFile {
 	};
 }
 
-export function toIndexConstantName(sourceModelName: string): string {
-	return `${toSnakeUpper(sourceModelName)}_INDEX_NAME`;
+export function toIndexConstantName(projectionModelName: string): string {
+	return `${toSnakeUpper(projectionModelName)}_INDEX_NAME`;
 }
 
 function toSnakeUpper(value: string): string {

--- a/src/emit-index.ts
+++ b/src/emit-index.ts
@@ -1,0 +1,44 @@
+import { toKebabCase } from "./emit-doc-type.js";
+import type { ResolvedProjection } from "./projection.js";
+
+export interface EmittedIndexFile {
+	fileName: string;
+	content: string;
+}
+
+export function emitIndex(projections: ResolvedProjection[]): EmittedIndexFile {
+	const sorted = [...projections].sort((a, b) =>
+		a.projectionModel.name.localeCompare(b.projectionModel.name),
+	);
+
+	const lines: string[] = [];
+	for (const projection of sorted) {
+		const docTypeFile = `${toKebabCase(projection.projectionModel.name)}-search-doc.js`;
+		lines.push(
+			`export type { ${projection.projectionModel.name} } from "./${docTypeFile}";`,
+		);
+		lines.push(
+			`export const ${toIndexConstantName(projection.sourceModel.name)} = "${projection.indexName}";`,
+		);
+	}
+
+	return {
+		fileName: "index.ts",
+		content: `${lines.join("\n")}\n`,
+	};
+}
+
+export function toIndexConstantName(sourceModelName: string): string {
+	return `${toSnakeUpper(sourceModelName)}_INDEX_NAME`;
+}
+
+function toSnakeUpper(value: string): string {
+	return value
+		.replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+		.replace(/[-\s]+/g, "_")
+		.toUpperCase();
+}
+
+export const __test = {
+	toIndexConstantName,
+};

--- a/src/emit-mapping.test.ts
+++ b/src/emit-mapping.test.ts
@@ -67,6 +67,10 @@ describe("mapping emitter", () => {
 		assert.deepEqual(Object.keys(parsed.mappings.properties.owner.properties), [
 			"name",
 		]);
+		assert.equal(
+			parsed.mappings.properties.owner.properties.name.type,
+			"keyword",
+		);
 		assert.equal(parsed.mappings.properties.tags.type, "nested");
 		assert.deepEqual(Object.keys(parsed.mappings.properties.tags.properties), [
 			"name",

--- a/src/emit-mapping.test.ts
+++ b/src/emit-mapping.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { createTestHost, createTestWrapper } from "@typespec/compiler/testing";
+import { emitMapping } from "./emit-mapping.js";
+import { resolveProjectionModel } from "./projection.js";
+import { OpenSearchEmitterTestLibrary } from "./testing/index.js";
+
+async function createRunner() {
+	const host = await createTestHost({
+		libraries: [OpenSearchEmitterTestLibrary],
+	});
+
+	return createTestWrapper(host, {
+		autoImports: ["@kattebak/typespec-opensearch-emitter"],
+		autoUsings: ["Kattebak.OpenSearch"],
+	});
+}
+
+describe("mapping emitter", () => {
+	it("emits OpenSearch mapping for projection", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Owner {
+        @searchable @keyword name: string;
+        email: string;
+      }
+
+      model Tag {
+        @searchable name: string;
+      }
+
+      model Product {
+        @searchable id: string;
+        @searchable @keyword title: string;
+        @searchable price: float64;
+        @searchable releasedAt: plainDate;
+        @searchable owner: Owner;
+        @searchable @nested tags: Tag[];
+      }
+
+      model ProductSearchDoc is SearchProjection<Product> {
+        @analyzer("edge_ngram") @boost(2)
+        id: string;
+      }
+    `);
+		assert.equal(diagnostics.length, 0);
+
+		const projection = runner.program
+			.getGlobalNamespaceType()
+			.models.get("ProductSearchDoc");
+		assert.ok(projection);
+
+		const resolved = resolveProjectionModel(runner.program, projection);
+		assert.ok(resolved);
+		const emitted = emitMapping(runner.program, resolved);
+		assert.equal(emitted.fileName, "product-search-doc-search-mapping.json");
+
+		const parsed = JSON.parse(emitted.content);
+		assert.equal(parsed.mappings.properties.title.type, "keyword");
+		assert.equal(parsed.mappings.properties.id.type, "text");
+		assert.equal(parsed.mappings.properties.id.analyzer, "edge_ngram");
+		assert.equal(parsed.mappings.properties.id.boost, 2);
+		assert.equal(parsed.mappings.properties.price.type, "double");
+		assert.equal(parsed.mappings.properties.releasedAt.type, "date");
+		assert.equal(parsed.mappings.properties.owner.type, "object");
+		assert.deepEqual(Object.keys(parsed.mappings.properties.owner.properties), [
+			"name",
+		]);
+		assert.equal(parsed.mappings.properties.tags.type, "nested");
+		assert.deepEqual(Object.keys(parsed.mappings.properties.tags.properties), [
+			"name",
+		]);
+	});
+});

--- a/src/emit-mapping.ts
+++ b/src/emit-mapping.ts
@@ -1,0 +1,192 @@
+import type { Model, Program, Scalar, Type, Union } from "@typespec/compiler";
+import { isSearchable } from "./decorators.js";
+import type { ResolvedProjection } from "./projection.js";
+
+export interface EmittedMappingFile {
+	fileName: string;
+	content: string;
+}
+
+type MappingProperty = Record<string, unknown>;
+
+export function emitMapping(
+	program: Program,
+	projection: ResolvedProjection,
+): EmittedMappingFile {
+	const fileName = `${toKebabCase(projection.projectionModel.name)}-search-mapping.json`;
+	const properties = Object.fromEntries(
+		projection.fields.map((field) => [
+			field.name,
+			toMapping(program, field.type, {
+				keyword: field.keyword,
+				nested: field.nested,
+				analyzer: field.analyzer,
+				boost: field.boost,
+			}),
+		]),
+	);
+
+	return {
+		fileName,
+		content: `${JSON.stringify({ mappings: { properties } }, null, 2)}\n`,
+	};
+}
+
+function toMapping(
+	program: Program,
+	type: Type,
+	override?: {
+		keyword?: boolean;
+		nested?: boolean;
+		analyzer?: string;
+		boost?: number;
+	},
+): MappingProperty {
+	switch (type.kind) {
+		case "Scalar":
+			return mapScalar(type, override);
+		case "Model":
+			return mapModel(program, type, override);
+		case "String":
+			return mapString(override);
+		case "Number":
+			return { type: "double" };
+		case "Boolean":
+			return { type: "boolean" };
+		case "Union":
+			return mapUnion(program, type, override);
+		default:
+			return { type: "object" };
+	}
+}
+
+function mapString(override?: {
+	keyword?: boolean;
+	analyzer?: string;
+	boost?: number;
+}): MappingProperty {
+	if (override?.keyword) {
+		return { type: "keyword" };
+	}
+
+	const mapping: MappingProperty = {
+		type: "text",
+		fields: {
+			keyword: {
+				type: "keyword",
+				ignore_above: 256,
+			},
+		},
+	};
+
+	if (override?.analyzer) {
+		mapping.analyzer = override.analyzer;
+	}
+	if (override?.boost !== undefined) {
+		mapping.boost = override.boost;
+	}
+
+	return mapping;
+}
+
+function mapScalar(
+	scalar: Scalar,
+	override?: { keyword?: boolean; analyzer?: string; boost?: number },
+): MappingProperty {
+	let base = scalar;
+	while (base.baseScalar) {
+		base = base.baseScalar;
+	}
+
+	switch (base.name) {
+		case "string":
+			return mapString(override);
+		case "int32":
+		case "int64":
+		case "integer":
+		case "safeint":
+		case "uint8":
+		case "uint16":
+		case "uint32":
+		case "uint64":
+		case "int8":
+		case "int16":
+			return { type: "long" };
+		case "float":
+		case "float32":
+		case "float64":
+		case "decimal":
+		case "numeric":
+		case "number":
+			return { type: "double" };
+		case "boolean":
+			return { type: "boolean" };
+		case "utcDateTime":
+		case "plainDate":
+			return { type: "date" };
+		default:
+			return { type: "object" };
+	}
+}
+
+function mapModel(
+	program: Program,
+	model: Model,
+	override?: { nested?: boolean },
+): MappingProperty {
+	if (model.name === "Array" && model.indexer?.value) {
+		const elementType = model.indexer.value;
+		if (elementType.kind === "Model") {
+			return {
+				type: override?.nested ? "nested" : "object",
+				properties: mapModelProperties(program, elementType),
+			};
+		}
+		return toMapping(program, elementType);
+	}
+
+	return {
+		type: "object",
+		properties: mapModelProperties(program, model),
+	};
+}
+
+function mapModelProperties(
+	program: Program,
+	model: Model,
+): Record<string, MappingProperty> {
+	return Object.fromEntries(
+		Array.from(model.properties.values())
+			.filter((prop) => isSearchable(program, prop))
+			.map((prop) => [prop.name, toMapping(program, prop.type)]),
+	);
+}
+
+function mapUnion(
+	program: Program,
+	union: Union,
+	override?: { keyword?: boolean; analyzer?: string; boost?: number },
+): MappingProperty {
+	for (const variant of union.variants.values()) {
+		if (variant.type.kind === "Scalar" || variant.type.kind === "String") {
+			return toMapping(program, variant.type, override);
+		}
+	}
+	return { type: "object" };
+}
+
+export function toKebabCase(name: string): string {
+	return name
+		.replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+		.replace(/[-\s]+/g, "-")
+		.toLowerCase();
+}
+
+export const __test = {
+	mapModel,
+	mapScalar,
+	mapString,
+	mapUnion,
+	toKebabCase,
+	toMapping,
+};

--- a/src/emit-mapping.ts
+++ b/src/emit-mapping.ts
@@ -1,5 +1,11 @@
 import type { Model, Program, Scalar, Type, Union } from "@typespec/compiler";
-import { isSearchable } from "./decorators.js";
+import {
+	getAnalyzer,
+	getBoost,
+	isKeyword,
+	isNested,
+	isSearchable,
+} from "./decorators.js";
 import type { ResolvedProjection } from "./projection.js";
 
 export interface EmittedMappingFile {
@@ -158,7 +164,15 @@ function mapModelProperties(
 	return Object.fromEntries(
 		Array.from(model.properties.values())
 			.filter((prop) => isSearchable(program, prop))
-			.map((prop) => [prop.name, toMapping(program, prop.type)]),
+			.map((prop) => [
+				prop.name,
+				toMapping(program, prop.type, {
+					keyword: isKeyword(program, prop),
+					nested: isNested(program, prop),
+					analyzer: getAnalyzer(program, prop),
+					boost: getBoost(program, prop),
+				}),
+			]),
 	);
 }
 

--- a/src/emitter.test.ts
+++ b/src/emitter.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { createTestHost, createTestWrapper } from "@typespec/compiler/testing";
+import { __test } from "./emitter.js";
+import type { ResolvedProjection } from "./projection.js";
+import { OpenSearchEmitterTestLibrary } from "./testing/index.js";
+
+async function createRunner() {
+	const host = await createTestHost({
+		libraries: [OpenSearchEmitterTestLibrary],
+	});
+
+	return createTestWrapper(host, {
+		autoImports: ["@kattebak/typespec-opensearch-emitter"],
+		autoUsings: ["Kattebak.OpenSearch"],
+	});
+}
+
+describe("emitter model collection", () => {
+	it("collects only SearchProjection<T> models", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Product {
+        @searchable name: string;
+        hidden: string;
+      }
+
+      model ProductSearchDoc is SearchProjection<Product> {}
+      model Inventory {}
+    `);
+
+		assert.equal(diagnostics.length, 0);
+
+		const models = __test.collectProjectionModels(
+			runner.program,
+			runner.program.getGlobalNamespaceType(),
+		);
+		assert.deepEqual(
+			models.map((x) => x.name),
+			["ProductSearchDoc"],
+		);
+	});
+
+	it("serializes resolved projections", () => {
+		const projections = [
+			{
+				projectionModel: { name: "ProductSearchDoc" },
+				sourceModel: { name: "Product" },
+				indexName: "product_search_doc",
+				fields: [
+					{
+						name: "name",
+						optional: false,
+						keyword: true,
+						nested: false,
+						analyzer: "edge_ngram",
+						boost: 2,
+					},
+				],
+			},
+		] as unknown as ResolvedProjection[];
+		const serialized = __test.serializeProjections(projections);
+
+		assert.deepEqual(serialized, {
+			projections: [
+				{
+					name: "ProductSearchDoc",
+					sourceModel: "Product",
+					indexName: "product_search_doc",
+					fields: [
+						{
+							name: "name",
+							optional: false,
+							keyword: true,
+							nested: false,
+							analyzer: "edge_ngram",
+							boost: 2,
+						},
+					],
+				},
+			],
+		});
+	});
+});

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -1,35 +1,65 @@
-import type { EmitContext, Model, Namespace } from "@typespec/compiler";
+import type {
+	EmitContext,
+	Model,
+	Namespace,
+	Program,
+} from "@typespec/compiler";
 import { emitFile, resolvePath } from "@typespec/compiler";
 import type { OpenSearchEmitterOptions } from "./lib.js";
+import {
+	isSearchProjectionModel,
+	type ResolvedProjection,
+	resolveProjectionModel,
+} from "./projection.js";
 
 export async function $onEmit(
 	context: EmitContext<OpenSearchEmitterOptions>,
 ): Promise<void> {
 	const outputFile =
 		context.options["output-file"] ?? "opensearch-projections.json";
-	const models: string[] = [];
 
-	collectModels(context.program.getGlobalNamespaceType(), models);
+	const projectionModels = collectProjectionModels(
+		context.program,
+		context.program.getGlobalNamespaceType(),
+	);
+	if (projectionModels.length === 0) {
+		return;
+	}
+
+	const resolved = projectionModels
+		.map((model) => resolveProjectionModel(context.program, model))
+		.filter((x): x is ResolvedProjection => x !== undefined);
 
 	await emitFile(context.program, {
 		path: resolvePath(context.emitterOutputDir, outputFile),
-		content: `${JSON.stringify({ models }, null, 2)}\n`,
+		content: `${JSON.stringify(serializeProjections(resolved), null, 2)}\n`,
 	});
 }
 
-function collectModels(namespace: Namespace, models: string[]): void {
+function collectProjectionModels(
+	program: Program,
+	namespace: Namespace,
+): Model[] {
+	const models: Model[] = [];
+
 	for (const model of namespace.models.values()) {
-		if (isUserModel(model)) {
-			models.push(model.name);
+		if (
+			isCandidateModel(model) &&
+			!isTemplateDeclaration(model) &&
+			isSearchProjectionModel(program, model)
+		) {
+			models.push(model);
 		}
 	}
 
 	for (const child of namespace.namespaces.values()) {
-		collectModels(child, models);
+		models.push(...collectProjectionModels(program, child));
 	}
+
+	return models;
 }
 
-function isUserModel(model: Model): boolean {
+function isCandidateModel(model: Model): boolean {
 	if (
 		model.name === "Array" ||
 		model.name === "Record" ||
@@ -55,7 +85,38 @@ function isUserModel(model: Model): boolean {
 	return !!model.name;
 }
 
+function isTemplateDeclaration(model: Model): boolean {
+	if (model.node && "templateParameters" in model.node) {
+		const templateParams = (
+			model.node as { templateParameters?: readonly unknown[] }
+		).templateParameters;
+		return !!templateParams && templateParams.length > 0;
+	}
+
+	return false;
+}
+
+function serializeProjections(resolved: ResolvedProjection[]) {
+	return {
+		projections: resolved.map((projection) => ({
+			name: projection.projectionModel.name,
+			sourceModel: projection.sourceModel.name,
+			indexName: projection.indexName,
+			fields: projection.fields.map((field) => ({
+				name: field.name,
+				optional: field.optional,
+				keyword: field.keyword,
+				nested: field.nested,
+				analyzer: field.analyzer,
+				boost: field.boost,
+			})),
+		})),
+	};
+}
+
 export const __test = {
-	collectModels,
-	isUserModel,
+	collectProjectionModels,
+	isCandidateModel,
+	isTemplateDeclaration,
+	serializeProjections,
 };

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -73,15 +73,6 @@ function isCandidateModel(model: Model): boolean {
 		return false;
 	}
 
-	// Temporary name-based filter for library models.
-	// This will be replaced by explicit SearchProjection<T> resolution in #10/#11.
-	if (
-		namespaceName === "OpenSearch" &&
-		model.namespace?.namespace?.name === "Kattebak"
-	) {
-		return false;
-	}
-
 	return !!model.name;
 }
 

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -6,6 +6,7 @@ import type {
 } from "@typespec/compiler";
 import { emitFile, resolvePath } from "@typespec/compiler";
 import { emitDocType } from "./emit-doc-type.js";
+import { emitMapping } from "./emit-mapping.js";
 import type { OpenSearchEmitterOptions } from "./lib.js";
 import {
 	isSearchProjectionModel,
@@ -36,6 +37,12 @@ export async function $onEmit(
 		await emitFile(context.program, {
 			path: resolvePath(context.emitterOutputDir, docTypeFile.fileName),
 			content: docTypeFile.content,
+		});
+
+		const mappingFile = emitMapping(context.program, projection);
+		await emitFile(context.program, {
+			path: resolvePath(context.emitterOutputDir, mappingFile.fileName),
+			content: mappingFile.content,
 		});
 	}
 

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -5,6 +5,7 @@ import type {
 	Program,
 } from "@typespec/compiler";
 import { emitFile, resolvePath } from "@typespec/compiler";
+import { emitDocType } from "./emit-doc-type.js";
 import type { OpenSearchEmitterOptions } from "./lib.js";
 import {
 	isSearchProjectionModel,
@@ -29,6 +30,14 @@ export async function $onEmit(
 	const resolved = projectionModels
 		.map((model) => resolveProjectionModel(context.program, model))
 		.filter((x): x is ResolvedProjection => x !== undefined);
+
+	for (const projection of resolved) {
+		const docTypeFile = emitDocType(context.program, projection);
+		await emitFile(context.program, {
+			path: resolvePath(context.emitterOutputDir, docTypeFile.fileName),
+			content: docTypeFile.content,
+		});
+	}
 
 	await emitFile(context.program, {
 		path: resolvePath(context.emitterOutputDir, outputFile),

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -6,6 +6,7 @@ import type {
 } from "@typespec/compiler";
 import { emitFile, resolvePath } from "@typespec/compiler";
 import { emitDocType } from "./emit-doc-type.js";
+import { emitIndex } from "./emit-index.js";
 import { emitMapping } from "./emit-mapping.js";
 import type { OpenSearchEmitterOptions } from "./lib.js";
 import {
@@ -45,6 +46,12 @@ export async function $onEmit(
 			content: mappingFile.content,
 		});
 	}
+
+	const indexFile = emitIndex(resolved);
+	await emitFile(context.program, {
+		path: resolvePath(context.emitterOutputDir, indexFile.fileName),
+		content: indexFile.content,
+	});
 
 	await emitFile(context.program, {
 		path: resolvePath(context.emitterOutputDir, outputFile),

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,4 +1,4 @@
-import { createTypeSpecLibrary } from "@typespec/compiler";
+import { createTypeSpecLibrary, paramMessage } from "@typespec/compiler";
 
 export interface OpenSearchEmitterOptions {
 	"output-file"?: string;
@@ -6,7 +6,27 @@ export interface OpenSearchEmitterOptions {
 
 export const $lib = createTypeSpecLibrary({
 	name: "@kattebak/typespec-opensearch-emitter",
-	diagnostics: {},
+	diagnostics: {
+		"string-property-required": {
+			severity: "error",
+			messages: {
+				default: paramMessage`Decorator @${"decorator"} can only be applied to string properties.`,
+			},
+		},
+		"nested-array-model-required": {
+			severity: "error",
+			messages: {
+				default:
+					"Decorator @nested can only be applied to array properties whose element type is a model.",
+			},
+		},
+		"positive-boost-required": {
+			severity: "error",
+			messages: {
+				default: "Decorator @boost requires a factor greater than 0.",
+			},
+		},
+	},
 	state: {
 		searchable: { description: "Marks a property as searchable" },
 		keyword: { description: "Marks a property as keyword" },

--- a/src/projection.test.ts
+++ b/src/projection.test.ts
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { createTestHost, createTestWrapper } from "@typespec/compiler/testing";
+import { isSearchable } from "./decorators.js";
+import { resolveProjectionModel } from "./projection.js";
+import { OpenSearchEmitterTestLibrary } from "./testing/index.js";
+
+async function createRunner() {
+	const host = await createTestHost({
+		libraries: [OpenSearchEmitterTestLibrary],
+	});
+
+	return createTestWrapper(host, {
+		autoImports: ["@kattebak/typespec-opensearch-emitter"],
+		autoUsings: ["Kattebak.OpenSearch"],
+	});
+}
+
+describe("projection resolution", () => {
+	it("resolves only searchable fields and merges projection overrides", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Tag {
+        @searchable label: string;
+        hidden: string;
+      }
+
+      model Product {
+        @searchable @keyword name: string;
+        @searchable tags: Tag[];
+        hidden: string;
+      }
+
+      @indexName("products_v1")
+      model ProductSearchDoc is SearchProjection<Product> {
+        @analyzer("edge_ngram") @boost(2.0)
+        name: string;
+
+        @nested
+        tags: Tag[];
+      }
+    `);
+
+		assert.equal(diagnostics.length, 0);
+
+		const projectionModel = runner.program
+			.getGlobalNamespaceType()
+			.models.get("ProductSearchDoc");
+		assert.ok(projectionModel);
+
+		const resolved = resolveProjectionModel(runner.program, projectionModel);
+		assert.ok(resolved);
+
+		assert.equal(resolved.sourceModel.name, "Product");
+		assert.equal(resolved.indexName, "products_v1");
+		assert.deepEqual(
+			resolved.fields.map((x) => x.name),
+			["name", "tags"],
+		);
+
+		const nameField = resolved.fields.find((x) => x.name === "name");
+		assert.ok(nameField);
+		assert.equal(nameField.keyword, true);
+		assert.equal(nameField.analyzer, "edge_ngram");
+		assert.equal(nameField.boost, 2);
+
+		const tagsField = resolved.fields.find((x) => x.name === "tags");
+		assert.ok(tagsField);
+		assert.equal(tagsField.nested, true);
+	});
+
+	it("returns undefined for non projection model", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Product {
+        @searchable name: string;
+      }
+    `);
+		assert.equal(diagnostics.length, 0);
+
+		const model = runner.program.getGlobalNamespaceType().models.get("Product");
+		assert.ok(model);
+		assert.equal(resolveProjectionModel(runner.program, model), undefined);
+	});
+
+	it("keeps non-searchable source fields excluded", async () => {
+		const runner = await createRunner();
+		await runner.compile(`
+      model Product {
+        @searchable name: string;
+        hidden: string;
+      }
+
+      model ProductSearchDoc is SearchProjection<Product> {}
+    `);
+
+		const source = runner.program
+			.getGlobalNamespaceType()
+			.models.get("Product");
+		assert.ok(source);
+		const hidden = source.properties.get("hidden");
+		assert.ok(hidden);
+		assert.equal(isSearchable(runner.program, hidden), false);
+
+		const projection = runner.program
+			.getGlobalNamespaceType()
+			.models.get("ProductSearchDoc");
+		assert.ok(projection);
+		const resolved = resolveProjectionModel(runner.program, projection);
+		assert.ok(resolved);
+		assert.deepEqual(
+			resolved.fields.map((x) => x.name),
+			["name"],
+		);
+	});
+});

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -1,0 +1,130 @@
+import type { Model, ModelProperty, Program, Type } from "@typespec/compiler";
+import {
+	getAnalyzer,
+	getBoost,
+	getIndexName,
+	isKeyword,
+	isNested,
+	isSearchable,
+} from "./decorators.js";
+
+export interface ResolvedProjectionField {
+	name: string;
+	type: Type;
+	optional: boolean;
+	sourceProperty: ModelProperty;
+	projectionProperty?: ModelProperty;
+	searchable: boolean;
+	keyword: boolean;
+	nested: boolean;
+	analyzer?: string;
+	boost?: number;
+}
+
+export interface ResolvedProjection {
+	projectionModel: Model;
+	sourceModel: Model;
+	indexName: string;
+	fields: ResolvedProjectionField[];
+}
+
+export function isSearchProjectionModel(
+	program: Program,
+	model: Model,
+): boolean {
+	return !!getProjectionSourceModel(program, model);
+}
+
+export function getProjectionSourceModel(
+	program: Program,
+	projectionModel: Model,
+): Model | undefined {
+	if (projectionModel.name === "SearchProjection") {
+		return undefined;
+	}
+
+	if (projectionModel.sourceModel?.name !== "SearchProjection") {
+		return undefined;
+	}
+
+	const isExpression =
+		projectionModel.node && "is" in projectionModel.node
+			? (projectionModel.node.is as
+					| { arguments?: readonly unknown[] }
+					| undefined)
+			: undefined;
+	const arg = isExpression?.arguments?.[0];
+	if (!arg) {
+		return undefined;
+	}
+
+	const sourceType = program.checker.getTypeForNode(arg as never);
+	return sourceType.kind === "Model" ? sourceType : undefined;
+}
+
+export function resolveProjectionModel(
+	program: Program,
+	projectionModel: Model,
+): ResolvedProjection | undefined {
+	const sourceModel = getProjectionSourceModel(program, projectionModel);
+	if (!sourceModel) {
+		return undefined;
+	}
+
+	const fields: ResolvedProjectionField[] = [];
+	for (const sourceProperty of sourceModel.properties.values()) {
+		if (!isSearchable(program, sourceProperty)) {
+			continue;
+		}
+
+		const projectionProperty = projectionModel.properties.get(
+			sourceProperty.name,
+		);
+		fields.push(
+			resolveProjectionField(program, sourceProperty, projectionProperty),
+		);
+	}
+
+	return {
+		projectionModel,
+		sourceModel,
+		indexName: getIndexName(program, projectionModel),
+		fields,
+	};
+}
+
+function resolveProjectionField(
+	program: Program,
+	sourceProperty: ModelProperty,
+	projectionProperty?: ModelProperty,
+): ResolvedProjectionField {
+	const analyzer =
+		(projectionProperty && getAnalyzer(program, projectionProperty)) ??
+		getAnalyzer(program, sourceProperty);
+	const boost =
+		(projectionProperty && getBoost(program, projectionProperty)) ??
+		getBoost(program, sourceProperty);
+
+	return {
+		name: sourceProperty.name,
+		type: projectionProperty?.type ?? sourceProperty.type,
+		optional: projectionProperty?.optional ?? sourceProperty.optional,
+		sourceProperty,
+		projectionProperty,
+		searchable: true,
+		keyword:
+			(projectionProperty && isKeyword(program, projectionProperty)) ||
+			isKeyword(program, sourceProperty),
+		nested:
+			(projectionProperty && isNested(program, projectionProperty)) ||
+			isNested(program, sourceProperty),
+		analyzer,
+		boost,
+	};
+}
+
+export const __test = {
+	getProjectionSourceModel,
+	isSearchProjectionModel,
+	resolveProjectionField,
+};

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -43,22 +43,21 @@ export function getProjectionSourceModel(
 		return undefined;
 	}
 
-	if (projectionModel.sourceModel?.name !== "SearchProjection") {
+	const isSource = projectionModel.sourceModels.find(
+		(x) => x.usage === "is" && x.model.name === "SearchProjection",
+	);
+	if (!isSource?.node) {
 		return undefined;
 	}
 
-	const isExpression =
-		projectionModel.node && "is" in projectionModel.node
-			? (projectionModel.node.is as
-					| { arguments?: readonly unknown[] }
-					| undefined)
-			: undefined;
-	const arg = isExpression?.arguments?.[0];
+	const node = isSource.node as { arguments?: readonly unknown[] };
+	const arg = node.arguments?.[0];
 	if (!arg) {
 		return undefined;
 	}
 
-	const sourceType = program.checker.getTypeForNode(arg as never);
+	type TypeForNodeInput = Parameters<Program["checker"]["getTypeForNode"]>[0];
+	const sourceType = program.checker.getTypeForNode(arg as TypeForNodeInput);
 	return sourceType.kind === "Model" ? sourceType : undefined;
 }
 

--- a/test/example.js
+++ b/test/example.js
@@ -73,7 +73,9 @@ test("emits index.ts barrel", async () => {
 		true,
 	);
 	assert.equal(
-		content.includes('export const PRODUCT_SEARCH_DOC_INDEX_NAME = "products_v1";'),
+		content.includes(
+			'export const PRODUCT_SEARCH_DOC_INDEX_NAME = "products_v1";',
+		),
 		true,
 	);
 });

--- a/test/example.js
+++ b/test/example.js
@@ -58,3 +58,18 @@ test("emits OpenSearch mapping JSON", async () => {
 	assert.equal(parsed.mappings.properties.title.type, "keyword");
 	assert.equal(parsed.mappings.properties.title.fields, undefined);
 });
+
+test("emits index.ts barrel", async () => {
+	const content = await readFile("build/opensearch/index.ts", "utf8");
+
+	assert.equal(
+		content.includes(
+			'export type { ProductSearchDoc } from "./product-search-doc-search-doc.js";',
+		),
+		true,
+	);
+	assert.equal(
+		content.includes('export const PRODUCT_INDEX_NAME = "products_v1";'),
+		true,
+	);
+});

--- a/test/example.js
+++ b/test/example.js
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { readFile, writeFile } from "node:fs/promises";
 import test from "node:test";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
 
 test("emits resolved search projections", async () => {
 	const content = await readFile(
@@ -37,7 +41,7 @@ test("emits resolved search projections", async () => {
 
 test("emits TypeScript document type", async () => {
 	const content = await readFile(
-		"build/opensearch/product-search-doc-search-doc.ts",
+		"build/opensearch/product-search-doc.ts",
 		"utf8",
 	);
 
@@ -64,12 +68,39 @@ test("emits index.ts barrel", async () => {
 
 	assert.equal(
 		content.includes(
-			'export type { ProductSearchDoc } from "./product-search-doc-search-doc.js";',
+			'export type { ProductSearchDoc } from "./product-search-doc.js";',
 		),
 		true,
 	);
 	assert.equal(
-		content.includes('export const PRODUCT_INDEX_NAME = "products_v1";'),
+		content.includes('export const PRODUCT_SEARCH_DOC_INDEX_NAME = "products_v1";'),
 		true,
 	);
+});
+
+test("generated doc type compiles under tsc --noEmit", async () => {
+	await writeFile(
+		"build/opensearch/tsconfig.json",
+		JSON.stringify(
+			{
+				compilerOptions: {
+					module: "ESNext",
+					moduleResolution: "bundler",
+					target: "ES2020",
+					strict: true,
+					noEmit: true,
+				},
+				include: ["*.ts"],
+			},
+			null,
+			2,
+		),
+	);
+
+	await execFileAsync("npx", [
+		"tsc",
+		"--noEmit",
+		"-p",
+		"build/opensearch/tsconfig.json",
+	]);
 });

--- a/test/example.js
+++ b/test/example.js
@@ -46,3 +46,15 @@ test("emits TypeScript document type", async () => {
 	assert.equal(content.includes("\ttitle: string;"), true);
 	assert.equal(content.includes("internalNotes"), false);
 });
+
+test("emits OpenSearch mapping JSON", async () => {
+	const content = await readFile(
+		"build/opensearch/product-search-doc-search-mapping.json",
+		"utf8",
+	);
+	const parsed = JSON.parse(content);
+
+	assert.equal(parsed.mappings.properties.id.type, "text");
+	assert.equal(parsed.mappings.properties.title.type, "keyword");
+	assert.equal(parsed.mappings.properties.title.fields, undefined);
+});

--- a/test/example.js
+++ b/test/example.js
@@ -34,3 +34,15 @@ test("emits resolved search projections", async () => {
 		],
 	});
 });
+
+test("emits TypeScript document type", async () => {
+	const content = await readFile(
+		"build/opensearch/product-search-doc-search-doc.ts",
+		"utf8",
+	);
+
+	assert.equal(content.includes("export interface ProductSearchDoc"), true);
+	assert.equal(content.includes("\tid: string;"), true);
+	assert.equal(content.includes("\ttitle: string;"), true);
+	assert.equal(content.includes("internalNotes"), false);
+});

--- a/test/example.js
+++ b/test/example.js
@@ -2,12 +2,35 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 
-test("emits OpenSearch projection file", async () => {
+test("emits resolved search projections", async () => {
 	const content = await readFile(
 		"build/opensearch/opensearch-projections.json",
 		"utf8",
 	);
 	const parsed = JSON.parse(content);
 
-	assert.deepEqual(parsed.models, ["ProductDocument"]);
+	assert.deepEqual(parsed, {
+		projections: [
+			{
+				name: "ProductSearchDoc",
+				sourceModel: "Product",
+				indexName: "products_v1",
+				fields: [
+					{
+						name: "id",
+						optional: false,
+						keyword: false,
+						nested: false,
+					},
+					{
+						name: "title",
+						optional: false,
+						keyword: true,
+						nested: false,
+						analyzer: "edge_ngram",
+					},
+				],
+			},
+		],
+	});
 });

--- a/test/main.tsp
+++ b/test/main.tsp
@@ -1,7 +1,14 @@
 import "@kattebak/typespec-opensearch-emitter";
 
-model ProductDocument {
-	id: string;
-	title: string;
-	price: float64;
+using Kattebak.OpenSearch;
+
+model Product {
+	@searchable id: string;
+	@searchable @keyword title: string;
+	internalNotes: string;
+}
+
+@indexName("products_v1")
+model ProductSearchDoc is SearchProjection<Product> {
+	@analyzer("edge_ngram") title: string;
 }


### PR DESCRIPTION
## Summary

Implements index-module generation as the canonical import surface.

## Changes

- Added `src/emit-index.ts`
  - emits `index.ts`
  - per projection:
    - `export type { <ProjectionDoc> } from "./<doc-file>.js"`
    - `export const <SOURCE_MODEL>_INDEX_NAME = "<resolved-index-name>"`
- Updated `src/emitter.ts`
  - emits `index.ts` after doc and mapping files
- Added tests
  - `src/emit-index.test.ts`
  - E2E assertion in `test/example.js`
- Updated README status/output section

## Validation

- `npm test` passes

## Issues

- Closes #14

## Stack

- Parent: #23
