### PR TITLE
feat: emit OpenSearch mapping JSON for projections

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Implemented so far:
 - `SearchProjection<T>` template + projection resolution
 - Emitter collection of projection models and resolved projection metadata output
 - TypeScript document type emission per projection (`*-search-doc.ts`)
+- OpenSearch mapping JSON emission per projection (`*-search-mapping.json`)
 - CI, linting, unit tests, emitter E2E test
 
 ## Usage
@@ -41,4 +42,4 @@ options:
     output-file: "opensearch-projections.json"
 ```
 
-Current outputs include projection metadata JSON and generated TypeScript document interfaces. OpenSearch mapping JSON emission is next.
+Current outputs include projection metadata JSON, generated TypeScript document interfaces, and OpenSearch mapping JSON files.

--- a/src/emit-mapping.test.ts
+++ b/src/emit-mapping.test.ts
@@ -67,6 +67,10 @@ describe("mapping emitter", () => {
 		assert.deepEqual(Object.keys(parsed.mappings.properties.owner.properties), [
 			"name",
 		]);
+		assert.equal(
+			parsed.mappings.properties.owner.properties.name.type,
+			"keyword",
+		);
 		assert.equal(parsed.mappings.properties.tags.type, "nested");
 		assert.deepEqual(Object.keys(parsed.mappings.properties.tags.properties), [
 			"name",

--- a/src/emit-mapping.test.ts
+++ b/src/emit-mapping.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { createTestHost, createTestWrapper } from "@typespec/compiler/testing";
+import { emitMapping } from "./emit-mapping.js";
+import { resolveProjectionModel } from "./projection.js";
+import { OpenSearchEmitterTestLibrary } from "./testing/index.js";
+
+async function createRunner() {
+	const host = await createTestHost({
+		libraries: [OpenSearchEmitterTestLibrary],
+	});
+
+	return createTestWrapper(host, {
+		autoImports: ["@kattebak/typespec-opensearch-emitter"],
+		autoUsings: ["Kattebak.OpenSearch"],
+	});
+}
+
+describe("mapping emitter", () => {
+	it("emits OpenSearch mapping for projection", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Owner {
+        @searchable @keyword name: string;
+        email: string;
+      }
+
+      model Tag {
+        @searchable name: string;
+      }
+
+      model Product {
+        @searchable id: string;
+        @searchable @keyword title: string;
+        @searchable price: float64;
+        @searchable releasedAt: plainDate;
+        @searchable owner: Owner;
+        @searchable @nested tags: Tag[];
+      }
+
+      model ProductSearchDoc is SearchProjection<Product> {
+        @analyzer("edge_ngram") @boost(2)
+        id: string;
+      }
+    `);
+		assert.equal(diagnostics.length, 0);
+
+		const projection = runner.program
+			.getGlobalNamespaceType()
+			.models.get("ProductSearchDoc");
+		assert.ok(projection);
+
+		const resolved = resolveProjectionModel(runner.program, projection);
+		assert.ok(resolved);
+		const emitted = emitMapping(runner.program, resolved);
+		assert.equal(emitted.fileName, "product-search-doc-search-mapping.json");
+
+		const parsed = JSON.parse(emitted.content);
+		assert.equal(parsed.mappings.properties.title.type, "keyword");
+		assert.equal(parsed.mappings.properties.id.type, "text");
+		assert.equal(parsed.mappings.properties.id.analyzer, "edge_ngram");
+		assert.equal(parsed.mappings.properties.id.boost, 2);
+		assert.equal(parsed.mappings.properties.price.type, "double");
+		assert.equal(parsed.mappings.properties.releasedAt.type, "date");
+		assert.equal(parsed.mappings.properties.owner.type, "object");
+		assert.deepEqual(Object.keys(parsed.mappings.properties.owner.properties), [
+			"name",
+		]);
+		assert.equal(parsed.mappings.properties.tags.type, "nested");
+		assert.deepEqual(Object.keys(parsed.mappings.properties.tags.properties), [
+			"name",
+		]);
+	});
+});

--- a/src/emit-mapping.ts
+++ b/src/emit-mapping.ts
@@ -1,0 +1,192 @@
+import type { Model, Program, Scalar, Type, Union } from "@typespec/compiler";
+import { isSearchable } from "./decorators.js";
+import type { ResolvedProjection } from "./projection.js";
+
+export interface EmittedMappingFile {
+	fileName: string;
+	content: string;
+}
+
+type MappingProperty = Record<string, unknown>;
+
+export function emitMapping(
+	program: Program,
+	projection: ResolvedProjection,
+): EmittedMappingFile {
+	const fileName = `${toKebabCase(projection.projectionModel.name)}-search-mapping.json`;
+	const properties = Object.fromEntries(
+		projection.fields.map((field) => [
+			field.name,
+			toMapping(program, field.type, {
+				keyword: field.keyword,
+				nested: field.nested,
+				analyzer: field.analyzer,
+				boost: field.boost,
+			}),
+		]),
+	);
+
+	return {
+		fileName,
+		content: `${JSON.stringify({ mappings: { properties } }, null, 2)}\n`,
+	};
+}
+
+function toMapping(
+	program: Program,
+	type: Type,
+	override?: {
+		keyword?: boolean;
+		nested?: boolean;
+		analyzer?: string;
+		boost?: number;
+	},
+): MappingProperty {
+	switch (type.kind) {
+		case "Scalar":
+			return mapScalar(type, override);
+		case "Model":
+			return mapModel(program, type, override);
+		case "String":
+			return mapString(override);
+		case "Number":
+			return { type: "double" };
+		case "Boolean":
+			return { type: "boolean" };
+		case "Union":
+			return mapUnion(program, type, override);
+		default:
+			return { type: "object" };
+	}
+}
+
+function mapString(override?: {
+	keyword?: boolean;
+	analyzer?: string;
+	boost?: number;
+}): MappingProperty {
+	if (override?.keyword) {
+		return { type: "keyword" };
+	}
+
+	const mapping: MappingProperty = {
+		type: "text",
+		fields: {
+			keyword: {
+				type: "keyword",
+				ignore_above: 256,
+			},
+		},
+	};
+
+	if (override?.analyzer) {
+		mapping.analyzer = override.analyzer;
+	}
+	if (override?.boost !== undefined) {
+		mapping.boost = override.boost;
+	}
+
+	return mapping;
+}
+
+function mapScalar(
+	scalar: Scalar,
+	override?: { keyword?: boolean; analyzer?: string; boost?: number },
+): MappingProperty {
+	let base = scalar;
+	while (base.baseScalar) {
+		base = base.baseScalar;
+	}
+
+	switch (base.name) {
+		case "string":
+			return mapString(override);
+		case "int32":
+		case "int64":
+		case "integer":
+		case "safeint":
+		case "uint8":
+		case "uint16":
+		case "uint32":
+		case "uint64":
+		case "int8":
+		case "int16":
+			return { type: "long" };
+		case "float":
+		case "float32":
+		case "float64":
+		case "decimal":
+		case "numeric":
+		case "number":
+			return { type: "double" };
+		case "boolean":
+			return { type: "boolean" };
+		case "utcDateTime":
+		case "plainDate":
+			return { type: "date" };
+		default:
+			return { type: "object" };
+	}
+}
+
+function mapModel(
+	program: Program,
+	model: Model,
+	override?: { nested?: boolean },
+): MappingProperty {
+	if (model.name === "Array" && model.indexer?.value) {
+		const elementType = model.indexer.value;
+		if (elementType.kind === "Model") {
+			return {
+				type: override?.nested ? "nested" : "object",
+				properties: mapModelProperties(program, elementType),
+			};
+		}
+		return toMapping(program, elementType);
+	}
+
+	return {
+		type: "object",
+		properties: mapModelProperties(program, model),
+	};
+}
+
+function mapModelProperties(
+	program: Program,
+	model: Model,
+): Record<string, MappingProperty> {
+	return Object.fromEntries(
+		Array.from(model.properties.values())
+			.filter((prop) => isSearchable(program, prop))
+			.map((prop) => [prop.name, toMapping(program, prop.type)]),
+	);
+}
+
+function mapUnion(
+	program: Program,
+	union: Union,
+	override?: { keyword?: boolean; analyzer?: string; boost?: number },
+): MappingProperty {
+	for (const variant of union.variants.values()) {
+		if (variant.type.kind === "Scalar" || variant.type.kind === "String") {
+			return toMapping(program, variant.type, override);
+		}
+	}
+	return { type: "object" };
+}
+
+export function toKebabCase(name: string): string {
+	return name
+		.replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+		.replace(/[-\s]+/g, "-")
+		.toLowerCase();
+}
+
+export const __test = {
+	mapModel,
+	mapScalar,
+	mapString,
+	mapUnion,
+	toKebabCase,
+	toMapping,
+};

--- a/src/emit-mapping.ts
+++ b/src/emit-mapping.ts
@@ -1,5 +1,11 @@
 import type { Model, Program, Scalar, Type, Union } from "@typespec/compiler";
-import { isSearchable } from "./decorators.js";
+import {
+	getAnalyzer,
+	getBoost,
+	isKeyword,
+	isNested,
+	isSearchable,
+} from "./decorators.js";
 import type { ResolvedProjection } from "./projection.js";
 
 export interface EmittedMappingFile {
@@ -158,7 +164,15 @@ function mapModelProperties(
 	return Object.fromEntries(
 		Array.from(model.properties.values())
 			.filter((prop) => isSearchable(program, prop))
-			.map((prop) => [prop.name, toMapping(program, prop.type)]),
+			.map((prop) => [
+				prop.name,
+				toMapping(program, prop.type, {
+					keyword: isKeyword(program, prop),
+					nested: isNested(program, prop),
+					analyzer: getAnalyzer(program, prop),
+					boost: getBoost(program, prop),
+				}),
+			]),
 	);
 }
 

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -6,6 +6,7 @@ import type {
 } from "@typespec/compiler";
 import { emitFile, resolvePath } from "@typespec/compiler";
 import { emitDocType } from "./emit-doc-type.js";
+import { emitMapping } from "./emit-mapping.js";
 import type { OpenSearchEmitterOptions } from "./lib.js";
 import {
 	isSearchProjectionModel,
@@ -36,6 +37,12 @@ export async function $onEmit(
 		await emitFile(context.program, {
 			path: resolvePath(context.emitterOutputDir, docTypeFile.fileName),
 			content: docTypeFile.content,
+		});
+
+		const mappingFile = emitMapping(context.program, projection);
+		await emitFile(context.program, {
+			path: resolvePath(context.emitterOutputDir, mappingFile.fileName),
+			content: mappingFile.content,
 		});
 	}
 

--- a/test/example.js
+++ b/test/example.js
@@ -51,6 +51,18 @@ test("emits TypeScript document type", async () => {
 	assert.equal(content.includes("internalNotes"), false);
 });
 
+test("emits OpenSearch mapping JSON", async () => {
+	const content = await readFile(
+		"build/opensearch/product-search-doc-search-mapping.json",
+		"utf8",
+	);
+	const parsed = JSON.parse(content);
+
+	assert.equal(parsed.mappings.properties.id.type, "text");
+	assert.equal(parsed.mappings.properties.title.type, "keyword");
+	assert.equal(parsed.mappings.properties.title.fields, undefined);
+});
+
 test("generated doc type compiles under tsc --noEmit", async () => {
 	await writeFile(
 		"build/opensearch/tsconfig.json",


### PR DESCRIPTION
## Summary

Implements OpenSearch mapping JSON emission for each resolved `SearchProjection<T>`.

## Changes

- Added `src/emit-mapping.ts`
  - emits `<kebab-case-projection-name>-search-mapping.json`
  - mapping envelope: `{ mappings: { properties: ... } }`
  - applies decorator overrides at top-level and nested model properties
- Updated `src/emitter.ts`
  - emits mapping JSON file per resolved projection
- Added tests
  - `src/emit-mapping.test.ts` covers representative rules and nested decorator behavior
  - `test/example.js` E2E asserts mapping file output
- Updated README status/output notes

## Validation

- `npm test` passes

## Issues

- Closes #13
