### PR TITLE
Fix nested inline object indentation in doc type emitter

### DIFF
--- a/src/emit-doc-type.test.ts
+++ b/src/emit-doc-type.test.ts
@@ -2,9 +2,11 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import { createTestHost, createTestWrapper } from "@typespec/compiler/testing";
-import { emitDocType } from "./emit-doc-type.js";
+import { __test, emitDocType } from "./emit-doc-type.js";
 import { resolveProjectionModel } from "./projection.js";
 import { OpenSearchEmitterTestLibrary } from "./testing/index.js";
+
+const { toKebabCase, toDocTypeFileName } = __test;
 
 async function createRunner() {
 	const host = await createTestHost({
@@ -17,44 +19,344 @@ async function createRunner() {
 	});
 }
 
+async function emitFor(source: string, modelName: string) {
+	const runner = await createRunner();
+	const diagnostics = await runner.diagnose(source);
+	assert.equal(
+		diagnostics.length,
+		0,
+		`Unexpected diagnostics: ${JSON.stringify(diagnostics)}`,
+	);
+
+	const projection = runner.program
+		.getGlobalNamespaceType()
+		.models.get(modelName);
+	assert.ok(projection, `Model ${modelName} not found`);
+
+	const resolved = resolveProjectionModel(runner.program, projection);
+	assert.ok(resolved, `Could not resolve projection for ${modelName}`);
+
+	return emitDocType(runner.program, resolved);
+}
+
+describe("toKebabCase", () => {
+	it("converts PascalCase to kebab-case", () => {
+		assert.equal(toKebabCase("PetSearchDoc"), "pet-search-doc");
+	});
+
+	it("converts camelCase to kebab-case", () => {
+		assert.equal(toKebabCase("petSearchDoc"), "pet-search-doc");
+	});
+
+	it("handles single word", () => {
+		assert.equal(toKebabCase("Pet"), "pet");
+	});
+
+	it("handles already kebab-case", () => {
+		assert.equal(toKebabCase("pet-search-doc"), "pet-search-doc");
+	});
+});
+
+describe("toDocTypeFileName", () => {
+	it("strips -search-doc suffix and re-adds it with .ts", () => {
+		assert.equal(toDocTypeFileName("PetSearchDoc"), "pet-search-doc.ts");
+	});
+
+	it("adds -search-doc.ts if not already present", () => {
+		assert.equal(toDocTypeFileName("PetIndex"), "pet-index-search-doc.ts");
+	});
+});
+
 describe("doc type emitter", () => {
 	it("emits TypeScript interface for projection model", async () => {
-		const runner = await createRunner();
-		const diagnostics = await runner.diagnose(`
-      model Owner {
-        @searchable name: string;
-        email: string;
-      }
+		const emitted = await emitFor(
+			`
+			model Owner {
+				@searchable name: string;
+				email: string;
+			}
 
-      model Product {
-        @searchable id: string;
-        @searchable price: float64;
-        @searchable owner: Owner;
-        @searchable tags: string[];
-      }
+			model Product {
+				@searchable id: string;
+				@searchable price: float64;
+				@searchable owner: Owner;
+				@searchable tags: string[];
+			}
 
-      model ProductSearchDoc is SearchProjection<Product> {}
-    `);
-		assert.equal(diagnostics.length, 0);
-
-		const projection = runner.program
-			.getGlobalNamespaceType()
-			.models.get("ProductSearchDoc");
-		assert.ok(projection);
-
-		const resolved = resolveProjectionModel(runner.program, projection);
-		assert.ok(resolved);
-
-		const emitted = emitDocType(runner.program, resolved);
-		assert.equal(emitted.fileName, "product-search-doc.ts");
-		assert.equal(
-			emitted.content.includes("export interface ProductSearchDoc"),
-			true,
+			model ProductSearchDoc is SearchProjection<Product> {}
+			`,
+			"ProductSearchDoc",
 		);
-		assert.equal(emitted.content.includes("\tid: string;"), true);
-		assert.equal(emitted.content.includes("\tprice: number;"), true);
-		assert.equal(emitted.content.includes("\towner:"), true);
-		assert.equal(emitted.content.includes("\ttags: string[];"), true);
-		assert.equal(emitted.content.includes("email"), false);
+
+		assert.equal(emitted.fileName, "product-search-doc.ts");
+		assert.ok(emitted.content.includes("export interface ProductSearchDoc"));
+		assert.ok(emitted.content.includes("\tid: string;"));
+		assert.ok(emitted.content.includes("\tprice: number;"));
+		assert.ok(emitted.content.includes("\towner:"));
+		assert.ok(emitted.content.includes("\ttags: string[];"));
+		assert.ok(!emitted.content.includes("email"));
+	});
+
+	it("emits empty body for model with no fields", async () => {
+		const emitted = await emitFor(
+			`
+			model Empty {
+				internalOnly: string;
+			}
+
+			model EmptySearchDoc is SearchProjection<Empty> {}
+			`,
+			"EmptySearchDoc",
+		);
+
+		assert.ok(emitted.content.includes("export interface EmptySearchDoc {}"));
+	});
+
+	it("emits optional fields with question mark", async () => {
+		const emitted = await emitFor(
+			`
+			model Item {
+				@searchable name: string;
+				@searchable description?: string;
+			}
+
+			model ItemSearchDoc is SearchProjection<Item> {}
+			`,
+			"ItemSearchDoc",
+		);
+
+		assert.ok(emitted.content.includes("\tname: string;"));
+		assert.ok(emitted.content.includes("\tdescription?: string;"));
+	});
+
+	it("renders scalar types correctly", async () => {
+		const emitted = await emitFor(
+			`
+			model Widget {
+				@searchable name: string;
+				@searchable count: int32;
+				@searchable bigCount: int64;
+				@searchable score: float64;
+				@searchable active: boolean;
+				@searchable created: plainDate;
+				@searchable updated: utcDateTime;
+			}
+
+			model WidgetSearchDoc is SearchProjection<Widget> {}
+			`,
+			"WidgetSearchDoc",
+		);
+
+		assert.ok(emitted.content.includes("\tname: string;"));
+		assert.ok(emitted.content.includes("\tcount: number;"));
+		assert.ok(emitted.content.includes("\tbigCount: number;"));
+		assert.ok(emitted.content.includes("\tscore: number;"));
+		assert.ok(emitted.content.includes("\tactive: boolean;"));
+		assert.ok(emitted.content.includes("\tcreated: string;"));
+		assert.ok(emitted.content.includes("\tupdated: string;"));
+	});
+
+	it("renders nested inline object with correct indentation", async () => {
+		const emitted = await emitFor(
+			`
+			model Address {
+				@searchable city: string;
+				@searchable zip: string;
+				country: string;
+			}
+
+			model Person {
+				@searchable name: string;
+				@searchable address: Address;
+			}
+
+			model PersonSearchDoc is SearchProjection<Person> {}
+			`,
+			"PersonSearchDoc",
+		);
+
+		const expected = [
+			"export interface PersonSearchDoc {",
+			"\tname: string;",
+			"\taddress: {",
+			"\t\tcity: string;",
+			"\t\tzip: string;",
+			"\t};",
+			"}",
+		].join("\n");
+
+		assert.equal(emitted.content, `${expected}\n`);
+	});
+
+	it("renders deeply nested objects with correct indentation", async () => {
+		const emitted = await emitFor(
+			`
+			model Street {
+				@searchable name: string;
+			}
+
+			model Address {
+				@searchable street: Street;
+				@searchable city: string;
+			}
+
+			model Person {
+				@searchable name: string;
+				@searchable address: Address;
+			}
+
+			model PersonSearchDoc is SearchProjection<Person> {}
+			`,
+			"PersonSearchDoc",
+		);
+
+		const expected = [
+			"export interface PersonSearchDoc {",
+			"\tname: string;",
+			"\taddress: {",
+			"\t\tstreet: {",
+			"\t\t\tname: string;",
+			"\t\t};",
+			"\t\tcity: string;",
+			"\t};",
+			"}",
+		].join("\n");
+
+		assert.equal(emitted.content, `${expected}\n`);
+	});
+
+	it("renders array of inline objects with correct indentation", async () => {
+		const emitted = await emitFor(
+			`
+			model Tag {
+				@searchable label: string;
+			}
+
+			model Item {
+				@searchable tags: Tag[];
+			}
+
+			model ItemSearchDoc is SearchProjection<Item> {}
+			`,
+			"ItemSearchDoc",
+		);
+
+		const expected = [
+			"export interface ItemSearchDoc {",
+			"\ttags: {",
+			"\t\tlabel: string;",
+			"\t}[];",
+			"}",
+		].join("\n");
+
+		assert.equal(emitted.content, `${expected}\n`);
+	});
+
+	it("renders inline object with no searchable fields as empty object", async () => {
+		const emitted = await emitFor(
+			`
+			model Meta {
+				internal: string;
+			}
+
+			model Item {
+				@searchable name: string;
+				@searchable meta: Meta;
+			}
+
+			model ItemSearchDoc is SearchProjection<Item> {}
+			`,
+			"ItemSearchDoc",
+		);
+
+		assert.ok(emitted.content.includes("\tmeta: {};"));
+	});
+
+	it("renders string array", async () => {
+		const emitted = await emitFor(
+			`
+			model Item {
+				@searchable aliases: string[];
+			}
+
+			model ItemSearchDoc is SearchProjection<Item> {}
+			`,
+			"ItemSearchDoc",
+		);
+
+		assert.ok(emitted.content.includes("\taliases: string[];"));
+	});
+
+	it("excludes non-searchable fields", async () => {
+		const emitted = await emitFor(
+			`
+			model Item {
+				@searchable visible: string;
+				hidden: string;
+			}
+
+			model ItemSearchDoc is SearchProjection<Item> {}
+			`,
+			"ItemSearchDoc",
+		);
+
+		assert.ok(emitted.content.includes("\tvisible: string;"));
+		assert.ok(!emitted.content.includes("hidden"));
+	});
+
+	it("renders full interface matching snapshot for complex model", async () => {
+		const emitted = await emitFor(
+			`
+			model Tag {
+				@searchable @keyword name: string;
+			}
+
+			model Owner {
+				@searchable @keyword name: string;
+				email: string;
+			}
+
+			model Pet {
+				@searchable id: string;
+				@searchable name: string;
+				@searchable @keyword species: string;
+				@searchable breed?: string;
+				@searchable birthDate: plainDate;
+				@searchable @nested tags: Tag[];
+				@searchable owner: Owner;
+				@searchable aliases: string[];
+				@searchable rank: int32;
+				@searchable active: boolean;
+				internalNotes: string;
+			}
+
+			@indexName("pets_v1")
+			model PetSearchDoc is SearchProjection<Pet> {
+				@analyzer("edge_ngram") @boost(2.0) name: string;
+			}
+			`,
+			"PetSearchDoc",
+		);
+
+		const expected = [
+			"export interface PetSearchDoc {",
+			"\tid: string;",
+			"\tname: string;",
+			"\tspecies: string;",
+			"\tbreed?: string;",
+			"\tbirthDate: string;",
+			"\ttags: {",
+			"\t\tname: string;",
+			"\t}[];",
+			"\towner: {",
+			"\t\tname: string;",
+			"\t};",
+			"\taliases: string[];",
+			"\trank: number;",
+			"\tactive: boolean;",
+			"}",
+		].join("\n");
+
+		assert.equal(emitted.content, `${expected}\n`);
 	});
 });

--- a/src/emit-doc-type.ts
+++ b/src/emit-doc-type.ts
@@ -13,13 +13,14 @@ export function emitDocType(
 	projection: ResolvedProjection,
 ): EmittedDocTypeFile {
 	const fileName = toDocTypeFileName(projection.projectionModel.name);
-	const body = renderInterfaceBody(
+	const body = renderBlock(
 		program,
 		projection.fields.map((x) => ({
 			name: x.name,
 			type: x.type,
 			optional: x.optional,
 		})),
+		1,
 	);
 
 	return {
@@ -28,29 +29,36 @@ export function emitDocType(
 	};
 }
 
-function renderInterfaceBody(
+/**
+ * Render a `{ ... }` block with fields indented at `depth`.
+ * `depth` always means "indent level of the fields inside this block".
+ */
+function renderBlock(
 	program: Program,
 	fields: ReadonlyArray<{ name: string; type: Type; optional: boolean }>,
+	depth: number,
 ): string {
 	if (fields.length === 0) {
 		return "{}";
 	}
 
+	const indent = "\t".repeat(depth);
+	const closingIndent = "\t".repeat(depth - 1);
 	const lines = fields.map((field) => {
 		const optional = field.optional ? "?" : "";
-		const type = renderType(program, field.type);
-		return `\t${field.name}${optional}: ${type};`;
+		const type = renderType(program, field.type, depth);
+		return `${indent}${field.name}${optional}: ${type};`;
 	});
 
-	return `\n{\n${lines.join("\n")}\n}`;
+	return `{\n${lines.join("\n")}\n${closingIndent}}`;
 }
 
-function renderType(program: Program, type: Type): string {
+function renderType(program: Program, type: Type, depth = 0): string {
 	switch (type.kind) {
 		case "Scalar":
 			return renderScalar(type);
 		case "Model":
-			return renderModel(program, type);
+			return renderModel(program, type, depth);
 		case "String":
 			return "string";
 		case "Number":
@@ -58,7 +66,7 @@ function renderType(program: Program, type: Type): string {
 		case "Boolean":
 			return "boolean";
 		case "Union":
-			return renderUnion(program, type);
+			return renderUnion(program, type, depth);
 		default:
 			return "unknown";
 	}
@@ -99,13 +107,13 @@ function renderScalar(scalar: Scalar): string {
 	}
 }
 
-function renderModel(program: Program, model: Model): string {
+function renderModel(program: Program, model: Model, depth = 0): string {
 	if (model.name === "Array" && model.indexer?.value) {
-		return `${renderType(program, model.indexer.value)}[]`;
+		return `${renderType(program, model.indexer.value, depth)}[]`;
 	}
 
 	if (model.name === "Record" && model.indexer?.value) {
-		return `Record<string, ${renderType(program, model.indexer.value)}>`;
+		return `Record<string, ${renderType(program, model.indexer.value, depth)}>`;
 	}
 
 	const searchableFields = Array.from(model.properties.values())
@@ -116,25 +124,16 @@ function renderModel(program: Program, model: Model): string {
 			optional: prop.optional,
 		}));
 
-	if (searchableFields.length === 0) {
-		return "{}";
-	}
-
-	const lines = searchableFields.map((field) => {
-		const optional = field.optional ? "?" : "";
-		return `\t${field.name}${optional}: ${renderType(program, field.type)};`;
-	});
-
-	return `{\n${lines.join("\n")}\n}`;
+	return renderBlock(program, searchableFields, depth + 1);
 }
 
-function renderUnion(program: Program, union: Union): string {
+function renderUnion(program: Program, union: Union, depth = 0): string {
 	const variants = Array.from(union.variants.values());
 	if (variants.length === 0) {
 		return "never";
 	}
 
-	return variants.map((x) => renderType(program, x.type)).join(" | ");
+	return variants.map((x) => renderType(program, x.type, depth)).join(" | ");
 }
 
 export function toDocTypeFileName(projectionModelName: string): string {


### PR DESCRIPTION
## Summary

Fixes #32 and #33.

### Indentation fix (#32)

Unified depth semantics across the rendering functions by extracting a shared `renderBlock(program, fields, depth)` where `depth` consistently means "indent level of fields inside this block".

**Before** — `renderInterfaceBody` and `renderModel` each had their own field-rendering logic with inconsistent `depth` semantics:
- `renderInterfaceBody`: depth = field indent level
- `renderModel`: depth = parent level, internally +1

**After** — single `renderBlock` function:
- `renderModel` delegates to `renderBlock(…, depth + 1)`
- `emitDocType` calls `renderBlock(…, 1)`
- No duplicated logic, one clear meaning for `depth`

Nested output now correctly indented:
```typescript
export interface PetSearchDoc {
	id: string;
	tags: {
		name: string;
	}[];
	owner: {
		name: string;
	};
}
```

### Test coverage (#33)

Expanded from 1 test to 17 tests:
- `toKebabCase`: PascalCase, camelCase, single word, already-kebab (4 tests)
- `toDocTypeFileName`: suffix stripping, suffix addition (2 tests)
- Doc type emitter: nested inline objects, deeply nested (3 levels), array of inline objects, empty bodies, optional fields, all scalar types, empty inline objects, string arrays, non-searchable field exclusion, full snapshot (11 tests)