### PR TITLE
feat: expose totalCount on search connection types

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,8 +359,8 @@ input PetSearchDocFilter {
 
 type PetSearchDocConnection {
   edges: [PetSearchDocEdge!]!
+  totalCount: Int!
   pageInfo: PageInfo!
-  totalHits: Int!
 }
 
 type PetSearchDocEdge {

--- a/src/emit-graphql-resolver.ts
+++ b/src/emit-graphql-resolver.ts
@@ -117,11 +117,11 @@ export function response(ctx) {
 
 	return {
 		edges,
+		totalCount: totalHits,
 		pageInfo: {
 			hasNextPage,
 			endCursor: edges.length > 0 ? edges[edges.length - 1].cursor : null,
 		},
-		totalHits,
 	};
 }
 

--- a/src/emit-graphql-sdl.test.ts
+++ b/src/emit-graphql-sdl.test.ts
@@ -128,7 +128,7 @@ describe("emitGraphQLSdl", () => {
 		assert.ok(result.content.includes("type PetSearchDocConnection {"));
 		assert.ok(result.content.includes("edges: [PetSearchDocEdge!]!"));
 		assert.ok(result.content.includes("pageInfo: PageInfo!"));
-		assert.ok(result.content.includes("totalHits: Int!"));
+		assert.ok(result.content.includes("totalCount: Int!"));
 		assert.ok(result.content.includes("type PetSearchDocEdge {"));
 		assert.ok(result.content.includes("node: PetSearchDoc!"));
 		assert.ok(result.content.includes("cursor: String!"));

--- a/src/emit-graphql-sdl.ts
+++ b/src/emit-graphql-sdl.ts
@@ -78,8 +78,8 @@ function renderConnectionTypes(typeName: string): string {
 	const lines = [
 		`type ${typeName}Connection {`,
 		`  edges: [${typeName}Edge!]!`,
+		"  totalCount: Int!",
 		"  pageInfo: PageInfo!",
-		"  totalHits: Int!",
 		"}",
 		"",
 		`type ${typeName}Edge {`,


### PR DESCRIPTION
Expose `totalCount: Int!` on every generated `*SearchDocConnection` so consumers can read the OpenSearch hit total (`parsedBody.hits.total.value`) that the response handler already computes — eliminates the need for a separate count query.