### PR TITLE
feat(emitter): emit scoped tsconfig.json alongside package.json

### DIFF
--- a/src/emitter.test.ts
+++ b/src/emitter.test.ts
@@ -262,6 +262,60 @@ describe("generatePackageJson", () => {
 	});
 });
 
+describe("generateTsConfig", () => {
+	it("generates tsconfig with index.ts and doc-type files", () => {
+		const projections = [
+			{
+				projectionModel: { name: "ProductSearchDoc" },
+				sourceModel: { name: "Product" },
+				indexName: "product_search_doc",
+				fields: [],
+			},
+		] as unknown as ResolvedProjection[];
+
+		const result = JSON.parse(__test.generateTsConfig(projections));
+
+		assert.deepEqual(result.compilerOptions, {
+			module: "NodeNext",
+			moduleResolution: "NodeNext",
+			target: "ES2020",
+			strict: true,
+			declaration: true,
+			outDir: ".",
+		});
+		assert.deepEqual(result.include, ["index.ts", "product-search-doc.ts"]);
+	});
+
+	it("sorts include entries alphabetically", () => {
+		const projections = [
+			{
+				projectionModel: { name: "ZetaSearchDoc" },
+				sourceModel: { name: "Zeta" },
+				indexName: "zeta",
+				fields: [],
+			},
+			{
+				projectionModel: { name: "AlphaSearchDoc" },
+				sourceModel: { name: "Alpha" },
+				indexName: "alpha",
+				fields: [],
+			},
+		] as unknown as ResolvedProjection[];
+
+		const result = JSON.parse(__test.generateTsConfig(projections));
+		assert.deepEqual(result.include, [
+			"alpha-search-doc.ts",
+			"index.ts",
+			"zeta-search-doc.ts",
+		]);
+	});
+
+	it("returns tsconfig with only index.ts when no projections", () => {
+		const result = JSON.parse(__test.generateTsConfig([]));
+		assert.deepEqual(result.include, ["index.ts"]);
+	});
+});
+
 describe("isTemplateDeclaration", () => {
 	it("returns true when model node has templateParameters", () => {
 		const model = {

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -5,7 +5,11 @@ import type {
 	Program,
 } from "@typespec/compiler";
 import { emitFile, resolvePath } from "@typespec/compiler";
-import { collectSubProjections, emitDocType } from "./emit-doc-type.js";
+import {
+	collectSubProjections,
+	emitDocType,
+	toDocTypeFileName,
+} from "./emit-doc-type.js";
 import { emitIndex } from "./emit-index.js";
 import { emitMapping } from "./emit-mapping.js";
 import type { OpenSearchEmitterOptions } from "./lib.js";
@@ -84,6 +88,12 @@ export async function $onEmit(
 		await emitFile(context.program, {
 			path: resolvePath(context.emitterOutputDir, "package.json"),
 			content: packageJsonContent,
+		});
+
+		const tsConfigContent = generateTsConfig(resolved);
+		await emitFile(context.program, {
+			path: resolvePath(context.emitterOutputDir, "tsconfig.json"),
+			content: tsConfigContent,
 		});
 	}
 }
@@ -167,7 +177,39 @@ export const __test = {
 	isTemplateDeclaration,
 	serializeProjections,
 	generatePackageJson,
+	generateTsConfig,
 };
+
+function generateTsConfig(projections: ResolvedProjection[]): string {
+	const tsFiles: string[] = ["index.ts"];
+
+	for (const projection of projections) {
+		tsFiles.push(toDocTypeFileName(projection.projectionModel.name));
+
+		for (const subProj of collectSubProjections(projection)) {
+			const subFileName = toDocTypeFileName(subProj.projectionModel.name);
+			if (!tsFiles.includes(subFileName)) {
+				tsFiles.push(subFileName);
+			}
+		}
+	}
+
+	tsFiles.sort();
+
+	const tsConfig = {
+		compilerOptions: {
+			module: "NodeNext",
+			moduleResolution: "NodeNext",
+			target: "ES2020",
+			strict: true,
+			declaration: true,
+			outDir: ".",
+		},
+		include: tsFiles,
+	};
+
+	return `${JSON.stringify(tsConfig, null, 2)}\n`;
+}
 
 function generatePackageJson(
 	packageName: string,


### PR DESCRIPTION
Closes #60

When `package-name` and `package-version` options are set, the emitter now also writes a `tsconfig.json` next to `package.json`. This scopes `prepare: tsc` to only compile the emitted `.ts` files, preventing it from walking up and picking up the consumer's root tsconfig.

**Generated tsconfig shape:**
```json
{
  "compilerOptions": {
    "module": "NodeNext",
    "moduleResolution": "NodeNext",
    "target": "ES2020",
    "strict": true,
    "declaration": true,
    "outDir": "."
  },
  "include": ["index.ts", "product-search-doc.ts"]
}
```

The `include` array lists every `.ts` file the emitter writes (index + each doc-type file, including sub-projections), sorted alphabetically.