### PR TITLE
feat(emitter): emit package.json (parity with zod-emitter)

### DIFF
--- a/src/emitter.test.ts
+++ b/src/emitter.test.ts
@@ -196,6 +196,72 @@ describe("isCandidateModel", () => {
 	});
 });
 
+describe("generatePackageJson", () => {
+	it("generates a minimal package.json with index and mapping exports", () => {
+		const projections = [
+			{
+				projectionModel: { name: "ProductSearchDoc" },
+				sourceModel: { name: "Product" },
+				indexName: "product_search_doc",
+				fields: [],
+			},
+		] as unknown as ResolvedProjection[];
+
+		const result = JSON.parse(
+			__test.generatePackageJson("@my/pkg", "1.0.0", projections),
+		);
+
+		assert.equal(result.name, "@my/pkg");
+		assert.equal(result.version, "1.0.0");
+		assert.equal(result.type, "module");
+		assert.equal(result.main, "./index.js");
+		assert.equal(result.types, "./index.d.ts");
+		assert.deepEqual(result.exports["."], {
+			types: "./index.d.ts",
+			default: "./index.js",
+		});
+		assert.equal(
+			result.exports["./product-search-doc-search-mapping.json"],
+			"./product-search-doc-search-mapping.json",
+		);
+	});
+
+	it("sorts mapping exports alphabetically", () => {
+		const projections = [
+			{
+				projectionModel: { name: "ZetaSearchDoc" },
+				sourceModel: { name: "Zeta" },
+				indexName: "zeta",
+				fields: [],
+			},
+			{
+				projectionModel: { name: "AlphaSearchDoc" },
+				sourceModel: { name: "Alpha" },
+				indexName: "alpha",
+				fields: [],
+			},
+		] as unknown as ResolvedProjection[];
+
+		const result = JSON.parse(
+			__test.generatePackageJson("@my/pkg", "2.0.0", projections),
+		);
+		const exportKeys = Object.keys(result.exports);
+
+		assert.equal(exportKeys[0], ".");
+		assert.equal(exportKeys[1], "./alpha-search-doc-search-mapping.json");
+		assert.equal(exportKeys[2], "./zeta-search-doc-search-mapping.json");
+	});
+
+	it("omits package.json when options are not provided", () => {
+		const result = JSON.parse(
+			__test.generatePackageJson("@my/pkg", "1.0.0", []),
+		);
+		const exportKeys = Object.keys(result.exports);
+		assert.equal(exportKeys.length, 1);
+		assert.equal(exportKeys[0], ".");
+	});
+});
+
 describe("isTemplateDeclaration", () => {
 	it("returns true when model node has templateParameters", () => {
 		const model = {

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -14,6 +14,7 @@ import {
 	type ResolvedProjection,
 	resolveProjectionModel,
 } from "./projection.js";
+import { toKebabCase } from "./utils.js";
 
 export async function $onEmit(
 	context: EmitContext<OpenSearchEmitterOptions>,
@@ -70,6 +71,21 @@ export async function $onEmit(
 		path: resolvePath(context.emitterOutputDir, outputFile),
 		content: `${JSON.stringify(serializeProjections(resolved), null, 2)}\n`,
 	});
+
+	const packageName = context.options["package-name"];
+	const packageVersion = context.options["package-version"];
+
+	if (packageName && packageVersion) {
+		const packageJsonContent = generatePackageJson(
+			packageName,
+			packageVersion,
+			resolved,
+		);
+		await emitFile(context.program, {
+			path: resolvePath(context.emitterOutputDir, "package.json"),
+			content: packageJsonContent,
+		});
+	}
 }
 
 function collectProjectionModels(
@@ -150,4 +166,45 @@ export const __test = {
 	isCandidateModel,
 	isTemplateDeclaration,
 	serializeProjections,
+	generatePackageJson,
 };
+
+function generatePackageJson(
+	packageName: string,
+	packageVersion: string,
+	projections: ResolvedProjection[],
+): string {
+	const mappingExports: Record<string, string> = {};
+
+	for (const projection of projections) {
+		const baseName = `${toKebabCase(projection.projectionModel.name)}-search-mapping`;
+		mappingExports[`./${baseName}.json`] = `./${baseName}.json`;
+	}
+
+	const sorted = Object.fromEntries(
+		Object.entries(mappingExports).sort(([a], [b]) => a.localeCompare(b)),
+	);
+
+	const packageJson = {
+		name: packageName,
+		version: packageVersion,
+		type: "module" as const,
+		main: "./index.js",
+		types: "./index.d.ts",
+		exports: {
+			".": {
+				types: "./index.d.ts",
+				default: "./index.js",
+			},
+			...sorted,
+		},
+		scripts: {
+			prepare: "tsc",
+		},
+		devDependencies: {
+			typescript: "^5.0.0",
+		},
+	};
+
+	return `${JSON.stringify(packageJson, null, 2)}\n`;
+}

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -3,6 +3,8 @@ import { createTypeSpecLibrary, paramMessage } from "@typespec/compiler";
 export interface OpenSearchEmitterOptions {
 	"output-file"?: string;
 	"default-ignore-above"?: number;
+	"package-name"?: string;
+	"package-version"?: string;
 }
 
 export const $lib = createTypeSpecLibrary({
@@ -88,6 +90,8 @@ export const $lib = createTypeSpecLibrary({
 					nullable: true,
 					default: 256,
 				},
+				"package-name": { type: "string", nullable: true },
+				"package-version": { type: "string", nullable: true },
 			},
 			required: [],
 		},


### PR DESCRIPTION
Accept `package-name` and `package-version` in the emitter options schema. When both are provided, generate a minimal `package.json` into the output dir with:

- `name`, `version`, `type: "module"`
- Exports for `./index` (types + default)
- Exports for each `*-search-mapping.json`
- `prepare` script and `typescript` devDependency

This matches `@kattebak/typespec-zod-emitter` behavior so a single tspconfig block fully describes a publishable package.

Closes #58