### PR TITLE
feat(emitter): add graphql exports to package.json and JS entry point

### DIFF
--- a/src/emitter.test.ts
+++ b/src/emitter.test.ts
@@ -260,6 +260,63 @@ describe("generatePackageJson", () => {
 		assert.equal(exportKeys.length, 1);
 		assert.equal(exportKeys[0], ".");
 	});
+
+	it("includes graphql artifact exports when graphqlProjections provided", () => {
+		const projections = [
+			{
+				projectionModel: { name: "ProductSearchDoc" },
+				sourceModel: { name: "Product" },
+				indexName: "product_search_doc",
+				fields: [],
+			},
+		] as unknown as ResolvedProjection[];
+
+		const result = JSON.parse(
+			__test.generatePackageJson("@my/pkg", "1.0.0", projections, projections),
+		);
+
+		assert.equal(
+			result.exports["./graphql-resolvers.json"],
+			"./graphql-resolvers.json",
+		);
+		assert.equal(
+			result.exports["./graphql-resolvers.js"],
+			"./graphql-resolvers.js",
+		);
+		assert.equal(
+			result.exports["./product-search-doc.graphql"],
+			"./product-search-doc.graphql",
+		);
+		assert.equal(
+			result.exports["./product-search-doc-resolver.js"],
+			"./product-search-doc-resolver.js",
+		);
+	});
+
+	it("sorts all exports including graphql artifacts", () => {
+		const projections = [
+			{
+				projectionModel: { name: "ZetaSearchDoc" },
+				sourceModel: { name: "Zeta" },
+				indexName: "zeta",
+				fields: [],
+			},
+			{
+				projectionModel: { name: "AlphaSearchDoc" },
+				sourceModel: { name: "Alpha" },
+				indexName: "alpha",
+				fields: [],
+			},
+		] as unknown as ResolvedProjection[];
+
+		const result = JSON.parse(
+			__test.generatePackageJson("@my/pkg", "2.0.0", projections, projections),
+		);
+		const exportKeys = Object.keys(result.exports).filter((k) => k !== ".");
+
+		const sortedKeys = [...exportKeys].sort();
+		assert.deepEqual(exportKeys, sortedKeys);
+	});
 });
 
 describe("generateTsConfig", () => {
@@ -315,6 +372,17 @@ describe("generateTsConfig", () => {
 	it("returns tsconfig with only index.ts when no projections", () => {
 		const result = JSON.parse(__test.generateTsConfig([]));
 		assert.deepEqual(result.include, ["index.ts"]);
+	});
+});
+
+describe("generateGraphQLEntryPoint", () => {
+	it("generates a JS module that exports manifest and packageDir", () => {
+		const result = __test.generateGraphQLEntryPoint();
+
+		assert.ok(result.includes("export const packageDir"));
+		assert.ok(result.includes("export const manifest"));
+		assert.ok(result.includes("export default manifest"));
+		assert.ok(result.includes("graphql-resolvers.json"));
 	});
 });
 

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -281,15 +281,13 @@ function generateTsConfig(projections: ResolvedProjection[]): string {
 }
 
 function generateGraphQLEntryPoint(): string {
-	return `import { createRequire } from "node:module";
-import { dirname } from "node:path";
+	return `import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const require = createRequire(import.meta.url);
-const manifestPath = require.resolve("./graphql-resolvers.json");
 export const packageDir = dirname(fileURLToPath(import.meta.url));
 export const manifest = JSON.parse(
-  (await import("node:fs")).readFileSync(manifestPath, "utf-8")
+  readFileSync(join(packageDir, "graphql-resolvers.json"), "utf-8")
 );
 export default manifest;
 `;

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -83,25 +83,6 @@ export async function $onEmit(
 
 	const packageName = context.options["package-name"];
 	const packageVersion = context.options["package-version"];
-
-	if (packageName && packageVersion) {
-		const packageJsonContent = generatePackageJson(
-			packageName,
-			packageVersion,
-			resolved,
-		);
-		await emitFile(context.program, {
-			path: resolvePath(context.emitterOutputDir, "package.json"),
-			content: packageJsonContent,
-		});
-
-		const tsConfigContent = generateTsConfig(resolved);
-		await emitFile(context.program, {
-			path: resolvePath(context.emitterOutputDir, "tsconfig.json"),
-			content: tsConfigContent,
-		});
-	}
-
 	const graphqlOptions = context.options.graphql;
 	if (graphqlOptions?.emit) {
 		const pageOptions = {
@@ -134,6 +115,32 @@ export async function $onEmit(
 		await emitFile(context.program, {
 			path: resolvePath(context.emitterOutputDir, "graphql-resolvers.json"),
 			content: manifest,
+		});
+
+		const entryPoint = generateGraphQLEntryPoint();
+		await emitFile(context.program, {
+			path: resolvePath(context.emitterOutputDir, "graphql-resolvers.js"),
+			content: entryPoint,
+		});
+	}
+
+	if (packageName && packageVersion) {
+		const graphqlArtifacts = graphqlOptions?.emit ? resolved : undefined;
+		const packageJsonContent = generatePackageJson(
+			packageName,
+			packageVersion,
+			resolved,
+			graphqlArtifacts,
+		);
+		await emitFile(context.program, {
+			path: resolvePath(context.emitterOutputDir, "package.json"),
+			content: packageJsonContent,
+		});
+
+		const tsConfigContent = generateTsConfig(resolved);
+		await emitFile(context.program, {
+			path: resolvePath(context.emitterOutputDir, "tsconfig.json"),
+			content: tsConfigContent,
 		});
 	}
 }
@@ -237,6 +244,7 @@ export const __test = {
 	generatePackageJson,
 	generateTsConfig,
 	generateGraphQLManifest,
+	generateGraphQLEntryPoint,
 };
 
 function generateTsConfig(projections: ResolvedProjection[]): string {
@@ -272,20 +280,46 @@ function generateTsConfig(projections: ResolvedProjection[]): string {
 	return `${JSON.stringify(tsConfig, null, 2)}\n`;
 }
 
+function generateGraphQLEntryPoint(): string {
+	return `import { createRequire } from "node:module";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+const manifestPath = require.resolve("./graphql-resolvers.json");
+export const packageDir = dirname(fileURLToPath(import.meta.url));
+export const manifest = JSON.parse(
+  (await import("node:fs")).readFileSync(manifestPath, "utf-8")
+);
+export default manifest;
+`;
+}
+
 function generatePackageJson(
 	packageName: string,
 	packageVersion: string,
 	projections: ResolvedProjection[],
+	graphqlProjections?: ResolvedProjection[],
 ): string {
-	const mappingExports: Record<string, string> = {};
+	const artifactExports: Record<string, string> = {};
 
 	for (const projection of projections) {
 		const baseName = `${toKebabCase(projection.projectionModel.name)}-search-mapping`;
-		mappingExports[`./${baseName}.json`] = `./${baseName}.json`;
+		artifactExports[`./${baseName}.json`] = `./${baseName}.json`;
+	}
+
+	if (graphqlProjections) {
+		artifactExports["./graphql-resolvers.json"] = "./graphql-resolvers.json";
+		artifactExports["./graphql-resolvers.js"] = "./graphql-resolvers.js";
+		for (const projection of graphqlProjections) {
+			const kebab = toKebabCase(projection.projectionModel.name);
+			artifactExports[`./${kebab}.graphql`] = `./${kebab}.graphql`;
+			artifactExports[`./${kebab}-resolver.js`] = `./${kebab}-resolver.js`;
+		}
 	}
 
 	const sorted = Object.fromEntries(
-		Object.entries(mappingExports).sort(([a], [b]) => a.localeCompare(b)),
+		Object.entries(artifactExports).sort(([a], [b]) => a.localeCompare(b)),
 	);
 
 	const packageJson = {


### PR DESCRIPTION
## Changes

### GraphQL artifact exports in package.json (#66)

When `graphql.emit: true`, the generated `package.json` now includes exports entries for all GraphQL artifacts:
- `./graphql-resolvers.json` — the manifest
- `./graphql-resolvers.js` — JS entry point (see #67)
- `./<name>.graphql` — SDL fragments
- `./<name>-resolver.js` — resolver files

This removes the need for post-build `jq` scripts to augment the exports map.

### JS entry point for manifest and packageDir (#67)

Emits a `graphql-resolvers.js` module that exports:
- `manifest` — parsed contents of `graphql-resolvers.json`
- `packageDir` — resolved directory path of the package
- `default` — alias for `manifest`

Consumers can now do:
```ts
import { manifest, packageDir } from "@stxgroup/cos-search-graphql/graphql-resolvers.js";
```

instead of the `require.resolve` + `readFileSync` dance.

Closes #66, closes #67