### PR TITLE
feat(emitter): add GraphQL emit target for AppSync-over-OpenSearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ TypeSpec emitter that generates OpenSearch artifacts from decorated models:
 - **OpenSearch mapping JSON** for index creation
 - **Barrel `index.ts`** with type exports and index name constants
 - **Projection metadata JSON** for tooling integration
+- **GraphQL SDL fragments** for AppSync-over-OpenSearch read APIs (opt-in)
+- **APPSYNC_JS resolver source** per searchable operation (opt-in)
 
 ## Install
 
@@ -291,8 +293,130 @@ In this example:
 | --- | --- | --- | --- |
 | `output-file` | `string` | `opensearch-projections.json` | Filename for the projection metadata JSON. |
 | `default-ignore-above` | `number` | `256` | Default `ignore_above` value for keyword sub-fields on text-mapped strings. |
+| `package-name` | `string` | — | Package name for emitted `package.json`. Requires `package-version`. |
+| `package-version` | `string` | — | Package version for emitted `package.json`. Requires `package-name`. |
+| `graphql.emit` | `boolean` | `false` | Enable GraphQL SDL and resolver emission. |
+| `graphql.default-page-size` | `number` | `20` | Default page size for connection queries. |
+| `graphql.max-page-size` | `number` | `100` | Maximum allowed page size. |
+| `graphql.track-total-hits-up-to` | `number` | `10000` | OpenSearch `track_total_hits` limit. |
 
 The `emitter-output-dir` option is a standard TypeSpec compiler option that controls the output directory.
+
+## GraphQL emit target (AppSync)
+
+Enable with `graphql.emit: true` to generate GraphQL SDL fragments and APPSYNC_JS resolvers alongside the standard OpenSearch artifacts.
+
+### Configuration
+
+```yaml
+emit:
+  - "@kattebak/typespec-opensearch-emitter"
+options:
+  "@kattebak/typespec-opensearch-emitter":
+    emitter-output-dir: "{cwd}/build/opensearch"
+    graphql:
+      emit: true
+      default-page-size: 20
+      max-page-size: 100
+      track-total-hits-up-to: 10000
+```
+
+### Generated files
+
+For each projection, the emitter produces:
+
+```text
+build/opensearch/
+  pet-search-doc.graphql          # GraphQL SDL fragment
+  pet-search-doc-resolver.js      # APPSYNC_JS resolver
+  graphql-resolvers.json           # manifest mapping projections to files
+```
+
+### GraphQL SDL (`.graphql`)
+
+Each fragment contains:
+
+- **Object type** — derived 1:1 from the search-doc TypeScript interface. Field types map from TypeSpec scalars to GraphQL scalars (`string` → `String`, `int32` → `Int`, `float64` → `Float`, `boolean` → `Boolean`).
+- **Filter input** — one optional `String` argument per `@keyword` field for term matching. Omitted if the projection has no keyword fields.
+- **Connection envelope** — `*Connection`, `*Edge`, and `PageInfo` types implementing opaque cursor pagination via `search_after`.
+
+Example output for `PetSearchDoc`:
+
+```graphql
+type PetSearchDoc {
+  id: String!
+  name: String!
+  species: String!
+  breed: String
+  birthDate: String!
+  tags: [TagSearchDoc!]!
+  owner: String!
+}
+
+input PetSearchDocFilter {
+  species: String
+}
+
+type PetSearchDocConnection {
+  edges: [PetSearchDocEdge!]!
+  pageInfo: PageInfo!
+  totalHits: Int!
+}
+
+type PetSearchDocEdge {
+  node: PetSearchDoc!
+  cursor: String!
+}
+
+type PageInfo {
+  hasNextPage: Boolean!
+  endCursor: String
+}
+```
+
+### APPSYNC_JS resolver (`.js`)
+
+Each resolver file exports `request(ctx)` and `response(ctx)` conforming to APPSYNC_JS runtime constraints:
+
+- **No imports** except `@aws-appsync/utils`
+- **No network I/O** — resolvers are pure request/response transformers
+- `request` builds an OpenSearch `_search` body with:
+  - `multi_match` across all `text` fields when `query` argument is provided
+  - `term` filters for each `@keyword` field present in the `filter` argument
+  - `search_after` cursor pagination (base64-encoded sort values)
+  - Deterministic sort: `[_score desc, _id asc]`
+- `response` projects hits into the Connection shape with edges, cursors, and pageInfo
+
+### Manifest (`graphql-resolvers.json`)
+
+Maps each projection to its resolver file, SDL file, query field name, and index name:
+
+```json
+{
+  "resolvers": [
+    {
+      "projection": "PetSearchDoc",
+      "indexName": "pets_v1",
+      "queryFieldName": "searchPet",
+      "resolverFile": "pet-search-doc-resolver.js",
+      "sdlFile": "pet-search-doc.graphql"
+    }
+  ]
+}
+```
+
+The consuming CDK construct can read this manifest to wire resolvers without hardcoded knowledge.
+
+### Conventions
+
+GraphQL intent is derived from the existing OpenSearch mapping — no additional decorators needed:
+
+| OpenSearch mapping | GraphQL behavior |
+| --- | --- |
+| `@keyword` field | Filterable input argument (term match) |
+| `text` field (no `@keyword`) | Included in `multi_match` field list |
+| All projection fields | Output type fields |
+| Sub-projection (`SearchProjection`) | Nested GraphQL type reference |
 
 ## Index settings (analyzers, tokenizers, filters)
 

--- a/src/emit-graphql-resolver.test.ts
+++ b/src/emit-graphql-resolver.test.ts
@@ -1,0 +1,165 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { Type } from "@typespec/compiler";
+import { emitGraphQLResolver } from "./emit-graphql-resolver.js";
+import type { ResolvedProjection } from "./projection.js";
+
+function makeProjection(
+	overrides: Partial<{
+		name: string;
+		indexName: string;
+		fields: ResolvedProjection["fields"];
+	}> = {},
+): ResolvedProjection {
+	return {
+		projectionModel: { name: overrides.name ?? "PetSearchDoc" },
+		sourceModel: { name: "Pet" },
+		indexName: overrides.indexName ?? "pets_v1",
+		fields: overrides.fields ?? [],
+	} as unknown as ResolvedProjection;
+}
+
+function makeField(
+	overrides: Partial<{
+		name: string;
+		projectedName: string;
+		keyword: boolean;
+		nested: boolean;
+		optional: boolean;
+		type: Type;
+		subProjection: ResolvedProjection;
+	}> = {},
+) {
+	return {
+		name: overrides.name ?? "field",
+		projectedName: overrides.projectedName,
+		keyword: overrides.keyword ?? false,
+		nested: overrides.nested ?? false,
+		optional: overrides.optional ?? false,
+		searchable: true,
+		type:
+			overrides.type ??
+			({
+				kind: "Scalar",
+				name: "string",
+			} as unknown as Type),
+		subProjection: overrides.subProjection,
+	} as unknown as ResolvedProjection["fields"][0];
+}
+
+const defaultOptions = {
+	defaultPageSize: 20,
+	maxPageSize: 100,
+	trackTotalHitsUpTo: 10000,
+};
+
+describe("emitGraphQLResolver", () => {
+	it("generates resolver file with correct name", () => {
+		const projection = makeProjection({ fields: [] });
+		const result = emitGraphQLResolver(projection, defaultOptions);
+
+		assert.equal(result.fileName, "pet-search-doc-resolver.js");
+		assert.equal(result.queryFieldName, "searchPet");
+	});
+
+	it("includes index name in request path", () => {
+		const projection = makeProjection({
+			indexName: "pets_v1",
+			fields: [],
+		});
+		const result = emitGraphQLResolver(projection, defaultOptions);
+
+		assert.ok(result.content.includes("/pets_v1/_search"));
+	});
+
+	it("includes text fields in multi_match", () => {
+		const projection = makeProjection({
+			fields: [makeField({ name: "name" }), makeField({ name: "breed" })],
+		});
+		const result = emitGraphQLResolver(projection, defaultOptions);
+
+		assert.ok(result.content.includes('"name","breed"'));
+	});
+
+	it("includes keyword fields in filter logic", () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({ name: "species", keyword: true }),
+				makeField({ name: "status", keyword: true }),
+			],
+		});
+		const result = emitGraphQLResolver(projection, defaultOptions);
+
+		assert.ok(result.content.includes('"species","status"'));
+	});
+
+	it("excludes nested and sub-projection fields from text fields", () => {
+		const subProjection = {
+			projectionModel: { name: "TagSearchDoc" },
+		} as unknown as ResolvedProjection;
+
+		const projection = makeProjection({
+			fields: [
+				makeField({ name: "name" }),
+				makeField({ name: "tags", nested: true }),
+				makeField({ name: "owner", subProjection }),
+			],
+		});
+		const result = emitGraphQLResolver(projection, defaultOptions);
+
+		assert.ok(result.content.includes('["name"]'));
+	});
+
+	it("respects custom page size and track_total_hits options", () => {
+		const projection = makeProjection({ fields: [] });
+		const result = emitGraphQLResolver(projection, {
+			defaultPageSize: 10,
+			maxPageSize: 50,
+			trackTotalHitsUpTo: 5000,
+		});
+
+		assert.ok(result.content.includes("args.first || 10"));
+		assert.ok(result.content.includes("50)"));
+		assert.ok(result.content.includes("track_total_hits: 5000"));
+	});
+
+	it("uses projectedName for field references", () => {
+		const projection = makeProjection({
+			fields: [makeField({ name: "name", projectedName: "displayName" })],
+		});
+		const result = emitGraphQLResolver(projection, defaultOptions);
+
+		assert.ok(result.content.includes('"displayName"'));
+		assert.ok(!result.content.includes('"name"'));
+	});
+
+	it("has no import statements except aws-appsync/utils", () => {
+		const projection = makeProjection({
+			fields: [makeField({ name: "name" })],
+		});
+		const result = emitGraphQLResolver(projection, defaultOptions);
+
+		const imports = result.content
+			.split("\n")
+			.filter((l) => l.startsWith("import "));
+		assert.equal(imports.length, 1);
+		assert.ok(imports[0].includes("@aws-appsync/utils"));
+	});
+
+	it("sorts by _score desc then _id asc", () => {
+		const projection = makeProjection({ fields: [] });
+		const result = emitGraphQLResolver(projection, defaultOptions);
+
+		assert.ok(result.content.includes('{ _score: "desc" }'));
+		assert.ok(result.content.includes('{ _id: "asc" }'));
+	});
+
+	it("uses search_after for cursor pagination", () => {
+		const projection = makeProjection({ fields: [] });
+		const result = emitGraphQLResolver(projection, defaultOptions);
+
+		assert.ok(result.content.includes("search_after"));
+		assert.ok(result.content.includes("base64Decode"));
+		assert.ok(result.content.includes("base64Encode"));
+	});
+});

--- a/src/emit-graphql-resolver.ts
+++ b/src/emit-graphql-resolver.ts
@@ -1,0 +1,168 @@
+import { toGraphQLQueryFieldName } from "./emit-graphql-sdl.js";
+import type {
+	ResolvedProjection,
+	ResolvedProjectionField,
+} from "./projection.js";
+import { toKebabCase } from "./utils.js";
+
+export interface EmittedResolverFile {
+	fileName: string;
+	content: string;
+	queryFieldName: string;
+}
+
+export interface ResolverOptions {
+	defaultPageSize: number;
+	maxPageSize: number;
+	trackTotalHitsUpTo: number;
+}
+
+export function emitGraphQLResolver(
+	projection: ResolvedProjection,
+	options: ResolverOptions,
+): EmittedResolverFile {
+	const typeName = projection.projectionModel.name;
+	const queryFieldName = toGraphQLQueryFieldName(typeName);
+	const fileName = `${toKebabCase(typeName)}-resolver.js`;
+
+	const textFields = projection.fields
+		.filter(
+			(f) => !f.keyword && !f.nested && !f.subProjection && hasTextType(f),
+		)
+		.map((f) => f.projectedName ?? f.name);
+
+	const keywordFields = projection.fields
+		.filter((f) => f.keyword)
+		.map((f) => f.projectedName ?? f.name);
+
+	const content = renderResolver(
+		projection.indexName,
+		textFields,
+		keywordFields,
+		options,
+	);
+
+	return {
+		fileName,
+		content,
+		queryFieldName,
+	};
+}
+
+function hasTextType(field: ResolvedProjectionField): boolean {
+	const type = field.type;
+	if (type.kind === "Scalar") {
+		let current = type;
+		while (current) {
+			if (current.name === "string") return true;
+			if (!current.baseScalar) break;
+			current = current.baseScalar;
+		}
+	}
+	return type.kind === "String";
+}
+
+function renderResolver(
+	indexName: string,
+	textFields: string[],
+	keywordFields: string[],
+	options: ResolverOptions,
+): string {
+	const textFieldsLiteral = JSON.stringify(textFields);
+	const keywordFieldsLiteral = JSON.stringify(keywordFields);
+
+	return `import { util } from "@aws-appsync/utils";
+
+export function request(ctx) {
+	const args = ctx.args;
+	const size = Math.min(args.first || ${options.defaultPageSize}, ${options.maxPageSize});
+	const searchAfter = args.after ? JSON.parse(util.base64Decode(args.after)) : undefined;
+
+	const query = buildQuery(args.query, args.filter);
+
+	const body = {
+		size: size + 1,
+		track_total_hits: ${options.trackTotalHitsUpTo},
+		sort: [{ _score: "desc" }, { _id: "asc" }],
+		query,
+	};
+
+	if (searchAfter) {
+		body.search_after = searchAfter;
+	}
+
+	return {
+		operation: "GET",
+		path: \`/${indexName}/_search\`,
+		params: { body: JSON.stringify(body) },
+	};
+}
+
+export function response(ctx) {
+	if (ctx.error) {
+		return util.error(ctx.error.message, ctx.error.type);
+	}
+
+	const body = JSON.parse(ctx.result.body);
+	const hits = body.hits.hits;
+	const totalHits = body.hits.total.value;
+	const args = ctx.args;
+	const size = Math.min(args.first || ${options.defaultPageSize}, ${options.maxPageSize});
+
+	const hasNextPage = hits.length > size;
+	const edges = hits.slice(0, size).map((hit) => ({
+		node: hit._source,
+		cursor: util.base64Encode(JSON.stringify(hit.sort)),
+	}));
+
+	return {
+		edges,
+		pageInfo: {
+			hasNextPage,
+			endCursor: edges.length > 0 ? edges[edges.length - 1].cursor : null,
+		},
+		totalHits,
+	};
+}
+
+function buildQuery(queryText, filter) {
+	const musts = [];
+	const filters = [];
+
+	if (queryText) {
+		musts.push({
+			multi_match: {
+				query: queryText,
+				fields: ${textFieldsLiteral},
+				type: "best_fields",
+			},
+		});
+	}
+
+	const keywordFields = ${keywordFieldsLiteral};
+	if (filter) {
+		for (const field of keywordFields) {
+			if (filter[field] != null) {
+				filters.push({ term: { [field]: filter[field] } });
+			}
+		}
+	}
+
+	if (musts.length === 0 && filters.length === 0) {
+		return { match_all: {} };
+	}
+
+	return {
+		bool: {
+			...(musts.length > 0 ? { must: musts } : {}),
+			...(filters.length > 0 ? { filter: filters } : {}),
+		},
+	};
+}
+`;
+}
+
+export const __test = {
+	hasTextType,
+	renderResolver,
+};

--- a/src/emit-graphql-sdl.test.ts
+++ b/src/emit-graphql-sdl.test.ts
@@ -1,0 +1,179 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { Scalar, Type, Union } from "@typespec/compiler";
+import {
+	__test,
+	emitGraphQLSdl,
+	toGraphQLQueryFieldName,
+} from "./emit-graphql-sdl.js";
+import type { ResolvedProjection } from "./projection.js";
+
+function makeProjection(
+	overrides: Partial<{
+		name: string;
+		sourceName: string;
+		indexName: string;
+		fields: ResolvedProjection["fields"];
+	}> = {},
+): ResolvedProjection {
+	return {
+		projectionModel: { name: overrides.name ?? "PetSearchDoc" },
+		sourceModel: { name: overrides.sourceName ?? "Pet" },
+		indexName: overrides.indexName ?? "pets_v1",
+		fields: overrides.fields ?? [],
+	} as unknown as ResolvedProjection;
+}
+
+function makeField(
+	overrides: Partial<{
+		name: string;
+		projectedName: string;
+		keyword: boolean;
+		nested: boolean;
+		optional: boolean;
+		analyzer: string;
+		boost: number;
+		type: Type;
+		subProjection: ResolvedProjection;
+	}> = {},
+) {
+	return {
+		name: overrides.name ?? "field",
+		projectedName: overrides.projectedName,
+		keyword: overrides.keyword ?? false,
+		nested: overrides.nested ?? false,
+		optional: overrides.optional ?? false,
+		searchable: true,
+		analyzer: overrides.analyzer,
+		boost: overrides.boost,
+		type:
+			overrides.type ?? ({ kind: "Scalar", name: "string" } as unknown as Type),
+		subProjection: overrides.subProjection,
+	} as unknown as ResolvedProjection["fields"][0];
+}
+
+const dummyProgram = {} as never;
+const defaultOptions = { defaultPageSize: 20, maxPageSize: 100 };
+
+describe("emitGraphQLSdl", () => {
+	it("generates object type from projection fields", () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "name",
+					type: { kind: "Scalar", name: "string" } as unknown as Type,
+				}),
+				makeField({
+					name: "rank",
+					type: { kind: "Scalar", name: "int32" } as unknown as Type,
+				}),
+				makeField({
+					name: "active",
+					type: { kind: "Scalar", name: "boolean" } as unknown as Type,
+				}),
+			],
+		});
+
+		const result = emitGraphQLSdl(dummyProgram, projection, defaultOptions);
+
+		assert.equal(result.fileName, "pet-search-doc.graphql");
+		assert.ok(result.content.includes("type PetSearchDoc {"));
+		assert.ok(result.content.includes("name: String!"));
+		assert.ok(result.content.includes("rank: Int!"));
+		assert.ok(result.content.includes("active: Boolean!"));
+	});
+
+	it("marks optional fields as nullable", () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "breed",
+					optional: true,
+					type: { kind: "Scalar", name: "string" } as unknown as Type,
+				}),
+			],
+		});
+
+		const result = emitGraphQLSdl(dummyProgram, projection, defaultOptions);
+		assert.ok(result.content.includes("breed: String\n"));
+		assert.ok(!result.content.includes("breed: String!"));
+	});
+
+	it("generates filter input for keyword fields", () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({ name: "species", keyword: true }),
+				makeField({ name: "name" }),
+			],
+		});
+
+		const result = emitGraphQLSdl(dummyProgram, projection, defaultOptions);
+		assert.ok(result.content.includes("input PetSearchDocFilter {"));
+		assert.ok(result.content.includes("  species: String"));
+	});
+
+	it("omits filter input when no keyword fields", () => {
+		const projection = makeProjection({
+			fields: [makeField({ name: "name" })],
+		});
+
+		const result = emitGraphQLSdl(dummyProgram, projection, defaultOptions);
+		assert.ok(!result.content.includes("Filter"));
+	});
+
+	it("generates connection types", () => {
+		const projection = makeProjection({ fields: [] });
+
+		const result = emitGraphQLSdl(dummyProgram, projection, defaultOptions);
+		assert.ok(result.content.includes("type PetSearchDocConnection {"));
+		assert.ok(result.content.includes("edges: [PetSearchDocEdge!]!"));
+		assert.ok(result.content.includes("pageInfo: PageInfo!"));
+		assert.ok(result.content.includes("totalHits: Int!"));
+		assert.ok(result.content.includes("type PetSearchDocEdge {"));
+		assert.ok(result.content.includes("node: PetSearchDoc!"));
+		assert.ok(result.content.includes("cursor: String!"));
+		assert.ok(result.content.includes("type PageInfo {"));
+	});
+
+	it("uses projectedName in output type", () => {
+		const projection = makeProjection({
+			fields: [makeField({ name: "name", projectedName: "displayName" })],
+		});
+
+		const result = emitGraphQLSdl(dummyProgram, projection, defaultOptions);
+		assert.ok(result.content.includes("displayName: String!"));
+		assert.ok(!result.content.includes("  name:"));
+	});
+
+	it("renders sub-projection as nested type reference", () => {
+		const subProjection = makeProjection({ name: "TagSearchDoc" });
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "tags",
+					nested: true,
+					subProjection,
+					type: {
+						kind: "Model",
+						name: "Array",
+						indexer: { value: { kind: "Model" } },
+					} as unknown as Type,
+				}),
+			],
+		});
+
+		const result = emitGraphQLSdl(dummyProgram, projection, defaultOptions);
+		assert.ok(result.content.includes("tags: [TagSearchDoc!]!"));
+	});
+});
+
+describe("toGraphQLQueryFieldName", () => {
+	it("strips SearchDoc suffix and prefixes with search", () => {
+		assert.equal(toGraphQLQueryFieldName("PetSearchDoc"), "searchPet");
+		assert.equal(toGraphQLQueryFieldName("ProductSearchDoc"), "searchProduct");
+	});
+
+	it("handles names without SearchDoc suffix", () => {
+		assert.equal(toGraphQLQueryFieldName("Inventory"), "searchInventory");
+	});
+});

--- a/src/emit-graphql-sdl.ts
+++ b/src/emit-graphql-sdl.ts
@@ -1,0 +1,195 @@
+import type { Model, Program, Scalar, Type, Union } from "@typespec/compiler";
+import { getSearchAs, isSearchable } from "./decorators.js";
+import type {
+	ResolvedProjection,
+	ResolvedProjectionField,
+} from "./projection.js";
+import { toKebabCase } from "./utils.js";
+
+export interface EmittedGraphQLFile {
+	fileName: string;
+	content: string;
+}
+
+export interface GraphQLOptions {
+	defaultPageSize: number;
+	maxPageSize: number;
+}
+
+export function emitGraphQLSdl(
+	program: Program,
+	projection: ResolvedProjection,
+	options: GraphQLOptions,
+): EmittedGraphQLFile {
+	const typeName = projection.projectionModel.name;
+	const fileName = `${toKebabCase(typeName)}.graphql`;
+
+	const lines: string[] = [];
+
+	lines.push(renderObjectType(program, projection));
+	lines.push("");
+
+	const filterType = renderFilterInput(projection);
+	if (filterType) {
+		lines.push(filterType);
+		lines.push("");
+	}
+
+	lines.push(renderConnectionTypes(typeName));
+
+	return {
+		fileName,
+		content: `${lines.join("\n")}\n`,
+	};
+}
+
+function renderObjectType(
+	program: Program,
+	projection: ResolvedProjection,
+): string {
+	const typeName = projection.projectionModel.name;
+	const fieldLines = projection.fields.map((field) => {
+		const gqlName = field.projectedName ?? field.name;
+		const gqlType = toGraphQLType(program, field.type, field);
+		const nullable = field.optional ? "" : "!";
+		return `  ${gqlName}: ${gqlType}${nullable}`;
+	});
+
+	return `type ${typeName} {\n${fieldLines.join("\n")}\n}`;
+}
+
+function renderFilterInput(projection: ResolvedProjection): string | undefined {
+	const typeName = projection.projectionModel.name;
+	const keywordFields = projection.fields.filter((f) => f.keyword);
+
+	if (keywordFields.length === 0) {
+		return undefined;
+	}
+
+	const fieldLines = keywordFields.map((field) => {
+		const gqlName = field.projectedName ?? field.name;
+		return `  ${gqlName}: String`;
+	});
+
+	return `input ${typeName}Filter {\n${fieldLines.join("\n")}\n}`;
+}
+
+function renderConnectionTypes(typeName: string): string {
+	const lines = [
+		`type ${typeName}Connection {`,
+		`  edges: [${typeName}Edge!]!`,
+		"  pageInfo: PageInfo!",
+		"  totalHits: Int!",
+		"}",
+		"",
+		`type ${typeName}Edge {`,
+		`  node: ${typeName}!`,
+		"  cursor: String!",
+		"}",
+		"",
+		"type PageInfo {",
+		"  hasNextPage: Boolean!",
+		"  endCursor: String",
+		"}",
+	];
+
+	return lines.join("\n");
+}
+
+function toGraphQLType(
+	program: Program,
+	type: Type,
+	field?: ResolvedProjectionField,
+): string {
+	if (field?.subProjection) {
+		const subName = field.subProjection.projectionModel.name;
+		const isArray =
+			type.kind === "Model" && type.name === "Array" && !!type.indexer?.value;
+		return isArray ? `[${subName}!]` : subName;
+	}
+
+	switch (type.kind) {
+		case "Scalar":
+			return scalarToGraphQL(type);
+		case "Model":
+			return modelToGraphQL(program, type);
+		case "String":
+			return "String";
+		case "Number":
+			return "Float";
+		case "Boolean":
+			return "Boolean";
+		case "Union":
+			return unionToGraphQL(program, type);
+		case "Enum":
+			return "String";
+		default:
+			return "String";
+	}
+}
+
+function scalarToGraphQL(scalar: Scalar): string {
+	let current: Scalar | undefined = scalar;
+	while (current) {
+		switch (current.name) {
+			case "string":
+			case "plainDate":
+			case "utcDateTime":
+				return "String";
+			case "int32":
+			case "int64":
+			case "integer":
+			case "safeint":
+			case "uint8":
+			case "uint16":
+			case "uint32":
+			case "uint64":
+			case "int8":
+			case "int16":
+				return "Int";
+			case "float":
+			case "float32":
+			case "float64":
+			case "decimal":
+			case "numeric":
+			case "number":
+				return "Float";
+			case "boolean":
+				return "Boolean";
+		}
+		current = current.baseScalar;
+	}
+
+	return "String";
+}
+
+function modelToGraphQL(program: Program, model: Model): string {
+	if (model.name === "Array" && model.indexer?.value) {
+		const elementType = toGraphQLType(program, model.indexer.value);
+		return `[${elementType}!]`;
+	}
+
+	return "String";
+}
+
+function unionToGraphQL(program: Program, union: Union): string {
+	for (const variant of union.variants.values()) {
+		if (variant.type.kind === "Scalar" || variant.type.kind === "String") {
+			return toGraphQLType(program, variant.type);
+		}
+	}
+	return "String";
+}
+
+export function toGraphQLQueryFieldName(projectionModelName: string): string {
+	const name = projectionModelName.replace(/SearchDoc$/, "");
+	return `search${name}`;
+}
+
+export const __test = {
+	renderObjectType,
+	renderFilterInput,
+	renderConnectionTypes,
+	toGraphQLType,
+	toGraphQLQueryFieldName,
+};

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -10,6 +10,11 @@ import {
 	emitDocType,
 	toDocTypeFileName,
 } from "./emit-doc-type.js";
+import {
+	type EmittedResolverFile,
+	emitGraphQLResolver,
+} from "./emit-graphql-resolver.js";
+import { emitGraphQLSdl } from "./emit-graphql-sdl.js";
 import { emitIndex } from "./emit-index.js";
 import { emitMapping } from "./emit-mapping.js";
 import type { OpenSearchEmitterOptions } from "./lib.js";
@@ -96,6 +101,41 @@ export async function $onEmit(
 			content: tsConfigContent,
 		});
 	}
+
+	const graphqlOptions = context.options.graphql;
+	if (graphqlOptions?.emit) {
+		const pageOptions = {
+			defaultPageSize: graphqlOptions["default-page-size"] ?? 20,
+			maxPageSize: graphqlOptions["max-page-size"] ?? 100,
+		};
+		const resolverOptions = {
+			...pageOptions,
+			trackTotalHitsUpTo: graphqlOptions["track-total-hits-up-to"] ?? 10000,
+		};
+
+		const resolverFiles: EmittedResolverFile[] = [];
+
+		for (const projection of resolved) {
+			const sdlFile = emitGraphQLSdl(context.program, projection, pageOptions);
+			await emitFile(context.program, {
+				path: resolvePath(context.emitterOutputDir, sdlFile.fileName),
+				content: sdlFile.content,
+			});
+
+			const resolverFile = emitGraphQLResolver(projection, resolverOptions);
+			resolverFiles.push(resolverFile);
+			await emitFile(context.program, {
+				path: resolvePath(context.emitterOutputDir, resolverFile.fileName),
+				content: resolverFile.content,
+			});
+		}
+
+		const manifest = generateGraphQLManifest(resolved, resolverFiles);
+		await emitFile(context.program, {
+			path: resolvePath(context.emitterOutputDir, "graphql-resolvers.json"),
+			content: manifest,
+		});
+	}
 }
 
 function collectProjectionModels(
@@ -171,6 +211,24 @@ function serializeProjections(resolved: ResolvedProjection[]) {
 	};
 }
 
+function generateGraphQLManifest(
+	projections: ResolvedProjection[],
+	resolverFiles: EmittedResolverFile[],
+): string {
+	const resolvers = projections.map((projection, i) => {
+		const resolver = resolverFiles[i];
+		return {
+			projection: projection.projectionModel.name,
+			indexName: projection.indexName,
+			queryFieldName: resolver.queryFieldName,
+			resolverFile: resolver.fileName,
+			sdlFile: `${toKebabCase(projection.projectionModel.name)}.graphql`,
+		};
+	});
+
+	return `${JSON.stringify({ resolvers }, null, 2)}\n`;
+}
+
 export const __test = {
 	collectProjectionModels,
 	isCandidateModel,
@@ -178,6 +236,7 @@ export const __test = {
 	serializeProjections,
 	generatePackageJson,
 	generateTsConfig,
+	generateGraphQLManifest,
 };
 
 function generateTsConfig(projections: ResolvedProjection[]): string {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,10 +1,18 @@
 import { createTypeSpecLibrary, paramMessage } from "@typespec/compiler";
 
+export interface GraphQLEmitterOptions {
+	emit?: boolean;
+	"default-page-size"?: number;
+	"max-page-size"?: number;
+	"track-total-hits-up-to"?: number;
+}
+
 export interface OpenSearchEmitterOptions {
 	"output-file"?: string;
 	"default-ignore-above"?: number;
 	"package-name"?: string;
 	"package-version"?: string;
+	graphql?: GraphQLEmitterOptions;
 }
 
 export const $lib = createTypeSpecLibrary({
@@ -92,6 +100,29 @@ export const $lib = createTypeSpecLibrary({
 				},
 				"package-name": { type: "string", nullable: true },
 				"package-version": { type: "string", nullable: true },
+				graphql: {
+					type: "object",
+					nullable: true,
+					properties: {
+						emit: { type: "boolean", nullable: true, default: false },
+						"default-page-size": {
+							type: "number",
+							nullable: true,
+							default: 20,
+						},
+						"max-page-size": {
+							type: "number",
+							nullable: true,
+							default: 100,
+						},
+						"track-total-hits-up-to": {
+							type: "number",
+							nullable: true,
+							default: 10000,
+						},
+					},
+					additionalProperties: false,
+				},
 			},
 			required: [],
 		},


### PR DESCRIPTION
Closes #64

## What

Adds two new emit targets behind the `graphql.emit` option flag:

### `graphql-sdl` — per-projection `.graphql` fragment
- GraphQL object type derived 1:1 from the search-doc interface
- `*Filter` input type with optional argument per `keyword` field (term match)
- `Connection` / `Edge` / `PageInfo` envelope with opaque cursor pagination (`search_after`)
- Free-text `query: String` matched across all `text` fields via `multi_match`

### `graphql-resolver` — per-operation APPSYNC_JS `.js` file
- `request(ctx)` builds the OpenSearch search body
- `response(ctx)` projects hits into Connection shape
- Sort fixed at `[_score desc, _id asc]` for deterministic `search_after` tie-break
- Respects APPSYNC_JS constraints (single `@aws-appsync/utils` import, no network I/O)

### `graphql-resolvers.json` manifest
Maps each projection to its resolver file, SDL file, query field name, and index name.

## Configuration

```yaml
graphql:
  emit: true          # default: false
  default-page-size: 20
  max-page-size: 100
  track-total-hits-up-to: 10000
```

Existing emitter behavior **unchanged** when `graphql.emit` is false (default).

## Tests

- 19 new unit tests covering SDL emission, resolver emission, OpenSearch request body shape, pagination, field classification
- All 114 unit tests + 4 integration tests pass