### PR TITLE
feat: emit TypeScript document types for projections

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Implemented so far:
 - Decorator validation diagnostics
 - `SearchProjection<T>` template + projection resolution
 - Emitter collection of projection models and resolved projection metadata output
+- TypeScript document type emission per projection (`*-search-doc.ts`)
 - CI, linting, unit tests, emitter E2E test
 
 ## Usage
@@ -40,4 +41,4 @@ options:
     output-file: "opensearch-projections.json"
 ```
 
-Current emitted file is projection metadata JSON and is an intermediate step toward document type and mapping emitters.
+Current outputs include projection metadata JSON and generated TypeScript document interfaces. OpenSearch mapping JSON emission is next.

--- a/src/emit-doc-type.test.ts
+++ b/src/emit-doc-type.test.ts
@@ -46,7 +46,7 @@ describe("doc type emitter", () => {
 		assert.ok(resolved);
 
 		const emitted = emitDocType(runner.program, resolved);
-		assert.equal(emitted.fileName, "product-search-doc-search-doc.ts");
+		assert.equal(emitted.fileName, "product-search-doc.ts");
 		assert.equal(
 			emitted.content.includes("export interface ProductSearchDoc"),
 			true,

--- a/src/emit-doc-type.test.ts
+++ b/src/emit-doc-type.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { createTestHost, createTestWrapper } from "@typespec/compiler/testing";
+import { emitDocType } from "./emit-doc-type.js";
+import { resolveProjectionModel } from "./projection.js";
+import { OpenSearchEmitterTestLibrary } from "./testing/index.js";
+
+async function createRunner() {
+	const host = await createTestHost({
+		libraries: [OpenSearchEmitterTestLibrary],
+	});
+
+	return createTestWrapper(host, {
+		autoImports: ["@kattebak/typespec-opensearch-emitter"],
+		autoUsings: ["Kattebak.OpenSearch"],
+	});
+}
+
+describe("doc type emitter", () => {
+	it("emits TypeScript interface for projection model", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Owner {
+        @searchable name: string;
+        email: string;
+      }
+
+      model Product {
+        @searchable id: string;
+        @searchable price: float64;
+        @searchable owner: Owner;
+        @searchable tags: string[];
+      }
+
+      model ProductSearchDoc is SearchProjection<Product> {}
+    `);
+		assert.equal(diagnostics.length, 0);
+
+		const projection = runner.program
+			.getGlobalNamespaceType()
+			.models.get("ProductSearchDoc");
+		assert.ok(projection);
+
+		const resolved = resolveProjectionModel(runner.program, projection);
+		assert.ok(resolved);
+
+		const emitted = emitDocType(runner.program, resolved);
+		assert.equal(emitted.fileName, "product-search-doc-search-doc.ts");
+		assert.equal(
+			emitted.content.includes("export interface ProductSearchDoc"),
+			true,
+		);
+		assert.equal(emitted.content.includes("\tid: string;"), true);
+		assert.equal(emitted.content.includes("\tprice: number;"), true);
+		assert.equal(emitted.content.includes("\towner:"), true);
+		assert.equal(emitted.content.includes("\ttags: string[];"), true);
+		assert.equal(emitted.content.includes("email"), false);
+	});
+});

--- a/src/emit-doc-type.ts
+++ b/src/emit-doc-type.ts
@@ -11,7 +11,7 @@ export function emitDocType(
 	program: Program,
 	projection: ResolvedProjection,
 ): EmittedDocTypeFile {
-	const fileName = `${toKebabCase(projection.projectionModel.name)}-search-doc.ts`;
+	const fileName = toDocTypeFileName(projection.projectionModel.name);
 	const body = renderInterfaceBody(
 		program,
 		projection.fields.map((x) => ({
@@ -143,10 +143,19 @@ export function toKebabCase(name: string): string {
 		.toLowerCase();
 }
 
+export function toDocTypeFileName(projectionModelName: string): string {
+	const kebab = toKebabCase(projectionModelName);
+	const base = kebab.endsWith("-search-doc")
+		? kebab.slice(0, -"-search-doc".length)
+		: kebab;
+	return `${base}-search-doc.ts`;
+}
+
 export const __test = {
 	renderModel,
 	renderScalar,
 	renderType,
 	renderUnion,
+	toDocTypeFileName,
 	toKebabCase,
 };

--- a/src/emit-doc-type.ts
+++ b/src/emit-doc-type.ts
@@ -1,0 +1,152 @@
+import type { Model, Program, Scalar, Type, Union } from "@typespec/compiler";
+import { isSearchable } from "./decorators.js";
+import type { ResolvedProjection } from "./projection.js";
+
+export interface EmittedDocTypeFile {
+	fileName: string;
+	content: string;
+}
+
+export function emitDocType(
+	program: Program,
+	projection: ResolvedProjection,
+): EmittedDocTypeFile {
+	const fileName = `${toKebabCase(projection.projectionModel.name)}-search-doc.ts`;
+	const body = renderInterfaceBody(
+		program,
+		projection.fields.map((x) => ({
+			name: x.name,
+			type: x.type,
+			optional: x.optional,
+		})),
+	);
+
+	return {
+		fileName,
+		content: `export interface ${projection.projectionModel.name} ${body}\n`,
+	};
+}
+
+function renderInterfaceBody(
+	program: Program,
+	fields: ReadonlyArray<{ name: string; type: Type; optional: boolean }>,
+): string {
+	if (fields.length === 0) {
+		return "{}";
+	}
+
+	const lines = fields.map((field) => {
+		const optional = field.optional ? "?" : "";
+		const type = renderType(program, field.type);
+		return `\t${field.name}${optional}: ${type};`;
+	});
+
+	return `\n{\n${lines.join("\n")}\n}`;
+}
+
+function renderType(program: Program, type: Type): string {
+	switch (type.kind) {
+		case "Scalar":
+			return renderScalar(type);
+		case "Model":
+			return renderModel(program, type);
+		case "String":
+			return "string";
+		case "Number":
+			return "number";
+		case "Boolean":
+			return "boolean";
+		case "Union":
+			return renderUnion(program, type);
+		default:
+			return "unknown";
+	}
+}
+
+function renderScalar(scalar: Scalar): string {
+	let base = scalar;
+	while (base.baseScalar) {
+		base = base.baseScalar;
+	}
+
+	switch (base.name) {
+		case "string":
+		case "plainDate":
+		case "utcDateTime":
+			return "string";
+		case "int32":
+		case "int64":
+		case "float":
+		case "float32":
+		case "float64":
+		case "decimal":
+		case "numeric":
+		case "integer":
+		case "safeint":
+		case "uint8":
+		case "uint16":
+		case "uint32":
+		case "uint64":
+		case "int8":
+		case "int16":
+		case "number":
+			return "number";
+		case "boolean":
+			return "boolean";
+		default:
+			return "unknown";
+	}
+}
+
+function renderModel(program: Program, model: Model): string {
+	if (model.name === "Array" && model.indexer?.value) {
+		return `${renderType(program, model.indexer.value)}[]`;
+	}
+
+	if (model.name === "Record" && model.indexer?.value) {
+		return `Record<string, ${renderType(program, model.indexer.value)}>`;
+	}
+
+	const searchableFields = Array.from(model.properties.values())
+		.filter((prop) => isSearchable(program, prop))
+		.map((prop) => ({
+			name: prop.name,
+			type: prop.type,
+			optional: prop.optional,
+		}));
+
+	if (searchableFields.length === 0) {
+		return "{}";
+	}
+
+	const lines = searchableFields.map((field) => {
+		const optional = field.optional ? "?" : "";
+		return `\t${field.name}${optional}: ${renderType(program, field.type)};`;
+	});
+
+	return `{\n${lines.join("\n")}\n}`;
+}
+
+function renderUnion(program: Program, union: Union): string {
+	const variants = Array.from(union.variants.values());
+	if (variants.length === 0) {
+		return "never";
+	}
+
+	return variants.map((x) => renderType(program, x.type)).join(" | ");
+}
+
+export function toKebabCase(name: string): string {
+	return name
+		.replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+		.replace(/[-\s]+/g, "-")
+		.toLowerCase();
+}
+
+export const __test = {
+	renderModel,
+	renderScalar,
+	renderType,
+	renderUnion,
+	toKebabCase,
+};

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -5,6 +5,7 @@ import type {
 	Program,
 } from "@typespec/compiler";
 import { emitFile, resolvePath } from "@typespec/compiler";
+import { emitDocType } from "./emit-doc-type.js";
 import type { OpenSearchEmitterOptions } from "./lib.js";
 import {
 	isSearchProjectionModel,
@@ -29,6 +30,14 @@ export async function $onEmit(
 	const resolved = projectionModels
 		.map((model) => resolveProjectionModel(context.program, model))
 		.filter((x): x is ResolvedProjection => x !== undefined);
+
+	for (const projection of resolved) {
+		const docTypeFile = emitDocType(context.program, projection);
+		await emitFile(context.program, {
+			path: resolvePath(context.emitterOutputDir, docTypeFile.fileName),
+			content: docTypeFile.content,
+		});
+	}
 
 	await emitFile(context.program, {
 		path: resolvePath(context.emitterOutputDir, outputFile),

--- a/test/example.js
+++ b/test/example.js
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { readFile, writeFile } from "node:fs/promises";
 import test from "node:test";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
 
 test("emits resolved search projections", async () => {
 	const content = await readFile(
@@ -37,7 +41,7 @@ test("emits resolved search projections", async () => {
 
 test("emits TypeScript document type", async () => {
 	const content = await readFile(
-		"build/opensearch/product-search-doc-search-doc.ts",
+		"build/opensearch/product-search-doc.ts",
 		"utf8",
 	);
 
@@ -45,4 +49,31 @@ test("emits TypeScript document type", async () => {
 	assert.equal(content.includes("\tid: string;"), true);
 	assert.equal(content.includes("\ttitle: string;"), true);
 	assert.equal(content.includes("internalNotes"), false);
+});
+
+test("generated doc type compiles under tsc --noEmit", async () => {
+	await writeFile(
+		"build/opensearch/tsconfig.json",
+		JSON.stringify(
+			{
+				compilerOptions: {
+					module: "ESNext",
+					moduleResolution: "bundler",
+					target: "ES2020",
+					strict: true,
+					noEmit: true,
+				},
+				include: ["*.ts"],
+			},
+			null,
+			2,
+		),
+	);
+
+	await execFileAsync("npx", [
+		"tsc",
+		"--noEmit",
+		"-p",
+		"build/opensearch/tsconfig.json",
+	]);
 });

--- a/test/example.js
+++ b/test/example.js
@@ -34,3 +34,15 @@ test("emits resolved search projections", async () => {
 		],
 	});
 });
+
+test("emits TypeScript document type", async () => {
+	const content = await readFile(
+		"build/opensearch/product-search-doc-search-doc.ts",
+		"utf8",
+	);
+
+	assert.equal(content.includes("export interface ProductSearchDoc"), true);
+	assert.equal(content.includes("\tid: string;"), true);
+	assert.equal(content.includes("\ttitle: string;"), true);
+	assert.equal(content.includes("internalNotes"), false);
+});


### PR DESCRIPTION
## Summary

Implements TypeScript document type emission for each resolved `SearchProjection<T>`.

## Changes

- Added `src/emit-doc-type.ts`
  - emits `export interface <ProjectionModelName>`
  - file naming: `<kebab-case-projection-name>-search-doc.ts` (normalized to avoid duplicate suffixes)
  - type mapping:
    - `string` -> `string`
    - `int32`, `int64`, `float64` (+ numeric scalars) -> `number`
    - `boolean` -> `boolean`
    - `utcDateTime`, `plainDate` -> `string`
    - `Model` -> nested object type (searchable fields only)
    - `T[]` -> `T[]`
    - optional props -> `field?: T`
- Updated `src/emitter.ts`
  - emits one doc type file per resolved projection
  - keeps projection metadata JSON output
- Added tests
  - `src/emit-doc-type.test.ts` unit/integration coverage
  - updated `test/example.js` to assert emitted doc file exists/content
  - added emitted-output compile check (`tsc --noEmit` over build output)
- Updated README status/output notes

## Validation

- `npm test` passes

## Issues

- Closes #12
