### PR TITLE
docs: complete README reference for emitter usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,50 @@
 # TypeSpec OpenSearch Emitter
 
-A TypeSpec emitter for generating OpenSearch projection metadata.
+TypeSpec emitter for generating OpenSearch projection artifacts from decorated models.
 
-## Status
+## Install
 
-Implemented so far:
-
-- Decorator infrastructure via TypeSpec library state
-- Decorators: `@searchable`, `@keyword`, `@nested`, `@analyzer`, `@boost`, `@indexName`
-- Decorator validation diagnostics
-- `SearchProjection<T>` template + projection resolution
-- Emitter collection of projection models and resolved projection metadata output
-- TypeScript document type emission per projection (`*-search-doc.ts`)
-- OpenSearch mapping JSON emission per projection (`*-search-mapping.json`)
-- Generated index barrel (`index.ts`) with doc type exports and index-name constants
-- CI, linting, unit tests, emitter E2E test
+```bash
+npm install --save-dev @kattebak/typespec-opensearch-emitter @typespec/compiler
+```
 
 ## Usage
+
+### TypeSpec example
 
 ```typespec
 import "@kattebak/typespec-opensearch-emitter";
 
 using Kattebak.OpenSearch;
 
-model Product {
-  @searchable id: string;
-  @searchable @keyword title: string;
+model Owner {
+  @searchable @keyword name: string;
+  email: string;
+  phone: string;
+}
+
+model Tag {
+  @searchable @keyword name: string;
+}
+
+model Pet {
+  @key id: string;
+  @searchable name: string;
+  @searchable @keyword species: string;
+  @searchable breed?: string;
+  @searchable birthDate: plainDate;
+  @searchable @nested tags: Tag[];
+  @searchable owner: Owner;
   internalNotes: string;
 }
 
-@indexName("products_v1")
-model ProductSearchDoc is SearchProjection<Product> {
-  @analyzer("edge_ngram") title: string;
+@indexName("pets_v1")
+model PetSearchDoc is SearchProjection<Pet> {
+  @analyzer("edge_ngram") @boost(2.0) name: string;
 }
 ```
+
+### `tspconfig.yaml`
 
 ```yaml
 emit:
@@ -41,6 +52,92 @@ emit:
 options:
   "@kattebak/typespec-opensearch-emitter":
     output-file: "opensearch-projections.json"
+    emitter-output-dir: "{cwd}/build/opensearch"
 ```
 
-Current outputs include projection metadata JSON, generated TypeScript document interfaces, OpenSearch mapping JSON files, and `index.ts` re-exports/constants.
+### Compile
+
+```bash
+npx tsp compile test/main.tsp --config test/tspconfig.yaml
+```
+
+## Decorator reference
+
+| Decorator | Target | Effect | Example |
+| --- | --- | --- | --- |
+| `@searchable` | `ModelProperty` | Includes a property in projection resolution. | `@searchable name: string;` |
+| `@keyword` | `ModelProperty` (string) | Maps a string field as OpenSearch `keyword`. | `@searchable @keyword species: string;` |
+| `@nested` | `ModelProperty` (`Model[]`) | Maps an array-of-model field as OpenSearch `nested`. | `@searchable @nested tags: Tag[];` |
+| `@analyzer("name")` | `ModelProperty` (string) | Sets text analyzer in mapping output. | `@analyzer("edge_ngram") name: string;` |
+| `@boost(2.0)` | `ModelProperty` | Sets field boost in mapping output. | `@boost(2.0) name: string;` |
+| `@indexName("name")` | `Model` (projection) | Overrides derived index name for projection output. | `@indexName("pets_v1") model PetSearchDoc ...` |
+
+## Emitter options
+
+Defined in `src/lib.ts`:
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `output-file` | `string` | `opensearch-projections.json` | File name for projection metadata JSON output. |
+
+## Output structure
+
+Current output files per projection:
+
+```text
+build/opensearch/
+  index.ts
+  opensearch-projections.json
+  <projection>-search-doc.ts
+  <projection>-search-mapping.json
+```
+
+Real output example from `test/main.tsp`:
+
+### `build/opensearch/product-search-doc.ts`
+
+```ts
+export interface ProductSearchDoc 
+{
+	id: string;
+	title: string;
+}
+```
+
+### `build/opensearch/product-search-doc-search-mapping.json`
+
+```json
+{
+  "mappings": {
+    "properties": {
+      "id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "title": {
+        "type": "keyword"
+      }
+    }
+  }
+}
+```
+
+### `build/opensearch/index.ts`
+
+```ts
+export type { ProductSearchDoc } from "./product-search-doc.js";
+export const PRODUCT_SEARCH_DOC_INDEX_NAME = "products_v1";
+```
+
+## Contributing
+
+```bash
+npm run fix
+npm run lint
+npm test
+```


### PR DESCRIPTION
## Summary

Completes README documentation for install, usage, decorators, options, and output structure.

## Changes

- Added install instructions
- Added full usage section with TypeSpec and `tspconfig.yaml`
- Added decorator reference table for:
  - `@searchable`
  - `@keyword`
  - `@nested`
  - `@analyzer`
  - `@boost`
  - `@indexName`
- Added emitter options reference from `src/lib.ts`
- Added output structure section with real emitted samples from `build/opensearch`
- Added contributing commands

## Validation

- `npm test` passes

## Issues

- Closes #16
