### PR TITLE
feat: support nested SearchProjection for sub-collection field whitelisting

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,38 @@ export type { PetSearchDoc } from "./pet-search-doc.js";
 export const PET_SEARCH_DOC_INDEX_NAME = "pets_v1";
 ```
 
+## Nested sub-projections
+
+By default, sub-model collections (e.g. `tags: Tag[]`) include every `@searchable` field of the sub-model. To whitelist specific fields per projection, create a `SearchProjection` for the sub-model and reference it in the parent projection:
+
+```typespec
+model Tag {
+  @searchable @keyword name: string;
+  @searchable createdAt: utcDateTime;
+  internalId: string;
+}
+
+model TagSearchDoc is SearchProjection<Tag> {}
+
+model Pet {
+  @searchable name: string;
+  @searchable @nested tags: Tag[];
+}
+
+@indexName("pets_v1")
+model PetSearchDoc is SearchProjection<Pet> {
+  tags: TagSearchDoc[];  // only Tag's @searchable fields via TagSearchDoc
+}
+```
+
+In this example:
+
+- `TagSearchDoc` resolves only `name` and `createdAt` from `Tag` (both `@searchable`). `internalId` is excluded.
+- `PetSearchDoc` references `TagSearchDoc[]` for the `tags` field, so the mapping and TypeScript interface use the sub-projection's fields.
+- The `@nested` decorator on the source `tags` field is preserved — the mapping emits `"type": "nested"`.
+- The emitted TypeScript interface references `TagSearchDoc[]` (with an import) instead of an inline object type.
+- Sub-projection interfaces are automatically emitted and exported from the barrel `index.ts`.
+
 ## Decorator reference
 
 | Decorator | Target | Effect | Example |

--- a/src/emit-doc-type.test.ts
+++ b/src/emit-doc-type.test.ts
@@ -360,6 +360,38 @@ describe("doc type emitter", () => {
 		assert.equal(emitted.content, `${expected}\n`);
 	});
 
+	it("renders sub-projection field as named type reference", async () => {
+		const emitted = await emitFor(
+			`
+			model Tag {
+				@searchable @keyword name: string;
+				@searchable createdAt: utcDateTime;
+				internalId: string;
+			}
+
+			model TagSearchDoc is SearchProjection<Tag> {}
+
+			model Pet {
+				@searchable name: string;
+				@searchable @nested tags: Tag[];
+			}
+
+			@indexName("pets_v1")
+			model PetSearchDoc is SearchProjection<Pet> {
+				tags: TagSearchDoc[];
+			}
+			`,
+			"PetSearchDoc",
+		);
+
+		assert.ok(emitted.content.includes("tags: TagSearchDoc[];"));
+		assert.ok(
+			emitted.content.includes(
+				'import type { TagSearchDoc } from "./tag-search-doc.js";',
+			),
+		);
+	});
+
 	it("renders enum field as string literal union", async () => {
 		const emitted = await emitFor(
 			`

--- a/src/emit-doc-type.ts
+++ b/src/emit-doc-type.ts
@@ -7,7 +7,10 @@ import type {
 	Union,
 } from "@typespec/compiler";
 import { isSearchable } from "./decorators.js";
-import type { ResolvedProjection } from "./projection.js";
+import type {
+	ResolvedProjection,
+	ResolvedProjectionField,
+} from "./projection.js";
 import { toKebabCase } from "./utils.js";
 
 export interface EmittedDocTypeFile {
@@ -15,24 +18,71 @@ export interface EmittedDocTypeFile {
 	content: string;
 }
 
+/**
+ * Collect all sub-projection models that need their own interface emitted.
+ */
+export function collectSubProjections(
+	projection: ResolvedProjection,
+): ResolvedProjection[] {
+	const result: ResolvedProjection[] = [];
+	const seen = new Set<string>();
+
+	function walk(fields: ResolvedProjectionField[]) {
+		for (const field of fields) {
+			if (field.subProjection) {
+				const name = field.subProjection.projectionModel.name;
+				if (!seen.has(name)) {
+					seen.add(name);
+					result.push(field.subProjection);
+					walk(field.subProjection.fields);
+				}
+			}
+		}
+	}
+
+	walk(projection.fields);
+	return result;
+}
+
 export function emitDocType(
 	program: Program,
 	projection: ResolvedProjection,
 ): EmittedDocTypeFile {
 	const fileName = toDocTypeFileName(projection.projectionModel.name);
+
+	// Collect sub-projection imports needed
+	const subProjections = collectSubProjections(projection);
+	const imports = subProjections
+		.map((sp) => {
+			const subFile = toDocTypeFileName(sp.projectionModel.name).replace(
+				/\.ts$/,
+				".js",
+			);
+			return `import type { ${sp.projectionModel.name} } from "./${subFile}";`;
+		})
+		.join("\n");
+
 	const body = renderBlock(
 		program,
 		projection.fields.map((x) => ({
 			name: x.projectedName ?? x.name,
 			type: x.type,
 			optional: x.optional,
+			subProjection: x.subProjection,
 		})),
 		1,
 	);
 
+	const parts: string[] = [];
+	if (imports) {
+		parts.push(imports);
+		parts.push("");
+	}
+	parts.push(`export interface ${projection.projectionModel.name} ${body}\n`);
+
 	return {
 		fileName,
-		content: `export interface ${projection.projectionModel.name} ${body}\n`,
+		content: parts.join("\n"),
 	};
 }
 
@@ -42,7 +92,12 @@ export function emitDocType(
  */
 function renderBlock(
 	program: Program,
-	fields: ReadonlyArray<{ name: string; type: Type; optional: boolean }>,
+	fields: ReadonlyArray<{
+		name: string;
+		type: Type;
+		optional: boolean;
+		subProjection?: ResolvedProjection;
+	}>,
 	depth: number,
 ): string {
 	if (fields.length === 0) {
@@ -53,7 +108,18 @@ function renderBlock(
 	const closingIndent = "\t".repeat(depth - 1);
 	const lines = fields.map((field) => {
 		const optional = field.optional ? "?" : "";
-		const type = renderType(program, field.type, depth);
+		let type: string;
+		if (field.subProjection) {
+			const subName = field.subProjection.projectionModel.name;
+			// Check if the source type is an array
+			const isArray =
+				field.type.kind === "Model" &&
+				field.type.name === "Array" &&
+				!!field.type.indexer?.value;
+			type = isArray ? `${subName}[]` : subName;
+		} else {
+			type = renderType(program, field.type, depth);
+		}
 		return `${indent}${field.name}${optional}: ${type};`;
 	});
 

--- a/src/emit-index.ts
+++ b/src/emit-index.ts
@@ -1,4 +1,4 @@
-import { toDocTypeFileName } from "./emit-doc-type.js";
+import { collectSubProjections, toDocTypeFileName } from "./emit-doc-type.js";
 import type { ResolvedProjection } from "./projection.js";
 
 export interface EmittedIndexFile {
@@ -11,7 +11,36 @@ export function emitIndex(projections: ResolvedProjection[]): EmittedIndexFile {
 		a.projectionModel.name.localeCompare(b.projectionModel.name),
 	);
 
+	// Collect all sub-projections that need type exports
+	const topLevelNames = new Set(sorted.map((p) => p.projectionModel.name));
+	const subProjections: ResolvedProjection[] = [];
+	const subNames = new Set<string>();
+	for (const projection of sorted) {
+		for (const sp of collectSubProjections(projection)) {
+			const name = sp.projectionModel.name;
+			if (!topLevelNames.has(name) && !subNames.has(name)) {
+				subNames.add(name);
+				subProjections.push(sp);
+			}
+		}
+	}
+	subProjections.sort((a, b) =>
+		a.projectionModel.name.localeCompare(b.projectionModel.name),
+	);
+
 	const lines: string[] = [];
+
+	// Export sub-projection types first
+	for (const sp of subProjections) {
+		const docTypeFile = toDocTypeFileName(sp.projectionModel.name).replace(
+			/\.ts$/,
+			".js",
+		);
+		lines.push(
+			`export type { ${sp.projectionModel.name} } from "./${docTypeFile}";`,
+		);
+	}
+
 	for (const projection of sorted) {
 		const docTypeFile = toDocTypeFileName(
 			projection.projectionModel.name,

--- a/src/emit-mapping.test.ts
+++ b/src/emit-mapping.test.ts
@@ -350,6 +350,84 @@ describe("mapping emitter", () => {
 		});
 	});
 
+	it("nested field with sub-projection emits only sub-projection fields in properties", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Tag {
+        @searchable @keyword name: string;
+        @searchable createdAt: utcDateTime;
+        internalId: string;
+      }
+
+      model TagSearchDoc is SearchProjection<Tag> {}
+
+      model Pet {
+        @searchable name: string;
+        @searchable @nested tags: Tag[];
+      }
+
+      @indexName("pets_v1")
+      model PetSearchDoc is SearchProjection<Pet> {
+        tags: TagSearchDoc[];
+      }
+    `);
+		assert.equal(diagnostics.length, 0);
+
+		const projection = runner.program
+			.getGlobalNamespaceType()
+			.models.get("PetSearchDoc");
+		assert.ok(projection);
+
+		const resolved = resolveProjectionModel(runner.program, projection);
+		assert.ok(resolved);
+		const emitted = emitMapping(runner.program, resolved);
+		const parsed = JSON.parse(emitted.content);
+
+		const tags = parsed.mappings.properties.tags;
+		assert.equal(tags.type, "nested");
+		assert.deepEqual(Object.keys(tags.properties).sort(), [
+			"createdAt",
+			"name",
+		]);
+		assert.equal(tags.properties.name.type, "keyword");
+		assert.equal(tags.properties.createdAt.type, "date");
+		// internalId should NOT appear
+		assert.equal(tags.properties.internalId, undefined);
+	});
+
+	it("@nested is honored on sub-projection fields", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Tag {
+        @searchable @keyword name: string;
+      }
+
+      model TagSearchDoc is SearchProjection<Tag> {}
+
+      model Pet {
+        @searchable name: string;
+        @searchable tags: Tag[];
+      }
+
+      model PetSearchDoc is SearchProjection<Pet> {
+        @nested tags: TagSearchDoc[];
+      }
+    `);
+		assert.equal(diagnostics.length, 0);
+
+		const projection = runner.program
+			.getGlobalNamespaceType()
+			.models.get("PetSearchDoc");
+		assert.ok(projection);
+
+		const resolved = resolveProjectionModel(runner.program, projection);
+		assert.ok(resolved);
+		const emitted = emitMapping(runner.program, resolved);
+		const parsed = JSON.parse(emitted.content);
+
+		assert.equal(parsed.mappings.properties.tags.type, "nested");
+	});
+
 	it("defaults ignore_above to 256 without decorator", async () => {
 		const runner = await createRunner();
 		const diagnostics = await runner.diagnose(`

--- a/src/emit-mapping.ts
+++ b/src/emit-mapping.ts
@@ -7,7 +7,10 @@ import {
 	isNested,
 	isSearchable,
 } from "./decorators.js";
-import type { ResolvedProjection } from "./projection.js";
+import type {
+	ResolvedProjection,
+	ResolvedProjectionField,
+} from "./projection.js";
 import { toKebabCase } from "./utils.js";
 
 export interface EmittedMappingFile {
@@ -23,22 +26,10 @@ export function emitMapping(
 	defaultIgnoreAbove?: number,
 ): EmittedMappingFile {
 	const fileName = `${toKebabCase(projection.projectionModel.name)}-search-mapping.json`;
-	const properties = Object.fromEntries(
-		projection.fields.map((field) => [
-			field.projectedName ?? field.name,
-			toMapping(
-				program,
-				field.type,
-				{
-					keyword: field.keyword,
-					nested: field.nested,
-					analyzer: field.analyzer,
-					boost: field.boost,
-					ignoreAbove: field.ignoreAbove,
-				},
-				defaultIgnoreAbove,
-			),
-		]),
+	const properties = buildPropertiesFromFields(
+		program,
+		projection.fields,
+		defaultIgnoreAbove,
 	);
 
 	const mappings: Record<string, unknown> = { mappings: { properties } };
@@ -163,6 +154,49 @@ function mapScalar(
 	}
 
 	return { type: "object" };
+}
+
+function buildPropertiesFromFields(
+	program: Program,
+	fields: ResolvedProjectionField[],
+	defaultIgnoreAbove?: number,
+): Record<string, MappingProperty> {
+	return Object.fromEntries(
+		fields.map((field) => [
+			field.projectedName ?? field.name,
+			field.subProjection
+				? mapSubProjectionField(program, field, defaultIgnoreAbove)
+				: toMapping(
+						program,
+						field.type,
+						{
+							keyword: field.keyword,
+							nested: field.nested,
+							analyzer: field.analyzer,
+							boost: field.boost,
+							ignoreAbove: field.ignoreAbove,
+						},
+						defaultIgnoreAbove,
+					),
+		]),
+	);
+}
+
+function mapSubProjectionField(
+	program: Program,
+	field: ResolvedProjectionField,
+	defaultIgnoreAbove?: number,
+): MappingProperty {
+	const subProjection = field.subProjection!;
+	const properties = buildPropertiesFromFields(
+		program,
+		subProjection.fields,
+		defaultIgnoreAbove,
+	);
+	return {
+		type: field.nested ? "nested" : "object",
+		properties,
+	};
 }
 
 function mapModel(

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -5,7 +5,7 @@ import type {
 	Program,
 } from "@typespec/compiler";
 import { emitFile, resolvePath } from "@typespec/compiler";
-import { emitDocType } from "./emit-doc-type.js";
+import { collectSubProjections, emitDocType } from "./emit-doc-type.js";
 import { emitIndex } from "./emit-index.js";
 import { emitMapping } from "./emit-mapping.js";
 import type { OpenSearchEmitterOptions } from "./lib.js";
@@ -39,6 +39,15 @@ export async function $onEmit(
 			path: resolvePath(context.emitterOutputDir, docTypeFile.fileName),
 			content: docTypeFile.content,
 		});
+
+		// Emit sub-projection doc type files
+		for (const subProj of collectSubProjections(projection)) {
+			const subDocTypeFile = emitDocType(context.program, subProj);
+			await emitFile(context.program, {
+				path: resolvePath(context.emitterOutputDir, subDocTypeFile.fileName),
+				content: subDocTypeFile.content,
+			});
+		}
 
 		const mappingFile = emitMapping(
 			context.program,

--- a/src/projection.test.ts
+++ b/src/projection.test.ts
@@ -145,6 +145,89 @@ describe("projection resolution", () => {
 		assert.ok(relevant[0].message.includes("phantom"));
 	});
 
+	it("resolves sub-projection field with nested SearchProjection", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Tag {
+        @searchable @keyword name: string;
+        @searchable createdAt: utcDateTime;
+        internalId: string;
+      }
+
+      model TagSearchDoc is SearchProjection<Tag> {}
+
+      model Pet {
+        @searchable name: string;
+        @searchable @nested tags: Tag[];
+      }
+
+      @indexName("pets_v1")
+      model PetSearchDoc is SearchProjection<Pet> {
+        tags: TagSearchDoc[];
+      }
+    `);
+
+		assert.equal(diagnostics.length, 0);
+
+		const projection = runner.program
+			.getGlobalNamespaceType()
+			.models.get("PetSearchDoc");
+		assert.ok(projection);
+
+		const resolved = resolveProjectionModel(runner.program, projection);
+		assert.ok(resolved);
+
+		const tagsField = resolved.fields.find((x) => x.name === "tags");
+		assert.ok(tagsField);
+		assert.equal(tagsField.nested, true);
+		assert.ok(tagsField.subProjection);
+		assert.equal(tagsField.subProjection.projectionModel.name, "TagSearchDoc");
+		assert.deepEqual(
+			tagsField.subProjection.fields.map((x) => x.name),
+			["name", "createdAt"],
+		);
+	});
+
+	it("sub-projection excludes non-searchable fields from sub-model", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Tag {
+        @searchable @keyword name: string;
+        internalId: string;
+        secret: string;
+      }
+
+      model TagSearchDoc is SearchProjection<Tag> {}
+
+      model Pet {
+        @searchable name: string;
+        @searchable @nested tags: Tag[];
+      }
+
+      @indexName("pets_v1")
+      model PetSearchDoc is SearchProjection<Pet> {
+        tags: TagSearchDoc[];
+      }
+    `);
+
+		assert.equal(diagnostics.length, 0);
+
+		const projection = runner.program
+			.getGlobalNamespaceType()
+			.models.get("PetSearchDoc");
+		assert.ok(projection);
+
+		const resolved = resolveProjectionModel(runner.program, projection);
+		assert.ok(resolved);
+
+		const tagsField = resolved.fields.find((x) => x.name === "tags");
+		assert.ok(tagsField?.subProjection);
+		const subFieldNames = tagsField.subProjection.fields.map((x) => x.name);
+		assert.deepEqual(subFieldNames, ["name"]);
+		assert.ok(!subFieldNames.includes("internalId"));
+		assert.ok(!subFieldNames.includes("secret"));
+	});
+
 	it("emits diagnostic for projection field that exists on source but is not @searchable", async () => {
 		const runner = await createRunner();
 		const _diagnostics = await runner.diagnose(`

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -25,6 +25,7 @@ export interface ResolvedProjectionField {
 	analyzer?: string;
 	boost?: number;
 	ignoreAbove?: number;
+	subProjection?: ResolvedProjection;
 }
 
 export interface ResolvedProjection {
@@ -84,19 +85,38 @@ export function resolveProjectionModel(
 		const projectionProperty = projectionModel.properties.get(
 			sourceProperty.name,
 		);
-		fields.push(
-			resolveProjectionField(program, sourceProperty, projectionProperty),
+		const field = resolveProjectionField(
+			program,
+			sourceProperty,
+			projectionProperty,
 		);
+
+		// Check if the projection redeclares this field with a sub-projection type
+		if (projectionProperty) {
+			const subProj = resolveSubProjectionFromType(
+				program,
+				projectionProperty.type,
+			);
+			if (subProj) {
+				field.subProjection = subProj;
+			}
+		}
+
+		fields.push(field);
 	}
 
 	for (const projProp of projectionModel.properties.values()) {
 		const sourceProp = sourceModel.properties.get(projProp.name);
 		if (!sourceProp || !isSearchable(program, sourceProp)) {
-			reportDiagnostic(program, {
-				code: "projection-field-not-on-source",
-				format: { name: projProp.name, sourceModel: sourceModel.name },
-				target: projProp,
-			});
+			// Allow sub-projection fields that reference a valid source field
+			const subProj = resolveSubProjectionFromType(program, projProp.type);
+			if (!subProj || !sourceProp) {
+				reportDiagnostic(program, {
+					code: "projection-field-not-on-source",
+					format: { name: projProp.name, sourceModel: sourceModel.name },
+					target: projProp,
+				});
+			}
 		}
 	}
 
@@ -145,6 +165,69 @@ function resolveProjectionField(
 		analyzer,
 		boost,
 		ignoreAbove,
+	};
+}
+
+/**
+ * Given a Type, check if it is (or is an array of) a SearchProjection model,
+ * and if so resolve it recursively.
+ */
+function resolveSubProjectionFromType(
+	program: Program,
+	type: Type,
+): ResolvedProjection | undefined {
+	// Handle direct model reference: TagSearchDoc
+	if (type.kind === "Model") {
+		// Handle Array<TagSearchDoc> — e.g. TagSearchDoc[]
+		if (type.name === "Array" && type.indexer?.value?.kind === "Model") {
+			return resolveSubProjectionModel(program, type.indexer.value);
+		}
+		return resolveSubProjectionModel(program, type);
+	}
+	return undefined;
+}
+
+function resolveSubProjectionModel(
+	program: Program,
+	model: Model,
+): ResolvedProjection | undefined {
+	const sourceModel = getProjectionSourceModel(program, model);
+	if (!sourceModel) {
+		return undefined;
+	}
+
+	const fields: ResolvedProjectionField[] = [];
+	for (const sourceProperty of sourceModel.properties.values()) {
+		if (!isSearchable(program, sourceProperty)) {
+			continue;
+		}
+
+		const projectionProperty = model.properties.get(sourceProperty.name);
+		const field = resolveProjectionField(
+			program,
+			sourceProperty,
+			projectionProperty,
+		);
+
+		if (projectionProperty) {
+			const subProj = resolveSubProjectionFromType(
+				program,
+				projectionProperty.type,
+			);
+			if (subProj) {
+				field.subProjection = subProj;
+			}
+		}
+
+		fields.push(field);
+	}
+
+	return {
+		projectionModel: model,
+		sourceModel,
+		indexName: getIndexName(program, model),
+		indexSettings: getIndexSettings(program, model),
+		fields,
 	};
 }
 


### PR DESCRIPTION
Fixes #50

## Summary

Adds support for nested  types, allowing per-sub-collection field whitelisting.

### Changes

- **projection.ts**: Detects sub-projection types (e.g. `TagSearchDoc[]`) on projection fields and resolves them recursively via `subProjection` on `ResolvedProjectionField`
- **emit-mapping.ts**: Uses sub-projection's resolved fields for the `properties` block instead of scanning raw model `@searchable` fields
- **emit-doc-type.ts**: Renders sub-projection fields as named type references (e.g. `TagSearchDoc[]`) with proper imports; collects sub-projections for separate interface files
- **emit-index.ts**: Exports sub-projection types that aren't top-level projections
- **emitter.ts**: Emits sub-projection doc type files alongside parent projections
- **Tests**: 5 new tests covering projection resolution, mapping emission, and doc type rendering for sub-projections
- **README**: New "Nested sub-projections" section with example