### PR TITLE
feat(emitter): nested-aware aggregations wrap aggs with nested+inner

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kattebak/typespec-opensearch-emitter",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "TypeSpec emitter for OpenSearch projections",
 	"type": "module",
 	"main": "dist/index.js",

--- a/src/aggregations.test.ts
+++ b/src/aggregations.test.ts
@@ -264,6 +264,145 @@ describe("collectAggregations", () => {
 	});
 });
 
+describe("collectAggregations with nested sub-projections", () => {
+	function makeNestedTagSubProjection() {
+		return {
+			projectionModel: { name: "TagSearchDoc" },
+			sourceModel: { name: "Tag" },
+			indexName: "tags",
+			fields: [
+				makeField({
+					name: "name",
+					keyword: true,
+					aggregations: ["terms", "cardinality"],
+				}),
+				makeField({
+					name: "note",
+					optional: true,
+					aggregations: ["missing"],
+					type: { kind: "Scalar", name: "string" } as unknown as Type,
+				}),
+			],
+		} as unknown as ResolvedProjection;
+	}
+
+	it("threads nestedPath into entries inside @nested sub-projections", () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "tags",
+					nested: true,
+					subProjection: makeNestedTagSubProjection(),
+					type: {
+						kind: "Model",
+						name: "Array",
+						indexer: { value: { kind: "Model" } },
+					} as unknown as Type,
+				}),
+			],
+		});
+
+		const entries = collectAggregations(projection);
+
+		assert.equal(entries.length, 3);
+
+		const byTagName = entries.find((e) => e.aggName === "byTagName");
+		assert.ok(byTagName);
+		assert.equal(byTagName.kind, "terms");
+		assert.equal(byTagName.nestedPath, "tags");
+		assert.equal(byTagName.openSearchField, "tags.name");
+
+		const uniqueTagNameCount = entries.find(
+			(e) => e.aggName === "uniqueTagNameCount",
+		);
+		assert.ok(uniqueTagNameCount);
+		assert.equal(uniqueTagNameCount.nestedPath, "tags");
+		assert.equal(uniqueTagNameCount.openSearchField, "tags.name");
+
+		const missingTagNoteCount = entries.find(
+			(e) => e.aggName === "missingTagNoteCount",
+		);
+		assert.ok(missingTagNoteCount);
+		assert.equal(missingTagNoteCount.nestedPath, "tags");
+		assert.equal(missingTagNoteCount.openSearchField, "tags.note.keyword");
+	});
+
+	it("does not set nestedPath on object (non-nested) sub-projections", () => {
+		const ownerSubProjection = {
+			projectionModel: { name: "OwnerSearchDoc" },
+			sourceModel: { name: "Owner" },
+			indexName: "owners",
+			fields: [
+				makeField({
+					name: "name",
+					keyword: true,
+					aggregations: ["terms"],
+				}),
+			],
+		} as unknown as ResolvedProjection;
+
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "owner",
+					nested: false,
+					subProjection: ownerSubProjection,
+					type: { kind: "Model" } as unknown as Type,
+				}),
+			],
+		});
+
+		const entries = collectAggregations(projection);
+		assert.equal(entries.length, 1);
+		assert.equal(entries[0].nestedPath, undefined);
+		assert.equal(entries[0].openSearchField, "name");
+		assert.equal(entries[0].aggName, "byName");
+	});
+
+	it("hasAggregations returns true when only nested sub-projection has aggs", () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "tags",
+					nested: true,
+					subProjection: makeNestedTagSubProjection(),
+					type: {
+						kind: "Model",
+						name: "Array",
+						indexer: { value: { kind: "Model" } },
+					} as unknown as Type,
+				}),
+			],
+		});
+
+		assert.equal(hasAggregations(projection), true);
+	});
+
+	it("uses projectedName for nestedPath when @searchAs renames the field", () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "tags",
+					projectedName: "labels",
+					nested: true,
+					subProjection: makeNestedTagSubProjection(),
+					type: {
+						kind: "Model",
+						name: "Array",
+						indexer: { value: { kind: "Model" } },
+					} as unknown as Type,
+				}),
+			],
+		});
+
+		const entries = collectAggregations(projection);
+		const byTagName = entries.find((e) => e.aggName === "byLabelName");
+		assert.ok(byTagName, "expected nestedPath prefix from projectedName");
+		assert.equal(byTagName.nestedPath, "labels");
+		assert.equal(byTagName.openSearchField, "labels.name");
+	});
+});
+
 describe("isTextField", () => {
 	it("returns false for keyword fields", () => {
 		assert.equal(isTextField(makeField({ keyword: true })), false);

--- a/src/aggregations.ts
+++ b/src/aggregations.ts
@@ -10,42 +10,73 @@ export interface AggregationEntry {
 	aggName: string;
 	openSearchField: string;
 	useTextType: boolean;
+	nestedPath?: string;
 }
+
+/**
+ * Inner agg name used when wrapping in `{ nested: { path }, aggs: { <innerName>: {...} } }`.
+ * Kept stable so the response handler can unwrap symmetrically.
+ */
+export const NESTED_INNER_AGG_NAME = "inner";
 
 export function collectAggregations(
 	projection: ResolvedProjection,
 ): AggregationEntry[] {
+	return collectAggregationsRecursive(projection, undefined);
+}
+
+function collectAggregationsRecursive(
+	projection: ResolvedProjection,
+	nestedPath: string | undefined,
+): AggregationEntry[] {
 	const entries: AggregationEntry[] = [];
 
+	if (!projection.fields) {
+		return entries;
+	}
+
 	for (const field of projection.fields) {
-		if (!field.aggregations || field.aggregations.length === 0) {
-			continue;
+		if (field.aggregations && field.aggregations.length > 0) {
+			const projectedName = field.projectedName ?? field.name;
+			const useTextType = isTextField(field);
+			const fieldPart = useTextType
+				? `${projectedName}.keyword`
+				: projectedName;
+			const openSearchField = nestedPath
+				? `${nestedPath}.${fieldPart}`
+				: fieldPart;
+
+			for (const kind of field.aggregations) {
+				entries.push({
+					field,
+					kind,
+					aggName: aggregationFieldName(projectedName, kind, nestedPath),
+					openSearchField,
+					useTextType,
+					nestedPath,
+				});
+			}
 		}
 
-		const projectedName = field.projectedName ?? field.name;
-		const useTextType = isTextField(field);
-		const openSearchField = useTextType
-			? `${projectedName}.keyword`
-			: projectedName;
-
-		for (const kind of field.aggregations) {
-			entries.push({
-				field,
-				kind,
-				aggName: aggregationFieldName(projectedName, kind),
-				openSearchField,
-				useTextType,
-			});
+		if (field.subProjection) {
+			const childPath = field.nested
+				? joinNestedPath(nestedPath, field.projectedName ?? field.name)
+				: nestedPath;
+			entries.push(
+				...collectAggregationsRecursive(field.subProjection, childPath),
+			);
 		}
 	}
 
 	return entries;
 }
 
+function joinNestedPath(parent: string | undefined, segment: string): string {
+	return parent ? `${parent}.${segment}` : segment;
+}
+
 export function hasAggregations(projection: ResolvedProjection): boolean {
-	return projection.fields.some(
-		(field) => field.aggregations && field.aggregations.length > 0,
-	);
+	return collectAggregations(projection).length > 0;
 }
 
 export function aggregationsTypeName(projectionName: string): string {
@@ -56,9 +87,11 @@ export function aggregationsTypeName(projectionName: string): string {
 export function aggregationFieldName(
 	fieldName: string,
 	kind: AggregationKind,
+	nestedPath?: string,
 ): string {
-	const singular = singularize(fieldName);
-	const capital = capitalize(singular);
+	const fieldPart = capitalize(singularize(fieldName));
+	const prefix = nestedPath ? nestedPathPrefix(nestedPath) : "";
+	const capital = `${prefix}${fieldPart}`;
 	switch (kind) {
 		case "terms":
 			return `by${capital}`;
@@ -67,6 +100,13 @@ export function aggregationFieldName(
 		case "missing":
 			return `missing${capital}Count`;
 	}
+}
+
+function nestedPathPrefix(nestedPath: string): string {
+	return nestedPath
+		.split(".")
+		.map((segment) => capitalize(singularize(segment)))
+		.join("");
 }
 
 function singularize(name: string): string {

--- a/src/emit-graphql-resolver.test.ts
+++ b/src/emit-graphql-resolver.test.ts
@@ -234,6 +234,97 @@ describe("emitGraphQLResolver", () => {
 		);
 	});
 
+	it("wraps aggs inside @nested sub-projection in nested+inner block", () => {
+		const subProjection = {
+			projectionModel: { name: "TagSearchDoc" },
+			sourceModel: { name: "Tag" },
+			indexName: "tags",
+			fields: [
+				makeField({
+					name: "name",
+					keyword: true,
+					aggregations: ["terms", "cardinality"],
+				}),
+				makeField({
+					name: "note",
+					optional: true,
+					aggregations: ["missing"],
+				}),
+			],
+		} as unknown as ResolvedProjection;
+
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "tags",
+					nested: true,
+					subProjection,
+					type: {
+						kind: "Model",
+						name: "Array",
+						indexer: { value: { kind: "Model" } },
+					} as unknown as Type,
+				}),
+			],
+		});
+
+		const result = emitGraphQLResolver(projection, defaultOptions);
+
+		assert.ok(
+			result.content.includes(
+				'byTagName: { nested: { path: "tags" }, aggs: { inner: { terms: { field: "tags.name" } } } }',
+			),
+		);
+		assert.ok(
+			result.content.includes(
+				'uniqueTagNameCount: { nested: { path: "tags" }, aggs: { inner: { cardinality: { field: "tags.name" } } } }',
+			),
+		);
+		assert.ok(
+			result.content.includes(
+				'missingTagNoteCount: { nested: { path: "tags" }, aggs: { inner: { missing: { field: "tags.note.keyword" } } } }',
+			),
+		);
+
+		assert.ok(
+			result.content.includes(
+				"byTagName: (parsedBody.aggregations?.byTagName?.inner?.buckets ?? []).map",
+			),
+		);
+		assert.ok(
+			result.content.includes(
+				"uniqueTagNameCount: parsedBody.aggregations?.uniqueTagNameCount?.inner?.value ?? 0",
+			),
+		);
+		assert.ok(
+			result.content.includes(
+				"missingTagNoteCount: parsedBody.aggregations?.missingTagNoteCount?.inner?.doc_count ?? 0",
+			),
+		);
+	});
+
+	it("does not wrap top-level aggregations in nested block", () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "tags",
+					aggregations: ["terms"],
+					type: {
+						kind: "Model",
+						name: "Array",
+						indexer: { value: { kind: "Scalar", name: "string" } },
+					} as unknown as Type,
+				}),
+			],
+		});
+
+		const result = emitGraphQLResolver(projection, defaultOptions);
+		assert.ok(
+			result.content.includes('byTag: { terms: { field: "tags.keyword" } }'),
+		);
+		assert.ok(!result.content.includes("nested: { path:"));
+	});
+
 	it("emits aggregations mapping in response", () => {
 		const projection = makeProjection({
 			fields: [

--- a/src/emit-graphql-resolver.ts
+++ b/src/emit-graphql-resolver.ts
@@ -1,4 +1,8 @@
-import { type AggregationEntry, collectAggregations } from "./aggregations.js";
+import {
+	type AggregationEntry,
+	collectAggregations,
+	NESTED_INNER_AGG_NAME,
+} from "./aggregations.js";
 import { toGraphQLQueryFieldName } from "./emit-graphql-sdl.js";
 import type {
 	ResolvedProjection,
@@ -174,12 +178,18 @@ function renderAggsBlock(aggregations: AggregationEntry[]): string {
 		return "";
 	}
 
-	const lines = aggregations.map((entry) => {
-		const aggType = osAggType(entry.kind);
-		return `\t\t${entry.aggName}: { ${aggType}: { field: ${JSON.stringify(entry.openSearchField)} } },`;
-	});
+	const lines = aggregations.map((entry) => renderAggLine(entry));
 
 	return `\n\t\taggs: {\n${lines.join("\n")}\n\t\t},`;
+}
+
+function renderAggLine(entry: AggregationEntry): string {
+	const aggType = osAggType(entry.kind);
+	const inner = `{ ${aggType}: { field: ${JSON.stringify(entry.openSearchField)} } }`;
+	if (entry.nestedPath) {
+		return `\t\t${entry.aggName}: { nested: { path: ${JSON.stringify(entry.nestedPath)} }, aggs: { ${NESTED_INNER_AGG_NAME}: ${inner} } },`;
+	}
+	return `\t\t${entry.aggName}: ${inner},`;
 }
 
 function renderResponseAggregations(aggregations: AggregationEntry[]): string {
@@ -195,13 +205,16 @@ function renderResponseAggregations(aggregations: AggregationEntry[]): string {
 }
 
 function renderResponseAggregationLine(entry: AggregationEntry): string {
+	const path = entry.nestedPath
+		? `parsedBody.aggregations?.${entry.aggName}?.${NESTED_INNER_AGG_NAME}`
+		: `parsedBody.aggregations?.${entry.aggName}`;
 	switch (entry.kind) {
 		case "terms":
-			return `\t\t\t${entry.aggName}: (parsedBody.aggregations?.${entry.aggName}?.buckets ?? []).map((b) => ({ key: b.key, count: b.doc_count })),`;
+			return `\t\t\t${entry.aggName}: (${path}?.buckets ?? []).map((b) => ({ key: b.key, count: b.doc_count })),`;
 		case "cardinality":
-			return `\t\t\t${entry.aggName}: parsedBody.aggregations?.${entry.aggName}?.value ?? 0,`;
+			return `\t\t\t${entry.aggName}: ${path}?.value ?? 0,`;
 		case "missing":
-			return `\t\t\t${entry.aggName}: parsedBody.aggregations?.${entry.aggName}?.doc_count ?? 0,`;
+			return `\t\t\t${entry.aggName}: ${path}?.doc_count ?? 0,`;
 	}
 }
 

--- a/src/emit-graphql-sdl.test.ts
+++ b/src/emit-graphql-sdl.test.ts
@@ -214,6 +214,42 @@ describe("emitGraphQLSdl aggregations", () => {
 		);
 	});
 
+	it("emits nested-aware aggregation field names from sub-projections", () => {
+		const subProjection = {
+			projectionModel: { name: "TagSearchDoc" },
+			sourceModel: { name: "Tag" },
+			indexName: "tags",
+			fields: [
+				makeField({
+					name: "name",
+					keyword: true,
+					aggregations: ["terms", "cardinality"],
+				}),
+			],
+		} as unknown as ResolvedProjection;
+
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "tags",
+					nested: true,
+					subProjection,
+					type: {
+						kind: "Model",
+						name: "Array",
+						indexer: { value: { kind: "Model" } },
+					} as unknown as Type,
+				}),
+			],
+		});
+
+		const result = emitGraphQLSdl(dummyProgram, projection, defaultOptions);
+		assert.ok(result.content.includes("type PetSearchAggregations {"));
+		assert.ok(result.content.includes("byTagName: [TermBucket!]!"));
+		assert.ok(result.content.includes("uniqueTagNameCount: Int!"));
+		assert.ok(result.content.includes("aggregations: PetSearchAggregations!"));
+	});
+
 	it("emits both terms and cardinality aggregation fields", () => {
 		const projection = makeProjection({
 			fields: [

--- a/test/example.js
+++ b/test/example.js
@@ -15,10 +15,10 @@ test("emits projection metadata for multiple projections", async () => {
 	);
 	const parsed = JSON.parse(content);
 
-	assert.equal(parsed.projections.length, 2);
 	assert.deepEqual(parsed.projections.map((x) => x.name).sort(), [
 		"PetPublicSearchDoc",
 		"PetSearchDoc",
+		"TagSearchDoc",
 	]);
 
 	const petSearch = parsed.projections.find((x) => x.name === "PetSearchDoc");
@@ -115,6 +115,49 @@ test("emits graphql aggregation types and resolver block", async () => {
 	);
 	assert.ok(resolver.includes("aggregations: {"));
 	assert.ok(resolver.includes("parsedBody.aggregations?.byAlias?.buckets"));
+});
+
+test("emits nested-aware aggregations on nested sub-projections", async () => {
+	const sdl = await readFile(`${OUT_DIR}/pet-search-doc.graphql`, "utf8");
+	const resolver = await readFile(
+		`${OUT_DIR}/pet-search-doc-resolver.js`,
+		"utf8",
+	);
+
+	assert.ok(sdl.includes("byTagName: [TermBucket!]!"));
+	assert.ok(sdl.includes("uniqueTagNameCount: Int!"));
+	assert.ok(sdl.includes("missingTagNoteCount: Int!"));
+
+	assert.ok(
+		resolver.includes(
+			'byTagName: { nested: { path: "tags" }, aggs: { inner: { terms: { field: "tags.name" } } } }',
+		),
+	);
+	assert.ok(
+		resolver.includes(
+			'uniqueTagNameCount: { nested: { path: "tags" }, aggs: { inner: { cardinality: { field: "tags.name" } } } }',
+		),
+	);
+	assert.ok(
+		resolver.includes(
+			'missingTagNoteCount: { nested: { path: "tags" }, aggs: { inner: { missing: { field: "tags.note.keyword" } } } }',
+		),
+	);
+	assert.ok(
+		resolver.includes(
+			"byTagName: (parsedBody.aggregations?.byTagName?.inner?.buckets ?? []).map",
+		),
+	);
+	assert.ok(
+		resolver.includes(
+			"uniqueTagNameCount: parsedBody.aggregations?.uniqueTagNameCount?.inner?.value ?? 0",
+		),
+	);
+	assert.ok(
+		resolver.includes(
+			"missingTagNoteCount: parsedBody.aggregations?.missingTagNoteCount?.inner?.doc_count ?? 0",
+		),
+	);
 });
 
 test("generated output compiles and exports constants", async () => {

--- a/test/main.tsp
+++ b/test/main.tsp
@@ -9,8 +9,11 @@ model Owner {
 }
 
 model Tag {
-	@searchable @keyword name: string;
+	@searchable @keyword @aggregatable("terms", "cardinality") name: string;
+	@searchable @aggregatable("missing") note?: string;
 }
+
+model TagSearchDoc is SearchProjection<Tag> {}
 
 model Pet {
 	@searchable id: string;
@@ -34,6 +37,8 @@ model Pet {
 model PetSearchDoc is SearchProjection<Pet> {
 	@analyzer("edge_ngram") @boost(2.0)
 	name: string;
+
+	@nested tags: TagSearchDoc[];
 }
 
 model PetPublicSearchDoc is SearchProjection<Pet> {


### PR DESCRIPTION
Introduces nested-path tracking through projection traversal so @aggregatable fields inside @nested sub-projections emit `{ nested: { path }, aggs: { inner: ... } }` in the resolver, solving the empty-bucket bug because OpenSearch aggs on nested fields must run at the nested doc level, not the parent. Partial fix for #76 (Item 1: nested-aware aggregations).