### PR TITLE
feat: emit index barrel with per-projection index constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Implemented so far:
 - Emitter collection of projection models and resolved projection metadata output
 - TypeScript document type emission per projection (`*-search-doc.ts`)
 - OpenSearch mapping JSON emission per projection (`*-search-mapping.json`)
+- Generated index barrel (`index.ts`) with doc type exports and index-name constants
 - CI, linting, unit tests, emitter E2E test
 
 ## Usage
@@ -42,4 +43,4 @@ options:
     output-file: "opensearch-projections.json"
 ```
 
-Current outputs include projection metadata JSON, generated TypeScript document interfaces, and OpenSearch mapping JSON files.
+Current outputs include projection metadata JSON, generated TypeScript document interfaces, OpenSearch mapping JSON files, and `index.ts` re-exports/constants.

--- a/src/emit-index.test.ts
+++ b/src/emit-index.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { emitIndex, toIndexConstantName } from "./emit-index.js";
+import type { ResolvedProjection } from "./projection.js";
+
+describe("index emitter", () => {
+	it("emits index.ts with type exports and index constants", () => {
+		const projections = [
+			{
+				projectionModel: { name: "ProductSearchDoc" },
+				sourceModel: { name: "Product" },
+				indexName: "products_v1",
+				fields: [],
+			},
+			{
+				projectionModel: { name: "AccountSearchDoc" },
+				sourceModel: { name: "Account" },
+				indexName: "accounts_v1",
+				fields: [],
+			},
+		] as unknown as ResolvedProjection[];
+
+		const emitted = emitIndex(projections);
+		assert.equal(emitted.fileName, "index.ts");
+		assert.equal(
+			emitted.content.includes(
+				'export type { AccountSearchDoc } from "./account-search-doc-search-doc.js";',
+			),
+			true,
+		);
+		assert.equal(
+			emitted.content.includes(
+				'export const ACCOUNT_INDEX_NAME = "accounts_v1";',
+			),
+			true,
+		);
+		assert.equal(
+			emitted.content.includes(
+				'export type { ProductSearchDoc } from "./product-search-doc-search-doc.js";',
+			),
+			true,
+		);
+		assert.equal(
+			emitted.content.includes(
+				'export const PRODUCT_INDEX_NAME = "products_v1";',
+			),
+			true,
+		);
+	});
+
+	it("derives constant names from source model names", () => {
+		assert.equal(
+			toIndexConstantName("Counterparty"),
+			"COUNTERPARTY_INDEX_NAME",
+		);
+		assert.equal(toIndexConstantName("PetStore"), "PET_STORE_INDEX_NAME");
+	});
+});

--- a/src/emit-index.test.ts
+++ b/src/emit-index.test.ts
@@ -25,35 +25,69 @@ describe("index emitter", () => {
 		assert.equal(emitted.fileName, "index.ts");
 		assert.equal(
 			emitted.content.includes(
-				'export type { AccountSearchDoc } from "./account-search-doc-search-doc.js";',
+				'export type { AccountSearchDoc } from "./account-search-doc.js";',
 			),
 			true,
 		);
 		assert.equal(
 			emitted.content.includes(
-				'export const ACCOUNT_INDEX_NAME = "accounts_v1";',
+				'export const ACCOUNT_SEARCH_DOC_INDEX_NAME = "accounts_v1";',
 			),
 			true,
 		);
 		assert.equal(
 			emitted.content.includes(
-				'export type { ProductSearchDoc } from "./product-search-doc-search-doc.js";',
+				'export type { ProductSearchDoc } from "./product-search-doc.js";',
 			),
 			true,
 		);
 		assert.equal(
 			emitted.content.includes(
-				'export const PRODUCT_INDEX_NAME = "products_v1";',
+				'export const PRODUCT_SEARCH_DOC_INDEX_NAME = "products_v1";',
 			),
 			true,
 		);
 	});
 
-	it("derives constant names from source model names", () => {
+	it("derives constant names from projection model names", () => {
 		assert.equal(
-			toIndexConstantName("Counterparty"),
-			"COUNTERPARTY_INDEX_NAME",
+			toIndexConstantName("CounterpartySearchDoc"),
+			"COUNTERPARTY_SEARCH_DOC_INDEX_NAME",
 		);
-		assert.equal(toIndexConstantName("PetStore"), "PET_STORE_INDEX_NAME");
+		assert.equal(
+			toIndexConstantName("PetStoreSearchDoc"),
+			"PET_STORE_SEARCH_DOC_INDEX_NAME",
+		);
+	});
+
+	it("avoids collisions for multiple projections of same source model", () => {
+		const projections = [
+			{
+				projectionModel: { name: "AccountSearchDoc" },
+				sourceModel: { name: "Account" },
+				indexName: "accounts_v1",
+				fields: [],
+			},
+			{
+				projectionModel: { name: "AccountSummarySearchDoc" },
+				sourceModel: { name: "Account" },
+				indexName: "accounts_summary_v1",
+				fields: [],
+			},
+		] as unknown as ResolvedProjection[];
+
+		const emitted = emitIndex(projections);
+		assert.equal(
+			emitted.content.includes(
+				'export const ACCOUNT_SEARCH_DOC_INDEX_NAME = "accounts_v1";',
+			),
+			true,
+		);
+		assert.equal(
+			emitted.content.includes(
+				'export const ACCOUNT_SUMMARY_SEARCH_DOC_INDEX_NAME = "accounts_summary_v1";',
+			),
+			true,
+		);
 	});
 });

--- a/src/emit-index.ts
+++ b/src/emit-index.ts
@@ -1,4 +1,4 @@
-import { toKebabCase } from "./emit-doc-type.js";
+import { toDocTypeFileName } from "./emit-doc-type.js";
 import type { ResolvedProjection } from "./projection.js";
 
 export interface EmittedIndexFile {
@@ -13,12 +13,14 @@ export function emitIndex(projections: ResolvedProjection[]): EmittedIndexFile {
 
 	const lines: string[] = [];
 	for (const projection of sorted) {
-		const docTypeFile = `${toKebabCase(projection.projectionModel.name)}-search-doc.js`;
+		const docTypeFile = toDocTypeFileName(
+			projection.projectionModel.name,
+		).replace(/\.ts$/, ".js");
 		lines.push(
 			`export type { ${projection.projectionModel.name} } from "./${docTypeFile}";`,
 		);
 		lines.push(
-			`export const ${toIndexConstantName(projection.sourceModel.name)} = "${projection.indexName}";`,
+			`export const ${toIndexConstantName(projection.projectionModel.name)} = "${projection.indexName}";`,
 		);
 	}
 
@@ -28,8 +30,8 @@ export function emitIndex(projections: ResolvedProjection[]): EmittedIndexFile {
 	};
 }
 
-export function toIndexConstantName(sourceModelName: string): string {
-	return `${toSnakeUpper(sourceModelName)}_INDEX_NAME`;
+export function toIndexConstantName(projectionModelName: string): string {
+	return `${toSnakeUpper(projectionModelName)}_INDEX_NAME`;
 }
 
 function toSnakeUpper(value: string): string {

--- a/src/emit-index.ts
+++ b/src/emit-index.ts
@@ -1,0 +1,44 @@
+import { toKebabCase } from "./emit-doc-type.js";
+import type { ResolvedProjection } from "./projection.js";
+
+export interface EmittedIndexFile {
+	fileName: string;
+	content: string;
+}
+
+export function emitIndex(projections: ResolvedProjection[]): EmittedIndexFile {
+	const sorted = [...projections].sort((a, b) =>
+		a.projectionModel.name.localeCompare(b.projectionModel.name),
+	);
+
+	const lines: string[] = [];
+	for (const projection of sorted) {
+		const docTypeFile = `${toKebabCase(projection.projectionModel.name)}-search-doc.js`;
+		lines.push(
+			`export type { ${projection.projectionModel.name} } from "./${docTypeFile}";`,
+		);
+		lines.push(
+			`export const ${toIndexConstantName(projection.sourceModel.name)} = "${projection.indexName}";`,
+		);
+	}
+
+	return {
+		fileName: "index.ts",
+		content: `${lines.join("\n")}\n`,
+	};
+}
+
+export function toIndexConstantName(sourceModelName: string): string {
+	return `${toSnakeUpper(sourceModelName)}_INDEX_NAME`;
+}
+
+function toSnakeUpper(value: string): string {
+	return value
+		.replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+		.replace(/[-\s]+/g, "_")
+		.toUpperCase();
+}
+
+export const __test = {
+	toIndexConstantName,
+};

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -6,6 +6,7 @@ import type {
 } from "@typespec/compiler";
 import { emitFile, resolvePath } from "@typespec/compiler";
 import { emitDocType } from "./emit-doc-type.js";
+import { emitIndex } from "./emit-index.js";
 import { emitMapping } from "./emit-mapping.js";
 import type { OpenSearchEmitterOptions } from "./lib.js";
 import {
@@ -45,6 +46,12 @@ export async function $onEmit(
 			content: mappingFile.content,
 		});
 	}
+
+	const indexFile = emitIndex(resolved);
+	await emitFile(context.program, {
+		path: resolvePath(context.emitterOutputDir, indexFile.fileName),
+		content: indexFile.content,
+	});
 
 	await emitFile(context.program, {
 		path: resolvePath(context.emitterOutputDir, outputFile),

--- a/test/example.js
+++ b/test/example.js
@@ -73,7 +73,9 @@ test("emits index.ts barrel", async () => {
 		true,
 	);
 	assert.equal(
-		content.includes('export const PRODUCT_SEARCH_DOC_INDEX_NAME = "products_v1";'),
+		content.includes(
+			'export const PRODUCT_SEARCH_DOC_INDEX_NAME = "products_v1";',
+		),
 		true,
 	);
 });

--- a/test/example.js
+++ b/test/example.js
@@ -63,6 +63,21 @@ test("emits OpenSearch mapping JSON", async () => {
 	assert.equal(parsed.mappings.properties.title.fields, undefined);
 });
 
+test("emits index.ts barrel", async () => {
+	const content = await readFile("build/opensearch/index.ts", "utf8");
+
+	assert.equal(
+		content.includes(
+			'export type { ProductSearchDoc } from "./product-search-doc.js";',
+		),
+		true,
+	);
+	assert.equal(
+		content.includes('export const PRODUCT_SEARCH_DOC_INDEX_NAME = "products_v1";'),
+		true,
+	);
+});
+
 test("generated doc type compiles under tsc --noEmit", async () => {
 	await writeFile(
 		"build/opensearch/tsconfig.json",


### PR DESCRIPTION
## Summary

Implements index-module generation as the canonical import surface.

## Changes

- Added `src/emit-index.ts`
  - emits `index.ts`
  - per projection:
    - `export type { <ProjectionDoc> } from "./<doc-file>.js"`
    - `export const <PROJECTION_MODEL>_INDEX_NAME = "<resolved-index-name>"`
- Updated `src/emitter.ts`
  - emits `index.ts` after doc and mapping files
- Added tests
  - `src/emit-index.test.ts`
  - E2E assertion in `test/example.js`
  - collision test for multiple projections on same source model
- Updated README status/output section

## Validation

- `npm test` passes

## Issues

- Closes #14
