### PR TITLE
feat(emitter): add @aggregatable for terms, cardinality, missing aggs

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ In this example:
 | `@indexName("name")` | `Model` (projection) | Sets an explicit index name for the projection. | `@indexName("pets_v1") model PetSearchDoc ...` |
 | `@indexSettings(json)` | `Model` (projection) | Embeds index settings (e.g. analysis config) in the mapping output. Value must be valid JSON. | See example below. |
 | `@searchAs("name")` | `ModelProperty` | Renames the field in mapping and TypeScript output. Can be set on source or projection (projection wins). | `@searchAs("firstName") givenName: string;` |
+| `@aggregatable(...kinds)` | `ModelProperty` | Declares OpenSearch aggregations to expose on the GraphQL connection. Allowed kinds: `"terms"`, `"cardinality"`, `"missing"`. Multi-arg emits all listed kinds. | `@aggregatable("terms", "cardinality") locations: Location[];` |
 
 ## Type mapping
 
@@ -406,6 +407,30 @@ Maps each projection to its resolver file, SDL file, query field name, and index
 ```
 
 The consuming CDK construct can read this manifest to wire resolvers without hardcoded knowledge.
+
+### Aggregations (`@aggregatable`)
+
+Annotate fields with `@aggregatable("terms" | "cardinality" | "missing", ...)` to expose OpenSearch aggregations on the connection's `aggregations` field. The aggregations run alongside the search query (no separate request).
+
+```typespec
+model Counterparty {
+  @searchable @aggregatable("terms") tags: string[];
+  @searchable @aggregatable("terms", "cardinality") locations: string[];
+  @searchable @aggregatable("missing") description?: string;
+}
+```
+
+Field-name conventions in the generated `*SearchAggregations` type (singular `<Field>`, e.g. `tags` -> `byTag`):
+
+| Aggregation kind | Generated field | GraphQL type |
+| --- | --- | --- |
+| `terms` | `by<Field>` | `[TermBucket!]!` |
+| `cardinality` | `unique<Field>Count` | `Int!` |
+| `missing` | `missing<Field>Count` | `Int!` |
+
+The `.keyword` sub-field is applied automatically when the underlying type is text. Numeric, date, and `@keyword` fields use the bare field name.
+
+When no field on a projection is `@aggregatable`, the `aggregations` connection field and aggregation types are omitted (no empty types emitted).
 
 ### Conventions
 

--- a/src/aggregations.test.ts
+++ b/src/aggregations.test.ts
@@ -1,0 +1,293 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { Type } from "@typespec/compiler";
+import {
+	__test,
+	aggregationsTypeName,
+	collectAggregations,
+	hasAggregations,
+} from "./aggregations.js";
+import type { ResolvedProjection } from "./projection.js";
+
+const { aggregationFieldName, singularize, capitalize, isTextField } = __test;
+
+function makeProjection(
+	overrides: Partial<{
+		name: string;
+		fields: ResolvedProjection["fields"];
+	}> = {},
+): ResolvedProjection {
+	return {
+		projectionModel: { name: overrides.name ?? "PetSearchDoc" },
+		sourceModel: { name: "Pet" },
+		indexName: "pets_v1",
+		fields: overrides.fields ?? [],
+	} as unknown as ResolvedProjection;
+}
+
+function makeField(
+	overrides: Partial<{
+		name: string;
+		projectedName: string;
+		keyword: boolean;
+		nested: boolean;
+		optional: boolean;
+		type: Type;
+		aggregations: ResolvedProjection["fields"][0]["aggregations"];
+		subProjection: ResolvedProjection;
+	}> = {},
+) {
+	return {
+		name: overrides.name ?? "field",
+		projectedName: overrides.projectedName,
+		keyword: overrides.keyword ?? false,
+		nested: overrides.nested ?? false,
+		optional: overrides.optional ?? false,
+		searchable: true,
+		type:
+			overrides.type ?? ({ kind: "Scalar", name: "string" } as unknown as Type),
+		aggregations: overrides.aggregations,
+		subProjection: overrides.subProjection,
+	} as unknown as ResolvedProjection["fields"][0];
+}
+
+describe("aggregationFieldName", () => {
+	it("emits byField for terms with plural drop", () => {
+		assert.equal(aggregationFieldName("tags", "terms"), "byTag");
+		assert.equal(aggregationFieldName("groups", "terms"), "byGroup");
+		assert.equal(aggregationFieldName("locations", "terms"), "byLocation");
+	});
+
+	it("emits uniqueFieldCount for cardinality", () => {
+		assert.equal(
+			aggregationFieldName("locations", "cardinality"),
+			"uniqueLocationCount",
+		);
+		assert.equal(aggregationFieldName("tags", "cardinality"), "uniqueTagCount");
+	});
+
+	it("emits missingFieldCount for missing", () => {
+		assert.equal(
+			aggregationFieldName("description", "missing"),
+			"missingDescriptionCount",
+		);
+	});
+
+	it("handles non-plural names", () => {
+		assert.equal(aggregationFieldName("description", "terms"), "byDescription");
+	});
+
+	it("handles -ies plural", () => {
+		assert.equal(aggregationFieldName("categories", "terms"), "byCategory");
+	});
+});
+
+describe("singularize", () => {
+	it("drops trailing s", () => {
+		assert.equal(singularize("tags"), "tag");
+	});
+
+	it("converts -ies to -y", () => {
+		assert.equal(singularize("categories"), "category");
+	});
+
+	it("preserves non-plurals", () => {
+		assert.equal(singularize("description"), "description");
+	});
+
+	it("converts -es endings (sxz)", () => {
+		assert.equal(singularize("statuses"), "status");
+		assert.equal(singularize("boxes"), "box");
+	});
+
+	it("preserves -ss endings", () => {
+		assert.equal(singularize("address"), "address");
+		assert.equal(singularize("class"), "class");
+	});
+});
+
+describe("capitalize", () => {
+	it("uppercases first letter", () => {
+		assert.equal(capitalize("tag"), "Tag");
+	});
+
+	it("handles empty string", () => {
+		assert.equal(capitalize(""), "");
+	});
+});
+
+describe("aggregationsTypeName", () => {
+	it("strips SearchDoc and adds SearchAggregations", () => {
+		assert.equal(
+			aggregationsTypeName("CounterpartySearchDoc"),
+			"CounterpartySearchAggregations",
+		);
+		assert.equal(aggregationsTypeName("PetSearchDoc"), "PetSearchAggregations");
+	});
+
+	it("handles names without SearchDoc suffix", () => {
+		assert.equal(aggregationsTypeName("Pet"), "PetSearchAggregations");
+	});
+});
+
+describe("hasAggregations", () => {
+	it("returns true when any field has aggregations", () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({ name: "name" }),
+				makeField({ name: "tags", aggregations: ["terms"] }),
+			],
+		});
+		assert.equal(hasAggregations(projection), true);
+	});
+
+	it("returns false when no fields have aggregations", () => {
+		const projection = makeProjection({
+			fields: [makeField({ name: "name" })],
+		});
+		assert.equal(hasAggregations(projection), false);
+	});
+
+	it("returns false when aggregations array is empty", () => {
+		const projection = makeProjection({
+			fields: [makeField({ name: "tags", aggregations: [] })],
+		});
+		assert.equal(hasAggregations(projection), false);
+	});
+});
+
+describe("collectAggregations", () => {
+	it("returns empty list when no aggregations", () => {
+		const projection = makeProjection({
+			fields: [makeField({ name: "name" })],
+		});
+		assert.deepEqual(collectAggregations(projection), []);
+	});
+
+	it("expands multi-kind aggregations into separate entries", () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "locations",
+					keyword: true,
+					aggregations: ["terms", "cardinality"],
+				}),
+			],
+		});
+
+		const entries = collectAggregations(projection);
+		assert.equal(entries.length, 2);
+		assert.equal(entries[0].kind, "terms");
+		assert.equal(entries[0].aggName, "byLocation");
+		assert.equal(entries[1].kind, "cardinality");
+		assert.equal(entries[1].aggName, "uniqueLocationCount");
+	});
+
+	it("appends .keyword for text string fields", () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "tags",
+					aggregations: ["terms"],
+					type: { kind: "Scalar", name: "string" } as unknown as Type,
+				}),
+			],
+		});
+
+		const entries = collectAggregations(projection);
+		assert.equal(entries[0].openSearchField, "tags.keyword");
+	});
+
+	it("appends .keyword for arrays of strings", () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "tags",
+					aggregations: ["terms"],
+					type: {
+						kind: "Model",
+						name: "Array",
+						indexer: { value: { kind: "Scalar", name: "string" } },
+					} as unknown as Type,
+				}),
+			],
+		});
+
+		const entries = collectAggregations(projection);
+		assert.equal(entries[0].openSearchField, "tags.keyword");
+	});
+
+	it("uses bare field name for keyword fields", () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "species",
+					keyword: true,
+					aggregations: ["terms"],
+				}),
+			],
+		});
+
+		const entries = collectAggregations(projection);
+		assert.equal(entries[0].openSearchField, "species");
+	});
+
+	it("uses bare field name for numeric fields", () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "rank",
+					aggregations: ["terms"],
+					type: { kind: "Scalar", name: "int32" } as unknown as Type,
+				}),
+			],
+		});
+
+		const entries = collectAggregations(projection);
+		assert.equal(entries[0].openSearchField, "rank");
+	});
+
+	it("uses projectedName when present", () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "tags",
+					projectedName: "labels",
+					aggregations: ["terms"],
+				}),
+			],
+		});
+
+		const entries = collectAggregations(projection);
+		assert.equal(entries[0].openSearchField, "labels.keyword");
+		assert.equal(entries[0].aggName, "byLabel");
+	});
+});
+
+describe("isTextField", () => {
+	it("returns false for keyword fields", () => {
+		assert.equal(isTextField(makeField({ keyword: true })), false);
+	});
+
+	it("returns true for plain string scalar", () => {
+		assert.equal(
+			isTextField(
+				makeField({
+					type: { kind: "Scalar", name: "string" } as unknown as Type,
+				}),
+			),
+			true,
+		);
+	});
+
+	it("returns false for date scalars", () => {
+		assert.equal(
+			isTextField(
+				makeField({
+					type: { kind: "Scalar", name: "plainDate" } as unknown as Type,
+				}),
+			),
+			false,
+		);
+	});
+});

--- a/src/aggregations.ts
+++ b/src/aggregations.ts
@@ -1,0 +1,142 @@
+import type { AggregationKind } from "./decorators.js";
+import type {
+	ResolvedProjection,
+	ResolvedProjectionField,
+} from "./projection.js";
+
+export interface AggregationEntry {
+	field: ResolvedProjectionField;
+	kind: AggregationKind;
+	aggName: string;
+	openSearchField: string;
+	useTextType: boolean;
+}
+
+export function collectAggregations(
+	projection: ResolvedProjection,
+): AggregationEntry[] {
+	const entries: AggregationEntry[] = [];
+
+	for (const field of projection.fields) {
+		if (!field.aggregations || field.aggregations.length === 0) {
+			continue;
+		}
+
+		const projectedName = field.projectedName ?? field.name;
+		const useTextType = isTextField(field);
+		const openSearchField = useTextType
+			? `${projectedName}.keyword`
+			: projectedName;
+
+		for (const kind of field.aggregations) {
+			entries.push({
+				field,
+				kind,
+				aggName: aggregationFieldName(projectedName, kind),
+				openSearchField,
+				useTextType,
+			});
+		}
+	}
+
+	return entries;
+}
+
+export function hasAggregations(projection: ResolvedProjection): boolean {
+	return projection.fields.some(
+		(field) => field.aggregations && field.aggregations.length > 0,
+	);
+}
+
+export function aggregationsTypeName(projectionName: string): string {
+	const base = projectionName.replace(/SearchDoc$/, "");
+	return `${base}SearchAggregations`;
+}
+
+export function aggregationFieldName(
+	fieldName: string,
+	kind: AggregationKind,
+): string {
+	const singular = singularize(fieldName);
+	const capital = capitalize(singular);
+	switch (kind) {
+		case "terms":
+			return `by${capital}`;
+		case "cardinality":
+			return `unique${capital}Count`;
+		case "missing":
+			return `missing${capital}Count`;
+	}
+}
+
+function singularize(name: string): string {
+	if (name.endsWith("ies") && name.length > 3) {
+		return `${name.slice(0, -3)}y`;
+	}
+	if (name.endsWith("ses") || name.endsWith("xes") || name.endsWith("zes")) {
+		return name.slice(0, -2);
+	}
+	if (name.endsWith("s") && !name.endsWith("ss") && name.length > 1) {
+		return name.slice(0, -1);
+	}
+	return name;
+}
+
+function capitalize(name: string): string {
+	if (name.length === 0) return name;
+	return name[0].toUpperCase() + name.slice(1);
+}
+
+function isTextField(field: ResolvedProjectionField): boolean {
+	if (field.keyword) {
+		return false;
+	}
+	if (field.subProjection) {
+		return false;
+	}
+	return isStringLikeType(field.type);
+}
+
+function isStringLikeType(type: ResolvedProjectionField["type"]): boolean {
+	if (type.kind === "String") {
+		return true;
+	}
+	if (type.kind === "Scalar") {
+		let current: typeof type | undefined = type;
+		while (current && current.kind === "Scalar") {
+			if (current.name === "string") {
+				return true;
+			}
+			if (current.name === "plainDate" || current.name === "utcDateTime") {
+				return false;
+			}
+			current = current.baseScalar;
+		}
+		return false;
+	}
+	if (type.kind === "Model" && type.name === "Array" && type.indexer?.value) {
+		const elementType = type.indexer.value;
+		if (elementType.kind === "String") {
+			return true;
+		}
+		if (elementType.kind === "Scalar") {
+			let current: typeof elementType | undefined = elementType;
+			while (current && current.kind === "Scalar") {
+				if (current.name === "string") return true;
+				if (current.name === "plainDate" || current.name === "utcDateTime") {
+					return false;
+				}
+				current = current.baseScalar;
+			}
+		}
+		return false;
+	}
+	return false;
+}
+
+export const __test = {
+	aggregationFieldName,
+	singularize,
+	capitalize,
+	isTextField,
+};

--- a/src/decorators.test.ts
+++ b/src/decorators.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 
 import { createTestHost, createTestWrapper } from "@typespec/compiler/testing";
 import {
+	getAggregatableKinds,
 	getAnalyzer,
 	getBoost,
 	getIgnoreAbove,
@@ -296,5 +297,80 @@ describe("decorators", () => {
 			hasDiagnosticCode(codes, "non-empty-search-as-required"),
 			true,
 		);
+	});
+
+	it("stores @aggregatable kinds with single argument", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Product {
+        @aggregatable("terms") @searchable tags: string[];
+      }
+    `);
+
+		assert.equal(diagnostics.length, 0);
+
+		const product = runner.program
+			.getGlobalNamespaceType()
+			.models.get("Product");
+		assert.ok(product);
+
+		const tags = product.properties.get("tags");
+		assert.ok(tags);
+		assert.deepEqual(getAggregatableKinds(runner.program, tags), ["terms"]);
+	});
+
+	it("stores @aggregatable kinds with multiple arguments", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Product {
+        @aggregatable("terms", "cardinality") @searchable locations: string[];
+      }
+    `);
+
+		assert.equal(diagnostics.length, 0);
+
+		const product = runner.program
+			.getGlobalNamespaceType()
+			.models.get("Product");
+		assert.ok(product);
+
+		const locations = product.properties.get("locations");
+		assert.ok(locations);
+		assert.deepEqual(getAggregatableKinds(runner.program, locations), [
+			"terms",
+			"cardinality",
+		]);
+	});
+
+	it("returns undefined when @aggregatable not used", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Product {
+        @searchable name: string;
+      }
+    `);
+
+		assert.equal(diagnostics.length, 0);
+
+		const product = runner.program
+			.getGlobalNamespaceType()
+			.models.get("Product");
+		assert.ok(product);
+
+		const name = product.properties.get("name");
+		assert.ok(name);
+		assert.equal(getAggregatableKinds(runner.program, name), undefined);
+	});
+
+	it("emits diagnostic for unknown @aggregatable kind", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Product {
+        @aggregatable("histogram") @searchable tags: string[];
+      }
+    `);
+
+		const codes = diagnostics.map((x) => x.code);
+		assert.equal(hasDiagnosticCode(codes, "invalid-aggregation-kind"), true);
 	});
 });

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -209,6 +209,56 @@ function isArrayOfModelType(type: Type): boolean {
 	return elementType?.kind === "Model";
 }
 
+export const AGGREGATION_KINDS = ["terms", "cardinality", "missing"] as const;
+export type AggregationKind = (typeof AGGREGATION_KINDS)[number];
+
+function isAggregationKind(value: string): value is AggregationKind {
+	return (AGGREGATION_KINDS as readonly string[]).includes(value);
+}
+
+export function $aggregatable(
+	context: DecoratorContext,
+	target: ModelProperty,
+	...kinds: string[]
+): void {
+	if (kinds.length === 0) {
+		reportDiagnostic(context.program, {
+			code: "aggregatable-requires-kind",
+			target,
+		});
+		return;
+	}
+
+	const validated: AggregationKind[] = [];
+	for (let index = 0; index < kinds.length; index++) {
+		const kind = kinds[index];
+		if (!isAggregationKind(kind)) {
+			reportDiagnostic(context.program, {
+				code: "invalid-aggregation-kind",
+				format: { kind },
+				target: context.getArgumentTarget(index) ?? target,
+			});
+			return;
+		}
+		if (!validated.includes(kind)) {
+			validated.push(kind);
+		}
+	}
+
+	context.program.stateMap(StateKeys.aggregatable).set(target, validated);
+}
+
+export function getAggregatableKinds(
+	program: Program,
+	target: ModelProperty,
+): AggregationKind[] | undefined {
+	const stored = program.stateMap(StateKeys.aggregatable).get(target);
+	if (!stored) {
+		return undefined;
+	}
+	return stored as AggregationKind[];
+}
+
 export function $searchAs(
 	context: DecoratorContext,
 	target: ModelProperty,

--- a/src/emit-graphql-resolver.test.ts
+++ b/src/emit-graphql-resolver.test.ts
@@ -27,6 +27,7 @@ function makeField(
 		nested: boolean;
 		optional: boolean;
 		type: Type;
+		aggregations: ResolvedProjection["fields"][0]["aggregations"];
 		subProjection: ResolvedProjection;
 	}> = {},
 ) {
@@ -43,6 +44,7 @@ function makeField(
 				kind: "Scalar",
 				name: "string",
 			} as unknown as Type),
+		aggregations: overrides.aggregations,
 		subProjection: overrides.subProjection,
 	} as unknown as ResolvedProjection["fields"][0];
 }
@@ -161,5 +163,114 @@ describe("emitGraphQLResolver", () => {
 		assert.ok(result.content.includes("search_after"));
 		assert.ok(result.content.includes("base64Decode"));
 		assert.ok(result.content.includes("base64Encode"));
+	});
+
+	it("omits aggs block when no aggregations", () => {
+		const projection = makeProjection({
+			fields: [makeField({ name: "name" })],
+		});
+		const result = emitGraphQLResolver(projection, defaultOptions);
+
+		assert.ok(!result.content.includes("aggs:"));
+		assert.ok(!result.content.includes("aggregations:"));
+	});
+
+	it("emits aggs block in request when fields have aggregations", () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "tags",
+					aggregations: ["terms"],
+					type: {
+						kind: "Model",
+						name: "Array",
+						indexer: { value: { kind: "Scalar", name: "string" } },
+					} as unknown as Type,
+				}),
+				makeField({
+					name: "species",
+					keyword: true,
+					aggregations: ["terms"],
+				}),
+			],
+		});
+		const result = emitGraphQLResolver(projection, defaultOptions);
+
+		assert.ok(result.content.includes("aggs:"));
+		assert.ok(
+			result.content.includes('byTag: { terms: { field: "tags.keyword" } }'),
+		);
+		assert.ok(
+			result.content.includes('bySpecy: { terms: { field: "species" } }'),
+		);
+	});
+
+	it("emits cardinality and missing aggs in request", () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "locations",
+					keyword: true,
+					aggregations: ["cardinality"],
+				}),
+				makeField({
+					name: "description",
+					optional: true,
+					aggregations: ["missing"],
+				}),
+			],
+		});
+		const result = emitGraphQLResolver(projection, defaultOptions);
+
+		assert.ok(
+			result.content.includes(
+				'uniqueLocationCount: { cardinality: { field: "locations" } }',
+			),
+		);
+		assert.ok(
+			result.content.includes(
+				'missingDescriptionCount: { missing: { field: "description.keyword" } }',
+			),
+		);
+	});
+
+	it("emits aggregations mapping in response", () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "tags",
+					keyword: true,
+					aggregations: ["terms"],
+				}),
+				makeField({
+					name: "locations",
+					keyword: true,
+					aggregations: ["cardinality"],
+				}),
+				makeField({
+					name: "description",
+					optional: true,
+					aggregations: ["missing"],
+				}),
+			],
+		});
+		const result = emitGraphQLResolver(projection, defaultOptions);
+
+		assert.ok(result.content.includes("aggregations: {"));
+		assert.ok(
+			result.content.includes(
+				"byTag: (parsedBody.aggregations?.byTag?.buckets ?? []).map",
+			),
+		);
+		assert.ok(
+			result.content.includes(
+				"uniqueLocationCount: parsedBody.aggregations?.uniqueLocationCount?.value ?? 0",
+			),
+		);
+		assert.ok(
+			result.content.includes(
+				"missingDescriptionCount: parsedBody.aggregations?.missingDescriptionCount?.doc_count ?? 0",
+			),
+		);
 	});
 });

--- a/src/emit-graphql-resolver.ts
+++ b/src/emit-graphql-resolver.ts
@@ -1,3 +1,4 @@
+import { type AggregationEntry, collectAggregations } from "./aggregations.js";
 import { toGraphQLQueryFieldName } from "./emit-graphql-sdl.js";
 import type {
 	ResolvedProjection,
@@ -35,10 +36,13 @@ export function emitGraphQLResolver(
 		.filter((f) => f.keyword)
 		.map((f) => f.projectedName ?? f.name);
 
+	const aggregations = collectAggregations(projection);
+
 	const content = renderResolver(
 		projection.indexName,
 		textFields,
 		keywordFields,
+		aggregations,
 		options,
 	);
 
@@ -66,10 +70,13 @@ function renderResolver(
 	indexName: string,
 	textFields: string[],
 	keywordFields: string[],
+	aggregations: AggregationEntry[],
 	options: ResolverOptions,
 ): string {
 	const textFieldsLiteral = JSON.stringify(textFields);
 	const keywordFieldsLiteral = JSON.stringify(keywordFields);
+	const aggsBlock = renderAggsBlock(aggregations);
+	const responseAggregations = renderResponseAggregations(aggregations);
 
 	return `import { util } from "@aws-appsync/utils";
 
@@ -84,7 +91,7 @@ export function request(ctx) {
 		size: size + 1,
 		track_total_hits: ${options.trackTotalHitsUpTo},
 		sort: [{ _score: "desc" }, { _id: "asc" }],
-		query,
+		query,${aggsBlock}
 	};
 
 	if (searchAfter) {
@@ -117,7 +124,7 @@ export function response(ctx) {
 
 	return {
 		edges,
-		totalCount: totalHits,
+		totalCount: totalHits,${responseAggregations}
 		pageInfo: {
 			hasNextPage,
 			endCursor: edges.length > 0 ? edges[edges.length - 1].cursor : null,
@@ -162,7 +169,56 @@ function buildQuery(queryText, filter) {
 `;
 }
 
+function renderAggsBlock(aggregations: AggregationEntry[]): string {
+	if (aggregations.length === 0) {
+		return "";
+	}
+
+	const lines = aggregations.map((entry) => {
+		const aggType = osAggType(entry.kind);
+		return `\t\t${entry.aggName}: { ${aggType}: { field: ${JSON.stringify(entry.openSearchField)} } },`;
+	});
+
+	return `\n\t\taggs: {\n${lines.join("\n")}\n\t\t},`;
+}
+
+function renderResponseAggregations(aggregations: AggregationEntry[]): string {
+	if (aggregations.length === 0) {
+		return "";
+	}
+
+	const lines = aggregations.map((entry) =>
+		renderResponseAggregationLine(entry),
+	);
+
+	return `\n\t\taggregations: {\n${lines.join("\n")}\n\t\t},`;
+}
+
+function renderResponseAggregationLine(entry: AggregationEntry): string {
+	switch (entry.kind) {
+		case "terms":
+			return `\t\t\t${entry.aggName}: (parsedBody.aggregations?.${entry.aggName}?.buckets ?? []).map((b) => ({ key: b.key, count: b.doc_count })),`;
+		case "cardinality":
+			return `\t\t\t${entry.aggName}: parsedBody.aggregations?.${entry.aggName}?.value ?? 0,`;
+		case "missing":
+			return `\t\t\t${entry.aggName}: parsedBody.aggregations?.${entry.aggName}?.doc_count ?? 0,`;
+	}
+}
+
+function osAggType(kind: AggregationEntry["kind"]): string {
+	switch (kind) {
+		case "terms":
+			return "terms";
+		case "cardinality":
+			return "cardinality";
+		case "missing":
+			return "missing";
+	}
+}
+
 export const __test = {
 	hasTextType,
 	renderResolver,
+	renderAggsBlock,
+	renderResponseAggregations,
 };

--- a/src/emit-graphql-sdl.test.ts
+++ b/src/emit-graphql-sdl.test.ts
@@ -34,6 +34,7 @@ function makeField(
 		analyzer: string;
 		boost: number;
 		type: Type;
+		aggregations: ResolvedProjection["fields"][0]["aggregations"];
 		subProjection: ResolvedProjection;
 	}> = {},
 ) {
@@ -48,6 +49,7 @@ function makeField(
 		boost: overrides.boost,
 		type:
 			overrides.type ?? ({ kind: "Scalar", name: "string" } as unknown as Type),
+		aggregations: overrides.aggregations,
 		subProjection: overrides.subProjection,
 	} as unknown as ResolvedProjection["fields"][0];
 }
@@ -164,6 +166,68 @@ describe("emitGraphQLSdl", () => {
 
 		const result = emitGraphQLSdl(dummyProgram, projection, defaultOptions);
 		assert.ok(result.content.includes("tags: [TagSearchDoc!]!"));
+	});
+});
+
+describe("emitGraphQLSdl aggregations", () => {
+	it("omits aggregations type and connection field when no aggregations", () => {
+		const projection = makeProjection({
+			fields: [makeField({ name: "name" })],
+		});
+
+		const result = emitGraphQLSdl(dummyProgram, projection, defaultOptions);
+		assert.ok(!result.content.includes("TermBucket"));
+		assert.ok(!result.content.includes("SearchAggregations"));
+		assert.ok(!result.content.includes("aggregations:"));
+	});
+
+	it("emits TermBucket and aggregations type when fields are aggregatable", () => {
+		const projection = makeProjection({
+			name: "CounterpartySearchDoc",
+			fields: [
+				makeField({
+					name: "tags",
+					aggregations: ["terms"],
+					type: {
+						kind: "Model",
+						name: "Array",
+						indexer: { value: { kind: "Scalar", name: "string" } },
+					} as unknown as Type,
+				}),
+				makeField({
+					name: "description",
+					optional: true,
+					aggregations: ["missing"],
+				}),
+			],
+		});
+
+		const result = emitGraphQLSdl(dummyProgram, projection, defaultOptions);
+		assert.ok(result.content.includes("type TermBucket {"));
+		assert.ok(result.content.includes("key: String!"));
+		assert.ok(result.content.includes("count: Int!"));
+		assert.ok(result.content.includes("type CounterpartySearchAggregations {"));
+		assert.ok(result.content.includes("byTag: [TermBucket!]!"));
+		assert.ok(result.content.includes("missingDescriptionCount: Int!"));
+		assert.ok(
+			result.content.includes("aggregations: CounterpartySearchAggregations!"),
+		);
+	});
+
+	it("emits both terms and cardinality aggregation fields", () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "locations",
+					keyword: true,
+					aggregations: ["terms", "cardinality"],
+				}),
+			],
+		});
+
+		const result = emitGraphQLSdl(dummyProgram, projection, defaultOptions);
+		assert.ok(result.content.includes("byLocation: [TermBucket!]!"));
+		assert.ok(result.content.includes("uniqueLocationCount: Int!"));
 	});
 });
 

--- a/src/emit-graphql-sdl.ts
+++ b/src/emit-graphql-sdl.ts
@@ -1,4 +1,10 @@
 import type { Model, Program, Scalar, Type, Union } from "@typespec/compiler";
+import {
+	type AggregationEntry,
+	aggregationsTypeName,
+	collectAggregations,
+	hasAggregations,
+} from "./aggregations.js";
 import { getSearchAs, isSearchable } from "./decorators.js";
 import type {
 	ResolvedProjection,
@@ -35,7 +41,13 @@ export function emitGraphQLSdl(
 		lines.push("");
 	}
 
-	lines.push(renderConnectionTypes(typeName));
+	const aggEntries = collectAggregations(projection);
+	if (aggEntries.length > 0) {
+		lines.push(renderAggregationTypes(typeName, aggEntries));
+		lines.push("");
+	}
+
+	lines.push(renderConnectionTypes(typeName, hasAggregations(projection)));
 
 	return {
 		fileName,
@@ -74,12 +86,24 @@ function renderFilterInput(projection: ResolvedProjection): string | undefined {
 	return `input ${typeName}Filter {\n${fieldLines.join("\n")}\n}`;
 }
 
-function renderConnectionTypes(typeName: string): string {
-	const lines = [
-		`type ${typeName}Connection {`,
+function renderConnectionTypes(
+	typeName: string,
+	includeAggregations: boolean,
+): string {
+	const aggregationsTypeReference = includeAggregations
+		? `  aggregations: ${aggregationsTypeName(typeName)}!`
+		: undefined;
+
+	const connectionFields = [
 		`  edges: [${typeName}Edge!]!`,
 		"  totalCount: Int!",
+		...(aggregationsTypeReference ? [aggregationsTypeReference] : []),
 		"  pageInfo: PageInfo!",
+	];
+
+	const lines = [
+		`type ${typeName}Connection {`,
+		...connectionFields,
 		"}",
 		"",
 		`type ${typeName}Edge {`,
@@ -90,6 +114,30 @@ function renderConnectionTypes(typeName: string): string {
 		"type PageInfo {",
 		"  hasNextPage: Boolean!",
 		"  endCursor: String",
+		"}",
+	];
+
+	return lines.join("\n");
+}
+
+function renderAggregationTypes(
+	typeName: string,
+	entries: AggregationEntry[],
+): string {
+	const aggregationsType = aggregationsTypeName(typeName);
+	const fieldLines = entries.map((entry) => {
+		const gqlType = entry.kind === "terms" ? "[TermBucket!]!" : "Int!";
+		return `  ${entry.aggName}: ${gqlType}`;
+	});
+
+	const lines = [
+		"type TermBucket {",
+		"  key: String!",
+		"  count: Int!",
+		"}",
+		"",
+		`type ${aggregationsType} {`,
+		...fieldLines,
 		"}",
 	];
 
@@ -190,6 +238,7 @@ export const __test = {
 	renderObjectType,
 	renderFilterInput,
 	renderConnectionTypes,
+	renderAggregationTypes,
 	toGraphQLType,
 	toGraphQLQueryFieldName,
 };

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -213,6 +213,9 @@ function serializeProjections(resolved: ResolvedProjection[]) {
 				nested: field.nested,
 				analyzer: field.analyzer,
 				boost: field.boost,
+				...(field.aggregations && field.aggregations.length > 0
+					? { aggregations: field.aggregations }
+					: {}),
 			})),
 		})),
 	};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export {
+	$aggregatable,
 	$analyzer,
 	$boost,
 	$ignoreAbove,
@@ -8,6 +9,7 @@ export {
 	$nested,
 	$searchAs,
 	$searchable,
+	getAggregatableKinds,
 	getAnalyzer,
 	getBoost,
 	getIgnoreAbove,

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -67,6 +67,19 @@ export const $lib = createTypeSpecLibrary({
 				default: paramMessage`Spread field "${"name"}" collides with existing field on projection model.`,
 			},
 		},
+		"invalid-aggregation-kind": {
+			severity: "error",
+			messages: {
+				default: paramMessage`Decorator @aggregatable received unsupported kind "${"kind"}". Allowed kinds: terms, cardinality, missing.`,
+			},
+		},
+		"aggregatable-requires-kind": {
+			severity: "error",
+			messages: {
+				default:
+					"Decorator @aggregatable requires at least one aggregation kind argument.",
+			},
+		},
 	},
 	state: {
 		searchable: { description: "Marks a property as searchable" },
@@ -81,6 +94,9 @@ export const $lib = createTypeSpecLibrary({
 		},
 		searchAs: {
 			description: "Rename a field in projection output",
+		},
+		aggregatable: {
+			description: "Declare aggregation kinds (terms, cardinality, missing)",
 		},
 	},
 	emitter: {

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -1,5 +1,7 @@
 import type { Model, ModelProperty, Program, Type } from "@typespec/compiler";
 import {
+	type AggregationKind,
+	getAggregatableKinds,
 	getAnalyzer,
 	getBoost,
 	getIgnoreAbove,
@@ -25,6 +27,7 @@ export interface ResolvedProjectionField {
 	analyzer?: string;
 	boost?: number;
 	ignoreAbove?: number;
+	aggregations?: AggregationKind[];
 	subProjection?: ResolvedProjection;
 }
 
@@ -191,6 +194,10 @@ function resolveProjectionField(
 		(projectionProperty && getSearchAs(program, projectionProperty)) ??
 		getSearchAs(program, sourceProperty);
 
+	const aggregations =
+		(projectionProperty && getAggregatableKinds(program, projectionProperty)) ??
+		getAggregatableKinds(program, sourceProperty);
+
 	return {
 		name: sourceProperty.name,
 		projectedName: searchAs,
@@ -208,6 +215,7 @@ function resolveProjectionField(
 		analyzer,
 		boost,
 		ignoreAbove,
+		aggregations,
 	};
 }
 

--- a/test/example.js
+++ b/test/example.js
@@ -90,6 +90,33 @@ test("emits doc types and index constants", async () => {
 	);
 });
 
+test("emits graphql aggregation types and resolver block", async () => {
+	const sdl = await readFile(`${OUT_DIR}/pet-search-doc.graphql`, "utf8");
+	const resolver = await readFile(
+		`${OUT_DIR}/pet-search-doc-resolver.js`,
+		"utf8",
+	);
+
+	assert.ok(sdl.includes("type TermBucket {"));
+	assert.ok(sdl.includes("type PetSearchAggregations {"));
+	assert.ok(sdl.includes("byAlias: [TermBucket!]!"));
+	assert.ok(sdl.includes("uniqueAliasCount: Int!"));
+	assert.ok(sdl.includes("missingNicknameCount: Int!"));
+	assert.ok(sdl.includes("aggregations: PetSearchAggregations!"));
+
+	assert.ok(resolver.includes("aggs:"));
+	assert.ok(
+		resolver.includes('byAlias: { terms: { field: "aliases.keyword" } }'),
+	);
+	assert.ok(
+		resolver.includes(
+			'uniqueAliasCount: { cardinality: { field: "aliases.keyword" } }',
+		),
+	);
+	assert.ok(resolver.includes("aggregations: {"));
+	assert.ok(resolver.includes("parsedBody.aggregations?.byAlias?.buckets"));
+});
+
 test("generated output compiles and exports constants", async () => {
 	await writeFile(
 		`${OUT_DIR}/tsconfig.json`,

--- a/test/main.tsp
+++ b/test/main.tsp
@@ -15,13 +15,14 @@ model Tag {
 model Pet {
 	@searchable id: string;
 	@searchable name: string;
-	@searchable @keyword species: string;
+	@searchable @keyword @aggregatable("terms") species: string;
 	@searchable breed?: string;
 	@searchable birthDate: plainDate;
 	@searchable createdAt: utcDateTime;
 	@searchable @nested tags: Tag[];
 	@searchable owner: Owner;
-	@searchable aliases: string[];
+	@searchable @aggregatable("terms", "cardinality") aliases: string[];
+	@searchable @aggregatable("missing") nickname?: string;
 	@searchable rank: int32;
 	@searchable stock: int64;
 	@searchable score: float64;

--- a/test/tspconfig.yaml
+++ b/test/tspconfig.yaml
@@ -4,3 +4,5 @@ options:
   "@kattebak/typespec-opensearch-emitter":
     output-file: "opensearch-projections.json"
     emitter-output-dir: "{cwd}/build/opensearch-emit"
+    graphql:
+      emit: true

--- a/tsp/main.tsp
+++ b/tsp/main.tsp
@@ -13,5 +13,6 @@ extern dec ignoreAbove(target: ModelProperty, limit: valueof uint32);
 extern dec indexName(target: Model, name: valueof string);
 extern dec indexSettings(target: Model, settings: valueof string);
 extern dec searchAs(target: ModelProperty, name: valueof string);
+extern dec aggregatable(target: ModelProperty, ...kinds: valueof string[]);
 
 model SearchProjection<T> {}


### PR DESCRIPTION
## Summary
- Adds `@aggregatable("terms" | "cardinality" | "missing", ...)` decorator that wires OpenSearch aggregations through to the generated GraphQL connection (multi-arg emits all listed kinds on one field).
- SDL: emits `TermBucket`, `<Type>SearchAggregations`, and an `aggregations` field on the connection. Naming follows the issue's conventions: `by<Field>`, `unique<Field>Count`, `missing<Field>Count`, with singular field names (drops `s`/`es`/`ies`).
- Resolver: embeds an `aggs` block in the request and maps `parsedBody.aggregations` in the response. `.keyword` is applied automatically for text string fields; numeric, date, and `@keyword` fields use the bare field name.
- When no field on a projection is `@aggregatable`, the aggregation types and connection field are omitted (no empty types emitted).

Notes / judgment calls:
- Singularization is rule-based: `-ies` -> `-y`, `-ses`/`-xes`/`-zes` drop `-es`, plain `-s` (not `-ss`) drops `-s`. Edge cases like `species` -> `specy` exist but matter less than the common `tags` -> `tag` case the issue calls out.
- For the `missing` aggregation on a text string field, `.keyword` is applied (matching the example in the issue: `missing: { field: "description.keyword" }`).
- Aggregations on model arrays (e.g. `Location[]`) use the bare field name. The issue's example showed `locations.keyword` but with the stated rule "apply `.keyword` only when the field is text" that wouldn't apply to a model array; consumers can use `@searchAs` or `@keyword` to control this.

## Test plan
- [x] `npm run fix` clean
- [x] `npm test` all 155 unit tests + 5 integration/example tests pass
- [x] End-to-end emit (`test:emit` + `test:example`) produces SDL with `TermBucket`, `*SearchAggregations`, and `aggregations: *!` on the connection
- [x] End-to-end emit produces resolver with `aggs:` block in request and `aggregations:` block in response
- [x] Projections without `@aggregatable` continue to emit the prior shape (no aggregation types or connection field)

Closes #74