### PR TITLE
docs: rewrite README with accurate examples and concept docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,34 @@
 # TypeSpec OpenSearch Emitter
 
-TypeSpec emitter for generating OpenSearch projection artifacts from decorated models.
+TypeSpec emitter that generates OpenSearch artifacts from decorated models:
+
+- **TypeScript interfaces** for search document types
+- **OpenSearch mapping JSON** for index creation
+- **Barrel `index.ts`** with type exports and index name constants
+- **Projection metadata JSON** for tooling integration
 
 ## Install
 
 ```bash
 npm install --save-dev @kattebak/typespec-opensearch-emitter @typespec/compiler
 ```
+
+## Concepts
+
+### `@searchable` and `SearchProjection<T>`
+
+The core workflow:
+
+1. **Annotate source models** — mark fields with `@searchable` to indicate they should be included in search projections.
+2. **Create a projection model** — use `model XxxSearchDoc is SearchProjection<SourceModel> {}` to create a search document type. Only `@searchable` fields from the source model are included.
+3. **Override decorators in the projection** — redeclare fields in the projection model to add or override `@keyword`, `@analyzer`, `@boost`, or `@nested`.
+
+Fields **not** marked `@searchable` on the source model are excluded from all projections.
+
+### Index name derivation
+
+- Use `@indexName("my_index_v1")` on a projection model to set an explicit index name.
+- If omitted, the index name is derived from the model name by converting PascalCase to snake_case (e.g. `PetSearchDoc` → `pet_search_doc`).
 
 ## Usage
 
@@ -20,7 +42,7 @@ using Kattebak.OpenSearch;
 model Owner {
   @searchable @keyword name: string;
   email: string;
-  phone: string;
+  phone?: string;
 }
 
 model Tag {
@@ -28,7 +50,7 @@ model Tag {
 }
 
 model Pet {
-  @key id: string;
+  @searchable id: string;
   @searchable name: string;
   @searchable @keyword species: string;
   @searchable breed?: string;
@@ -44,6 +66,14 @@ model PetSearchDoc is SearchProjection<Pet> {
 }
 ```
 
+In this example:
+
+- `Pet.internalNotes` is **excluded** (not `@searchable`).
+- `Owner.email` and `Owner.phone` are **excluded** (not `@searchable`).
+- `PetSearchDoc` overrides `name` to add a text analyzer and boost.
+- `tags` inherits `@nested` from the source model.
+- The index name is explicitly set to `pets_v1`.
+
 ### `tspconfig.yaml`
 
 ```yaml
@@ -58,53 +88,41 @@ options:
 ### Compile
 
 ```bash
-npx tsp compile test/main.tsp --config test/tspconfig.yaml
+npx tsp compile . --config tspconfig.yaml
 ```
 
-## Decorator reference
+## Output
 
-| Decorator | Target | Effect | Example |
-| --- | --- | --- | --- |
-| `@searchable` | `ModelProperty` | Includes a property in projection resolution. | `@searchable name: string;` |
-| `@keyword` | `ModelProperty` (string) | Maps a string field as OpenSearch `keyword`. | `@searchable @keyword species: string;` |
-| `@nested` | `ModelProperty` (`Model[]`) | Maps an array-of-model field as OpenSearch `nested`. | `@searchable @nested tags: Tag[];` |
-| `@analyzer("name")` | `ModelProperty` (string) | Sets text analyzer in mapping output. | `@analyzer("edge_ngram") name: string;` |
-| `@boost(2.0)` | `ModelProperty` | Sets field boost in mapping output. | `@boost(2.0) name: string;` |
-| `@indexName("name")` | `Model` (projection) | Overrides derived index name for projection output. | `@indexName("pets_v1") model PetSearchDoc ...` |
-
-## Emitter options
-
-Defined in `src/lib.ts`:
-
-| Option | Type | Default | Description |
-| --- | --- | --- | --- |
-| `output-file` | `string` | `opensearch-projections.json` | File name for projection metadata JSON output. |
-
-## Output structure
-
-Current output files per projection:
+The emitter produces the following files per projection:
 
 ```text
 build/opensearch/
-  index.ts
-  opensearch-projections.json
-  <projection>-search-doc.ts
-  <projection>-search-mapping.json
+  index.ts                                  # barrel with type re-exports and index name constants
+  opensearch-projections.json               # machine-readable projection metadata
+  pet-search-doc.ts                         # TypeScript interface for PetSearchDoc
+  pet-search-doc-search-mapping.json        # OpenSearch mapping JSON
 ```
 
-Real output example from `test/main.tsp`:
-
-### `build/opensearch/product-search-doc.ts`
+### `pet-search-doc.ts`
 
 ```ts
-export interface ProductSearchDoc 
+export interface PetSearchDoc 
 {
 	id: string;
-	title: string;
+	name: string;
+	species: string;
+	breed?: string;
+	birthDate: string;
+	tags: {
+	name: string;
+}[];
+	owner: {
+	name: string;
+};
 }
 ```
 
-### `build/opensearch/product-search-doc-search-mapping.json`
+### `pet-search-doc-search-mapping.json`
 
 ```json
 {
@@ -113,31 +131,109 @@ export interface ProductSearchDoc
       "id": {
         "type": "text",
         "fields": {
-          "keyword": {
-            "type": "keyword",
-            "ignore_above": 256
-          }
+          "keyword": { "type": "keyword", "ignore_above": 256 }
         }
       },
-      "title": {
-        "type": "keyword"
+      "name": {
+        "type": "text",
+        "fields": {
+          "keyword": { "type": "keyword", "ignore_above": 256 }
+        },
+        "analyzer": "edge_ngram",
+        "boost": 2
+      },
+      "species": { "type": "keyword" },
+      "breed": {
+        "type": "text",
+        "fields": {
+          "keyword": { "type": "keyword", "ignore_above": 256 }
+        }
+      },
+      "birthDate": { "type": "date" },
+      "tags": {
+        "type": "nested",
+        "properties": {
+          "name": { "type": "keyword" }
+        }
+      },
+      "owner": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "keyword" }
+        }
       }
     }
   }
 }
 ```
 
-### `build/opensearch/index.ts`
+### `index.ts`
 
 ```ts
-export type { ProductSearchDoc } from "./product-search-doc.js";
-export const PRODUCT_SEARCH_DOC_INDEX_NAME = "products_v1";
+export type { PetSearchDoc } from "./pet-search-doc.js";
+export const PET_SEARCH_DOC_INDEX_NAME = "pets_v1";
 ```
+
+## Decorator reference
+
+| Decorator | Target | Effect | Example |
+| --- | --- | --- | --- |
+| `@searchable` | `ModelProperty` | Includes a property in projection resolution. | `@searchable name: string;` |
+| `@keyword` | `ModelProperty` (string) | Maps a string field as OpenSearch `keyword` instead of `text`. | `@searchable @keyword species: string;` |
+| `@nested` | `ModelProperty` (Model[]) | Maps an array-of-model field as OpenSearch `nested` instead of `object`. | `@searchable @nested tags: Tag[];` |
+| `@analyzer("name")` | `ModelProperty` (string) | Sets the text analyzer in mapping output. | `@analyzer("edge_ngram") name: string;` |
+| `@boost(n)` | `ModelProperty` | Sets field boost factor in mapping output. Must be > 0. | `@boost(2.0) name: string;` |
+| `@indexName("name")` | `Model` (projection) | Sets an explicit index name for the projection. | `@indexName("pets_v1") model PetSearchDoc ...` |
+
+## Type mapping
+
+### TypeScript types (`*-search-doc.ts`)
+
+| TypeSpec type | TypeScript type |
+| --- | --- |
+| `string`, `plainDate`, `utcDateTime` | `string` |
+| `int32`, `int64`, `float64`, etc. | `number` |
+| `boolean` | `boolean` |
+| `Model` (object) | inline `{ ... }` (searchable fields only) |
+| `T[]` | `T[]` |
+| `Record<string, T>` | `Record<string, T>` |
+
+### OpenSearch mappings (`*-search-mapping.json`)
+
+| TypeSpec type | OpenSearch mapping type |
+| --- | --- |
+| `string` | `text` (with `keyword` sub-field) |
+| `string` + `@keyword` | `keyword` |
+| `int32`, `int64`, etc. | `long` |
+| `float32`, `float64`, etc. | `double` |
+| `boolean` | `boolean` |
+| `plainDate`, `utcDateTime` | `date` |
+| `Model` | `object` (with nested properties) |
+| `Model[]` + `@nested` | `nested` (with nested properties) |
+
+## Emitter options
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `output-file` | `string` | `opensearch-projections.json` | Filename for the projection metadata JSON. |
+
+The `emitter-output-dir` option is a standard TypeSpec compiler option that controls the output directory.
 
 ## Contributing
 
 ```bash
-npm run fix
+npm install
+npm run build
 npm run lint
-npm test
+npm test          # runs build + lint + unit tests + emit test + example test
 ```
+
+### Test structure
+
+- `src/**/*.test.ts` — unit tests (decorators, projection resolution, emitters)
+- `test/main.tsp` — integration fixture compiled by `npm run test:emit`
+- `test/example.js` — validates emitted output files against expectations
+
+## License
+
+See [LICENSE](./LICENSE).


### PR DESCRIPTION
Rewrites README to match actual emitter behavior:
- Adds Concepts section explaining SearchProjection<T> and @searchable workflow
- Replaces fictional Product example with actual Pet fixture
- Adds type mapping tables (TypeSpec → TypeScript, TypeSpec → OpenSearch)
- Documents index name derivation (explicit and auto)
- Documents emitter-output-dir as compiler option
- Adds test structure section