### PR TITLE
fix(emitter): add skipLibCheck and exclude to generated tsconfig

### DIFF
--- a/src/emitter.test.ts
+++ b/src/emitter.test.ts
@@ -280,10 +280,12 @@ describe("generateTsConfig", () => {
 			moduleResolution: "NodeNext",
 			target: "ES2020",
 			strict: true,
+			skipLibCheck: true,
 			declaration: true,
 			outDir: ".",
 		});
 		assert.deepEqual(result.include, ["index.ts", "product-search-doc.ts"]);
+		assert.deepEqual(result.exclude, ["node_modules"]);
 	});
 
 	it("sorts include entries alphabetically", () => {

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -202,10 +202,12 @@ function generateTsConfig(projections: ResolvedProjection[]): string {
 			moduleResolution: "NodeNext",
 			target: "ES2020",
 			strict: true,
+			skipLibCheck: true,
 			declaration: true,
 			outDir: ".",
 		},
 		include: tsFiles,
+		exclude: ["node_modules"],
 	};
 
 	return `${JSON.stringify(tsConfig, null, 2)}\n`;


### PR DESCRIPTION
Closes #62

The generated `tsconfig.json` fails with `TS18003: No inputs were found` because `outDir: "." ` causes TypeScript's default exclude to shadow all files in `include`.

**Fix:** Add `skipLibCheck: true` and `exclude: ["node_modules"]` to match the zod-emitter shape.

```diff
  compilerOptions: {
    module: "NodeNext",
    moduleResolution: "NodeNext",
    target: "ES2020",
    strict: true,
+   skipLibCheck: true,
    declaration: true,
    outDir: ".",
  },
  include: tsFiles,
+ exclude: ["node_modules"],
```