### PR TITLE
fix(filter-dsl): rewrite applyFilterSpec to iterative — APPSYNC_JS forbids recursion

### DIFF
--- a/src/emit-graphql-resolver.test.ts
+++ b/src/emit-graphql-resolver.test.ts
@@ -676,4 +676,126 @@ describe("emitGraphQLResolver search filter DSL", () => {
 			},
 		});
 	});
+
+	it("applyFilterSpec body contains no self-recursive call (APPSYNC_JS forbids recursion)", () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "species",
+					keyword: true,
+					filterables: ["term"],
+				}),
+				makeField({
+					name: "tags",
+					nested: true,
+					subProjection: nestedTagSubProjection(),
+					type: {
+						kind: "Model",
+						name: "Array",
+						indexer: { value: { kind: "Model" } },
+					} as unknown as Type,
+				}),
+			],
+		});
+		const result = emitGraphQLResolver(projection, defaultOptions);
+
+		const declStart = result.content.indexOf("function applyFilterSpec");
+		assert.ok(
+			declStart >= 0,
+			"expected to find applyFilterSpec function in emitted resolver",
+		);
+		const bodyStart = result.content.indexOf("{", declStart);
+		assert.ok(bodyStart > declStart, "function body opening brace not found");
+
+		let depth = 0;
+		let bodyEnd = -1;
+		for (let i = bodyStart; i < result.content.length; i++) {
+			const ch = result.content[i];
+			if (ch === "{") depth++;
+			else if (ch === "}") {
+				depth--;
+				if (depth === 0) {
+					bodyEnd = i + 1;
+					break;
+				}
+			}
+		}
+		assert.ok(bodyEnd > bodyStart, "function body closing brace not found");
+		const body = result.content.slice(bodyStart, bodyEnd);
+
+		assert.equal(
+			/\bapplyFilterSpec\s*\(/.test(body),
+			false,
+			`applyFilterSpec body must not call itself; APPSYNC_JS rejects recursive resolver code. Body was:\n${body}`,
+		);
+	});
+
+	it("buildQuery preserves nested-filter semantics for deeply structured input", () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "species",
+					keyword: true,
+					filterables: ["term"],
+				}),
+				makeField({
+					name: "tags",
+					nested: true,
+					subProjection: nestedTagSubProjection(),
+					type: {
+						kind: "Model",
+						name: "Array",
+						indexer: { value: { kind: "Model" } },
+					} as unknown as Type,
+				}),
+			],
+		});
+		const buildQuery = loadBuildQuery(
+			emitGraphQLResolver(projection, defaultOptions).content,
+		);
+		const result = buildQuery(undefined, undefined, {
+			species: "cat",
+			tags: { name: "vip", noteExists: true },
+		}) as { bool: { filter: unknown[] } };
+
+		assert.ok(
+			result.bool.filter.some(
+				(c) =>
+					JSON.stringify(c) === JSON.stringify({ term: { species: "cat" } }),
+			),
+			"flat term clause missing",
+		);
+		assert.ok(
+			result.bool.filter.some(
+				(c) =>
+					JSON.stringify(c) ===
+					JSON.stringify({
+						nested: {
+							path: "tags",
+							query: {
+								bool: { filter: [{ term: { "tags.name": "vip" } }] },
+							},
+						},
+					}),
+			),
+			"nested term clause missing",
+		);
+		assert.ok(
+			result.bool.filter.some(
+				(c) =>
+					JSON.stringify(c) ===
+					JSON.stringify({
+						nested: {
+							path: "tags",
+							query: {
+								bool: {
+									filter: [{ exists: { field: "tags.note.keyword" } }],
+								},
+							},
+						},
+					}),
+			),
+			"nested exists clause missing",
+		);
+	});
 });

--- a/src/emit-graphql-resolver.ts
+++ b/src/emit-graphql-resolver.ts
@@ -188,64 +188,101 @@ function buildQuery(queryText, filter, searchFilter) {
 	};
 }
 
-function applyFilterSpec(spec, input, outFilters, outMustNots) {
-	if (!spec || !input) return;
-	const rangeBuckets = {};
+function applyFilterSpec(rootSpec, rootInput, rootOutFilters, rootOutMustNots) {
+	if (!rootSpec || !rootInput) return;
 
-	for (const node of spec) {
-		const value = input[node.inputName];
-		if (node.kind === "nested") {
-			if (value == null) continue;
-			const nestedFilters = [];
-			const nestedMustNots = [];
-			applyFilterSpec(node.children, value, nestedFilters, nestedMustNots);
-			for (const clause of nestedFilters) {
-				outFilters.push({
+	const stack = [
+		{
+			kind: "process",
+			spec: rootSpec,
+			input: rootInput,
+			outFilters: rootOutFilters,
+			outMustNots: rootOutMustNots,
+		},
+	];
+
+	while (stack.length > 0) {
+		const work = stack.pop();
+
+		if (work.kind === "finalize") {
+			for (const clause of work.childFilters) {
+				work.parentFilters.push({
 					nested: {
-						path: node.path,
+						path: work.path,
 						query: { bool: { filter: [clause] } },
 					},
 				});
 			}
-			for (const clause of nestedMustNots) {
-				outMustNots.push({
+			for (const clause of work.childMustNots) {
+				work.parentMustNots.push({
 					nested: {
-						path: node.path,
+						path: work.path,
 						query: { bool: { filter: [clause] } },
 					},
 				});
 			}
 			continue;
 		}
-		if (node.kind === "term") {
-			if (value == null) continue;
-			outFilters.push({ term: { [node.field]: value } });
-			continue;
-		}
-		if (node.kind === "term_negate") {
-			if (value == null) continue;
-			outMustNots.push({ term: { [node.field]: value } });
-			continue;
-		}
-		if (node.kind === "exists") {
-			if (value == null) continue;
-			if (value === true) {
-				outFilters.push({ exists: { field: node.field } });
-			} else {
-				outMustNots.push({ exists: { field: node.field } });
-			}
-			continue;
-		}
-		if (node.kind === "range") {
-			if (value == null) continue;
-			const bucket = (rangeBuckets[node.field] = rangeBuckets[node.field] || {});
-			bucket[node.bound] = value;
-			continue;
-		}
-	}
 
-	for (const field in rangeBuckets) {
-		outFilters.push({ range: { [field]: rangeBuckets[field] } });
+		const spec = work.spec;
+		const input = work.input;
+		const outFilters = work.outFilters;
+		const outMustNots = work.outMustNots;
+		const rangeBuckets = {};
+
+		for (const node of spec) {
+			const value = input[node.inputName];
+			if (node.kind === "nested") {
+				if (value == null) continue;
+				const childFilters = [];
+				const childMustNots = [];
+				stack.push({
+					kind: "finalize",
+					path: node.path,
+					childFilters,
+					childMustNots,
+					parentFilters: outFilters,
+					parentMustNots: outMustNots,
+				});
+				stack.push({
+					kind: "process",
+					spec: node.children,
+					input: value,
+					outFilters: childFilters,
+					outMustNots: childMustNots,
+				});
+				continue;
+			}
+			if (node.kind === "term") {
+				if (value == null) continue;
+				outFilters.push({ term: { [node.field]: value } });
+				continue;
+			}
+			if (node.kind === "term_negate") {
+				if (value == null) continue;
+				outMustNots.push({ term: { [node.field]: value } });
+				continue;
+			}
+			if (node.kind === "exists") {
+				if (value == null) continue;
+				if (value === true) {
+					outFilters.push({ exists: { field: node.field } });
+				} else {
+					outMustNots.push({ exists: { field: node.field } });
+				}
+				continue;
+			}
+			if (node.kind === "range") {
+				if (value == null) continue;
+				const bucket = (rangeBuckets[node.field] = rangeBuckets[node.field] || {});
+				bucket[node.bound] = value;
+				continue;
+			}
+		}
+
+		for (const field in rangeBuckets) {
+			outFilters.push({ range: { [field]: rangeBuckets[field] } });
+		}
 	}
 }
 `;


### PR DESCRIPTION
Rewrites the runtime filter walker to iterative using an explicit work stack so AppSync resolvers using @filterable no longer get rejected by APPSYNC_JS at CFN deploy. Closes issue #79.