### PR TITLE
fix: rename response body var to avoid APPSYNC_JS scoping conflict

### DIFF
--- a/src/emit-graphql-resolver.ts
+++ b/src/emit-graphql-resolver.ts
@@ -103,9 +103,9 @@ export function response(ctx) {
 		return util.error(ctx.error.message, ctx.error.type);
 	}
 
-	const body = JSON.parse(ctx.result.body);
-	const hits = body.hits.hits;
-	const totalHits = body.hits.total.value;
+	const parsedBody = JSON.parse(ctx.result.body);
+	const hits = parsedBody.hits.hits;
+	const totalHits = parsedBody.hits.total.value;
 	const args = ctx.args;
 	const size = Math.min(args.first || ${options.defaultPageSize}, ${options.maxPageSize});
 


### PR DESCRIPTION
Rename the response-side `body` local to `parsedBody` so the APPSYNC_JS bundler doesn't throw `ReferenceError: body is not defined` on the next-line property access — companion fix to #70 (request-side); reproduced live by hot-patching a deployed resolver in dev.