### PR TITLE
fix: don't pre-stringify params.body for APPSYNC_JS OpenSearch resolvers

### DIFF
--- a/src/emit-graphql-resolver.ts
+++ b/src/emit-graphql-resolver.ts
@@ -94,7 +94,7 @@ export function request(ctx) {
 	return {
 		operation: "GET",
 		path: \`/${indexName}/_search\`,
-		params: { body: JSON.stringify(body) },
+		params: { body },
 	};
 }
 


### PR DESCRIPTION
Drop the `JSON.stringify` on `params.body` so AppSync's APPSYNC_JS runtime can serialize the OpenSearch search payload itself. Closes #69.