### PR TITLE
fix: response handler reads ctx.result directly, not ctx.result.body

### DIFF
--- a/src/emit-graphql-resolver.ts
+++ b/src/emit-graphql-resolver.ts
@@ -103,7 +103,7 @@ export function response(ctx) {
 		return util.error(ctx.error.message, ctx.error.type);
 	}
 
-	const parsedBody = JSON.parse(ctx.result.body);
+	const parsedBody = ctx.result;
 	const hits = parsedBody.hits.hits;
 	const totalHits = parsedBody.hits.total.value;
 	const args = ctx.args;


### PR DESCRIPTION
AppSync's APPSYNC_JS runtime passes the OpenSearch data-source response as `ctx.result` (already parsed), so the response handler must read `ctx.result` directly rather than `JSON.parse(ctx.result.body)` — verified live by hot-patching a deployed resolver, queries returned real data only after this change.