### PR TITLE
test: expand e2e fixture and runtime assertions

### DIFF
--- a/src/emit-mapping.ts
+++ b/src/emit-mapping.ts
@@ -99,40 +99,39 @@ function mapScalar(
 	scalar: Scalar,
 	override?: { keyword?: boolean; analyzer?: string; boost?: number },
 ): MappingProperty {
-	let base = scalar;
-	while (base.baseScalar) {
-		base = base.baseScalar;
+	let current: Scalar | undefined = scalar;
+	while (current) {
+		switch (current.name) {
+			case "string":
+				return mapString(override);
+			case "int32":
+			case "int64":
+			case "integer":
+			case "safeint":
+			case "uint8":
+			case "uint16":
+			case "uint32":
+			case "uint64":
+			case "int8":
+			case "int16":
+				return { type: "long" };
+			case "float":
+			case "float32":
+			case "float64":
+			case "decimal":
+			case "numeric":
+			case "number":
+				return { type: "double" };
+			case "boolean":
+				return { type: "boolean" };
+			case "utcDateTime":
+			case "plainDate":
+				return { type: "date" };
+		}
+		current = current.baseScalar;
 	}
 
-	switch (base.name) {
-		case "string":
-			return mapString(override);
-		case "int32":
-		case "int64":
-		case "integer":
-		case "safeint":
-		case "uint8":
-		case "uint16":
-		case "uint32":
-		case "uint64":
-		case "int8":
-		case "int16":
-			return { type: "long" };
-		case "float":
-		case "float32":
-		case "float64":
-		case "decimal":
-		case "numeric":
-		case "number":
-			return { type: "double" };
-		case "boolean":
-			return { type: "boolean" };
-		case "utcDateTime":
-		case "plainDate":
-			return { type: "date" };
-		default:
-			return { type: "object" };
-	}
+	return { type: "object" };
 }
 
 function mapModel(

--- a/test/example.js
+++ b/test/example.js
@@ -2,95 +2,105 @@ import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
 import { readFile, writeFile } from "node:fs/promises";
 import test from "node:test";
+import { pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
+const OUT_DIR = "build/opensearch-emit";
 
-test("emits resolved search projections", async () => {
+test("emits projection metadata for multiple projections", async () => {
 	const content = await readFile(
-		"build/opensearch/opensearch-projections.json",
+		`${OUT_DIR}/opensearch-projections.json`,
 		"utf8",
 	);
 	const parsed = JSON.parse(content);
 
-	assert.deepEqual(parsed, {
-		projections: [
-			{
-				name: "ProductSearchDoc",
-				sourceModel: "Product",
-				indexName: "products_v1",
-				fields: [
-					{
-						name: "id",
-						optional: false,
-						keyword: false,
-						nested: false,
-					},
-					{
-						name: "title",
-						optional: false,
-						keyword: true,
-						nested: false,
-						analyzer: "edge_ngram",
-					},
-				],
-			},
-		],
-	});
+	assert.equal(parsed.projections.length, 2);
+	assert.deepEqual(parsed.projections.map((x) => x.name).sort(), [
+		"PetPublicSearchDoc",
+		"PetSearchDoc",
+	]);
+
+	const petSearch = parsed.projections.find((x) => x.name === "PetSearchDoc");
+	assert.ok(petSearch);
+	assert.equal(petSearch.indexName, "pets_v1");
+	const nameField = petSearch.fields.find((x) => x.name === "name");
+	assert.ok(nameField);
+	assert.equal(nameField.analyzer, "edge_ngram");
+	assert.equal(nameField.boost, 2);
 });
 
-test("emits TypeScript document type", async () => {
-	const content = await readFile(
-		"build/opensearch/product-search-doc.ts",
+test("emits mapping files with expected field mappings", async () => {
+	const searchContent = await readFile(
+		`${OUT_DIR}/pet-search-doc-search-mapping.json`,
+		"utf8",
+	);
+	const publicContent = await readFile(
+		`${OUT_DIR}/pet-public-search-doc-search-mapping.json`,
+		"utf8",
+	);
+	const searchMapping = JSON.parse(searchContent).mappings.properties;
+	const publicMapping = JSON.parse(publicContent).mappings.properties;
+
+	assert.equal(searchMapping.name.type, "text");
+	assert.equal(searchMapping.name.analyzer, "edge_ngram");
+	assert.equal(searchMapping.name.boost, 2);
+	assert.equal(searchMapping.name.fields.keyword.type, "keyword");
+
+	assert.equal(searchMapping.species.type, "keyword");
+	assert.equal(searchMapping.birthDate.type, "date");
+	assert.equal(searchMapping.createdAt.type, "date");
+	assert.equal(searchMapping.rank.type, "long");
+	assert.equal(searchMapping.stock.type, "long");
+	assert.equal(searchMapping.score.type, "double");
+	assert.equal(searchMapping.active.type, "boolean");
+	assert.equal(searchMapping.tags.type, "nested");
+	assert.equal(searchMapping.tags.properties.name.type, "keyword");
+	assert.equal(searchMapping.owner.type, "object");
+	assert.equal(searchMapping.owner.properties.name.type, "keyword");
+	assert.equal(searchMapping.aliases.type, "text");
+
+	assert.equal(publicMapping.name.type, "keyword");
+	assert.equal(publicMapping.name.fields, undefined);
+});
+
+test("emits doc types and index constants", async () => {
+	const indexTs = await readFile(`${OUT_DIR}/index.ts`, "utf8");
+	const petSearchDoc = await readFile(`${OUT_DIR}/pet-search-doc.ts`, "utf8");
+	const petPublicSearchDoc = await readFile(
+		`${OUT_DIR}/pet-public-search-doc.ts`,
 		"utf8",
 	);
 
-	assert.equal(content.includes("export interface ProductSearchDoc"), true);
-	assert.equal(content.includes("\tid: string;"), true);
-	assert.equal(content.includes("\ttitle: string;"), true);
-	assert.equal(content.includes("internalNotes"), false);
-});
-
-test("emits OpenSearch mapping JSON", async () => {
-	const content = await readFile(
-		"build/opensearch/product-search-doc-search-mapping.json",
-		"utf8",
-	);
-	const parsed = JSON.parse(content);
-
-	assert.equal(parsed.mappings.properties.id.type, "text");
-	assert.equal(parsed.mappings.properties.title.type, "keyword");
-	assert.equal(parsed.mappings.properties.title.fields, undefined);
-});
-
-test("emits index.ts barrel", async () => {
-	const content = await readFile("build/opensearch/index.ts", "utf8");
-
 	assert.equal(
-		content.includes(
-			'export type { ProductSearchDoc } from "./product-search-doc.js";',
-		),
+		indexTs.includes('export const PET_SEARCH_DOC_INDEX_NAME = "pets_v1";'),
 		true,
 	);
 	assert.equal(
-		content.includes(
-			'export const PRODUCT_SEARCH_DOC_INDEX_NAME = "products_v1";',
+		indexTs.includes(
+			'export const PET_PUBLIC_SEARCH_DOC_INDEX_NAME = "pet_public_search_doc";',
 		),
+		true,
+	);
+	assert.equal(petSearchDoc.includes("breed?: string;"), true);
+	assert.equal(petSearchDoc.includes("internalNotes"), false);
+	assert.equal(
+		petPublicSearchDoc.includes("export interface PetPublicSearchDoc"),
 		true,
 	);
 });
 
-test("generated doc type compiles under tsc --noEmit", async () => {
+test("generated output compiles and exports constants", async () => {
 	await writeFile(
-		"build/opensearch/tsconfig.json",
+		`${OUT_DIR}/tsconfig.json`,
 		JSON.stringify(
 			{
 				compilerOptions: {
-					module: "ESNext",
-					moduleResolution: "bundler",
+					module: "NodeNext",
+					moduleResolution: "NodeNext",
 					target: "ES2020",
 					strict: true,
-					noEmit: true,
+					outDir: "./dist",
 				},
 				include: ["*.ts"],
 			},
@@ -99,10 +109,14 @@ test("generated doc type compiles under tsc --noEmit", async () => {
 		),
 	);
 
-	await execFileAsync("npx", [
-		"tsc",
-		"--noEmit",
-		"-p",
-		"build/opensearch/tsconfig.json",
-	]);
+	await execFileAsync("npx", ["tsc", "-p", `${OUT_DIR}/tsconfig.json`]);
+	const indexModule = await import(
+		pathToFileURL(`${OUT_DIR}/dist/index.js`).href
+	);
+
+	assert.equal(indexModule.PET_SEARCH_DOC_INDEX_NAME, "pets_v1");
+	assert.equal(
+		indexModule.PET_PUBLIC_SEARCH_DOC_INDEX_NAME,
+		"pet_public_search_doc",
+	);
 });

--- a/test/main.tsp
+++ b/test/main.tsp
@@ -2,13 +2,40 @@ import "@kattebak/typespec-opensearch-emitter";
 
 using Kattebak.OpenSearch;
 
-model Product {
+model Owner {
+	@searchable @keyword name: string;
+	email: string;
+	phone?: string;
+}
+
+model Tag {
+	@searchable @keyword name: string;
+}
+
+model Pet {
 	@searchable id: string;
-	@searchable @keyword title: string;
+	@searchable name: string;
+	@searchable @keyword species: string;
+	@searchable breed?: string;
+	@searchable birthDate: plainDate;
+	@searchable createdAt: utcDateTime;
+	@searchable @nested tags: Tag[];
+	@searchable owner: Owner;
+	@searchable aliases: string[];
+	@searchable rank: int32;
+	@searchable stock: int64;
+	@searchable score: float64;
+	@searchable active: boolean;
 	internalNotes: string;
 }
 
-@indexName("products_v1")
-model ProductSearchDoc is SearchProjection<Product> {
-	@analyzer("edge_ngram") title: string;
+@indexName("pets_v1")
+model PetSearchDoc is SearchProjection<Pet> {
+	@analyzer("edge_ngram") @boost(2.0)
+	name: string;
+}
+
+model PetPublicSearchDoc is SearchProjection<Pet> {
+	@keyword
+	name: string;
 }

--- a/test/tspconfig.yaml
+++ b/test/tspconfig.yaml
@@ -3,4 +3,4 @@ emit:
 options:
   "@kattebak/typespec-opensearch-emitter":
     output-file: "opensearch-projections.json"
-    emitter-output-dir: "{cwd}/build/opensearch"
+    emitter-output-dir: "{cwd}/build/opensearch-emit"


### PR DESCRIPTION
## Summary

Implements comprehensive end-to-end fixture coverage for emitted OpenSearch artifacts.

## Changes

- `test/main.tsp`
  - multiple projection models for the same source (`PetSearchDoc`, `PetPublicSearchDoc`)
  - all decorators exercised (`@searchable`, `@keyword`, `@nested`, `@analyzer`, `@boost`, `@indexName`)
  - nested models, arrays (with and without `@nested`), optional fields
  - numeric/date/bool/string scalar coverage
  - projection override layer on same-named property
- `test/tspconfig.yaml`
  - output dir moved to `{cwd}/build/opensearch-emit`
- `test/example.js`
  - runtime assertions for projection metadata JSON
  - field-by-field mapping JSON assertions
  - index constant assertions in emitted `index.ts`
  - compiles emitted output with `tsc`, imports built `index.js`, asserts runtime constants
- `src/emit-mapping.ts`
  - scalar mapping adjusted to resolve based on full scalar inheritance chain so int-family fields keep `long` mapping

## Validation

- `npm test` passes end-to-end

## Issues

- Closes #15
