### PR TITLE
fix(filter-dsl): replace while/continue with bounded for and if/else — APPSYNC_JS forbids both

### DIFF
--- a/src/emit-graphql-resolver.test.ts
+++ b/src/emit-graphql-resolver.test.ts
@@ -730,6 +730,64 @@ describe("emitGraphQLResolver search filter DSL", () => {
 		);
 	});
 
+	it("applyFilterSpec body contains no while or continue (APPSYNC_JS forbids both)", () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "species",
+					keyword: true,
+					filterables: ["term"],
+				}),
+				makeField({
+					name: "tags",
+					nested: true,
+					subProjection: nestedTagSubProjection(),
+					type: {
+						kind: "Model",
+						name: "Array",
+						indexer: { value: { kind: "Model" } },
+					} as unknown as Type,
+				}),
+			],
+		});
+		const result = emitGraphQLResolver(projection, defaultOptions);
+
+		const declStart = result.content.indexOf("function applyFilterSpec");
+		assert.ok(
+			declStart >= 0,
+			"expected to find applyFilterSpec function in emitted resolver",
+		);
+		const bodyStart = result.content.indexOf("{", declStart);
+		assert.ok(bodyStart > declStart, "function body opening brace not found");
+
+		let depth = 0;
+		let bodyEnd = -1;
+		for (let i = bodyStart; i < result.content.length; i++) {
+			const ch = result.content[i];
+			if (ch === "{") depth++;
+			else if (ch === "}") {
+				depth--;
+				if (depth === 0) {
+					bodyEnd = i + 1;
+					break;
+				}
+			}
+		}
+		assert.ok(bodyEnd > bodyStart, "function body closing brace not found");
+		const body = result.content.slice(bodyStart, bodyEnd);
+
+		assert.equal(
+			/\bwhile\s*\(/.test(body),
+			false,
+			`applyFilterSpec body must not contain a while statement; APPSYNC_JS lint rule @aws-appsync/no-while rejects it. Body was:\n${body}`,
+		);
+		assert.equal(
+			/\bcontinue\s*;/.test(body),
+			false,
+			`applyFilterSpec body must not contain a continue statement; APPSYNC_JS lint rule @aws-appsync/no-continue rejects it. Body was:\n${body}`,
+		);
+	});
+
 	it("buildQuery preserves nested-filter semantics for deeply structured input", () => {
 		const projection = makeProjection({
 			fields: [

--- a/src/emit-graphql-resolver.ts
+++ b/src/emit-graphql-resolver.ts
@@ -201,7 +201,14 @@ function applyFilterSpec(rootSpec, rootInput, rootOutFilters, rootOutMustNots) {
 		},
 	];
 
-	while (stack.length > 0) {
+	// APPSYNC_JS forbids \`while\` and \`continue\` (lint rules
+	// @aws-appsync/no-while, @aws-appsync/no-continue), so we drain the work
+	// stack with a bounded \`for\` and break when empty. The bound is set
+	// generously well above any realistic SearchFilter shape; it is a
+	// runtime-environment requirement, not an algorithmic one.
+	const MAX_FILTER_WORK_ITERATIONS = 256;
+	for (let __i = 0; __i < MAX_FILTER_WORK_ITERATIONS; __i++) {
+		if (stack.length === 0) break;
 		const work = stack.pop();
 
 		if (work.kind === "finalize") {
@@ -221,68 +228,69 @@ function applyFilterSpec(rootSpec, rootInput, rootOutFilters, rootOutMustNots) {
 					},
 				});
 			}
-			continue;
-		}
+		} else {
+			const spec = work.spec;
+			const input = work.input;
+			const outFilters = work.outFilters;
+			const outMustNots = work.outMustNots;
+			const rangeBuckets = {};
 
-		const spec = work.spec;
-		const input = work.input;
-		const outFilters = work.outFilters;
-		const outMustNots = work.outMustNots;
-		const rangeBuckets = {};
-
-		for (const node of spec) {
-			const value = input[node.inputName];
-			if (node.kind === "nested") {
-				if (value == null) continue;
-				const childFilters = [];
-				const childMustNots = [];
-				stack.push({
-					kind: "finalize",
-					path: node.path,
-					childFilters,
-					childMustNots,
-					parentFilters: outFilters,
-					parentMustNots: outMustNots,
-				});
-				stack.push({
-					kind: "process",
-					spec: node.children,
-					input: value,
-					outFilters: childFilters,
-					outMustNots: childMustNots,
-				});
-				continue;
-			}
-			if (node.kind === "term") {
-				if (value == null) continue;
-				outFilters.push({ term: { [node.field]: value } });
-				continue;
-			}
-			if (node.kind === "term_negate") {
-				if (value == null) continue;
-				outMustNots.push({ term: { [node.field]: value } });
-				continue;
-			}
-			if (node.kind === "exists") {
-				if (value == null) continue;
-				if (value === true) {
-					outFilters.push({ exists: { field: node.field } });
-				} else {
-					outMustNots.push({ exists: { field: node.field } });
+			for (const node of spec) {
+				const value = input[node.inputName];
+				if (node.kind === "nested") {
+					if (value != null) {
+						const childFilters = [];
+						const childMustNots = [];
+						stack.push({
+							kind: "finalize",
+							path: node.path,
+							childFilters,
+							childMustNots,
+							parentFilters: outFilters,
+							parentMustNots: outMustNots,
+						});
+						stack.push({
+							kind: "process",
+							spec: node.children,
+							input: value,
+							outFilters: childFilters,
+							outMustNots: childMustNots,
+						});
+					}
+				} else if (node.kind === "term") {
+					if (value != null) {
+						outFilters.push({ term: { [node.field]: value } });
+					}
+				} else if (node.kind === "term_negate") {
+					if (value != null) {
+						outMustNots.push({ term: { [node.field]: value } });
+					}
+				} else if (node.kind === "exists") {
+					if (value != null) {
+						if (value === true) {
+							outFilters.push({ exists: { field: node.field } });
+						} else {
+							outMustNots.push({ exists: { field: node.field } });
+						}
+					}
+				} else if (node.kind === "range") {
+					if (value != null) {
+						const bucket = (rangeBuckets[node.field] = rangeBuckets[node.field] || {});
+						bucket[node.bound] = value;
+					}
 				}
-				continue;
 			}
-			if (node.kind === "range") {
-				if (value == null) continue;
-				const bucket = (rangeBuckets[node.field] = rangeBuckets[node.field] || {});
-				bucket[node.bound] = value;
-				continue;
-			}
-		}
 
-		for (const field in rangeBuckets) {
-			outFilters.push({ range: { [field]: rangeBuckets[field] } });
+			for (const field in rangeBuckets) {
+				outFilters.push({ range: { [field]: rangeBuckets[field] } });
+			}
 		}
+	}
+
+	if (stack.length > 0) {
+		util.error(
+			"applyFilterSpec exceeded MAX_FILTER_WORK_ITERATIONS bound; SearchFilter shape too deep for APPSYNC_JS resolver",
+		);
 	}
 }
 `;


### PR DESCRIPTION
Rewrites the runtime applyFilterSpec walker to use a bounded for loop and if/else chains so the emitted resolver passes APPSYNC_JS lint (`@aws-appsync/no-while`, `@aws-appsync/no-continue`). Closes #81.