### PR TITLE
fix(projection): admit @filterable / @aggregatable on non-@searchable fields + numeric metric aggs + nested-path exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,13 @@ The core workflow:
 2. **Create a projection model** — use `model XxxSearchDoc is SearchProjection<SourceModel> {}` to create a search document type. Only `@searchable` fields from the source model are included.
 3. **Override decorators in the projection** — redeclare fields in the projection model to add or override `@keyword`, `@analyzer`, `@boost`, or `@nested`.
 
-Fields **not** marked `@searchable` on the source model are excluded from all projections.
+A field is included in the resolved projection if it carries any of `@searchable`, `@filterable`, or `@aggregatable`. Each role then dictates downstream emission:
+
+- `@searchable` — appears on the SDL response object type, the legacy `<Type>Filter` keyword input, and the OS mapping with text-or-keyword analysis.
+- `@filterable` — contributes to the `<Type>SearchFilter` input and `FILTER_SPEC` in the resolver.
+- `@aggregatable` — contributes to the aggregations type and the `aggs` block in the resolver.
+
+Filter-only / agg-only fields are mapped as `keyword` directly (no `text`+`keyword` sub-field) since there is no full-text-search surface. Fields with none of the three decorators are excluded from all projections.
 
 ### Index name derivation
 
@@ -260,7 +266,8 @@ In this example:
 | `@indexName("name")` | `Model` (projection) | Sets an explicit index name for the projection. | `@indexName("pets_v1") model PetSearchDoc ...` |
 | `@indexSettings(json)` | `Model` (projection) | Embeds index settings (e.g. analysis config) in the mapping output. Value must be valid JSON. | See example below. |
 | `@searchAs("name")` | `ModelProperty` | Renames the field in mapping and TypeScript output. Can be set on source or projection (projection wins). | `@searchAs("firstName") givenName: string;` |
-| `@aggregatable(...kinds)` | `ModelProperty` | Declares OpenSearch aggregations to expose on the GraphQL connection. Allowed kinds: `"terms"`, `"cardinality"`, `"missing"`. Multi-arg emits all listed kinds. | `@aggregatable("terms", "cardinality") locations: Location[];` |
+| `@aggregatable(...kinds)` | `ModelProperty` | Declares OpenSearch aggregations to expose on the GraphQL connection. Allowed kinds: `"terms"`, `"cardinality"`, `"missing"`, `"sum"`, `"avg"`, `"min"`, `"max"`. Multi-arg emits all listed kinds. Numeric metric kinds (`sum`/`avg`/`min`/`max`) emit a nullable `Float` field on the aggregations type — OpenSearch returns `null` when no documents match. | `@aggregatable("terms", "cardinality") locations: Location[];` / `@aggregatable("sum", "avg") notional: float64;` |
+| `@filterable(...kinds)` | `ModelProperty` | Declares filter inputs on the GraphQL `<Type>SearchFilter` input. Allowed kinds: `"term"`, `"term_negate"`, `"exists"`, `"range"`. On a `@nested` array field, `"exists"` becomes a path-level nested-existence check (`true` matches docs with at least one nested element; `false` matches docs with none). | `@filterable("term", "term_negate") status: string;` / `@filterable("exists") @nested tags: Tag[];` |
 
 ## Type mapping
 

--- a/src/aggregations.test.ts
+++ b/src/aggregations.test.ts
@@ -80,6 +80,24 @@ describe("aggregationFieldName", () => {
 	it("handles -ies plural", () => {
 		assert.equal(aggregationFieldName("categories", "terms"), "byCategory");
 	});
+
+	it("emits <field><Sum|Avg|Min|Max> for numeric metric aggs", () => {
+		assert.equal(aggregationFieldName("notional", "sum"), "notionalSum");
+		assert.equal(aggregationFieldName("notional", "avg"), "notionalAvg");
+		assert.equal(aggregationFieldName("rank", "min"), "rankMin");
+		assert.equal(aggregationFieldName("rank", "max"), "rankMax");
+	});
+
+	it("prefixes nested-path numeric metric aggs with the singularized parent", () => {
+		assert.equal(
+			aggregationFieldName("notional", "sum", "trades"),
+			"tradeNotionalSum",
+		);
+		assert.equal(
+			aggregationFieldName("validTo", "max", "approvals"),
+			"approvalValidToMax",
+		);
+	});
 });
 
 describe("singularize", () => {

--- a/src/aggregations.ts
+++ b/src/aggregations.ts
@@ -131,6 +131,11 @@ function isTextField(field: ResolvedProjectionField): boolean {
 	if (field.keyword) {
 		return false;
 	}
+	// Non-searchable string fields are mapped directly as keyword (see
+	// emit-mapping.ts), so there is no `.keyword` sub-field to address.
+	if (!field.searchable) {
+		return false;
+	}
 	if (field.subProjection) {
 		return false;
 	}

--- a/src/aggregations.ts
+++ b/src/aggregations.ts
@@ -92,6 +92,7 @@ export function aggregationFieldName(
 	const fieldPart = capitalize(singularize(fieldName));
 	const prefix = nestedPath ? nestedPathPrefix(nestedPath) : "";
 	const capital = `${prefix}${fieldPart}`;
+	const camel = lowerFirst(capital);
 	switch (kind) {
 		case "terms":
 			return `by${capital}`;
@@ -99,7 +100,20 @@ export function aggregationFieldName(
 			return `unique${capital}Count`;
 		case "missing":
 			return `missing${capital}Count`;
+		case "sum":
+			return `${camel}Sum`;
+		case "avg":
+			return `${camel}Avg`;
+		case "min":
+			return `${camel}Min`;
+		case "max":
+			return `${camel}Max`;
 	}
+}
+
+function lowerFirst(name: string): string {
+	if (name.length === 0) return name;
+	return name[0].toLowerCase() + name.slice(1);
 }
 
 function nestedPathPrefix(nestedPath: string): string {

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -259,6 +259,13 @@ export function getAggregatableKinds(
 	return stored as AggregationKind[];
 }
 
+export function hasAggregatable(
+	program: Program,
+	target: ModelProperty,
+): boolean {
+	return program.stateMap(StateKeys.aggregatable).has(target);
+}
+
 export const FILTERABLE_KINDS = [
 	"term",
 	"term_negate",
@@ -312,6 +319,13 @@ export function getFilterableKinds(
 		return undefined;
 	}
 	return stored as FilterableKind[];
+}
+
+export function hasFilterable(
+	program: Program,
+	target: ModelProperty,
+): boolean {
+	return program.stateMap(StateKeys.filterable).has(target);
 }
 
 export function $searchAs(

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -209,7 +209,15 @@ function isArrayOfModelType(type: Type): boolean {
 	return elementType?.kind === "Model";
 }
 
-export const AGGREGATION_KINDS = ["terms", "cardinality", "missing"] as const;
+export const AGGREGATION_KINDS = [
+	"terms",
+	"cardinality",
+	"missing",
+	"sum",
+	"avg",
+	"min",
+	"max",
+] as const;
 export type AggregationKind = (typeof AGGREGATION_KINDS)[number];
 
 function isAggregationKind(value: string): value is AggregationKind {

--- a/src/emit-graphql-resolver.test.ts
+++ b/src/emit-graphql-resolver.test.ts
@@ -310,6 +310,44 @@ describe("emitGraphQLResolver", () => {
 		);
 	});
 
+	it("emits sum/avg/min/max numeric metric aggs", () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "notional",
+					type: { kind: "Scalar", name: "float64" } as unknown as Type,
+					aggregations: ["sum", "avg"],
+				}),
+				makeField({
+					name: "rank",
+					type: { kind: "Scalar", name: "int32" } as unknown as Type,
+					aggregations: ["min", "max"],
+				}),
+			],
+		});
+		const result = emitGraphQLResolver(projection, defaultOptions);
+
+		assert.ok(
+			result.content.includes('notionalSum: { sum: { field: "notional" } }'),
+		);
+		assert.ok(
+			result.content.includes('notionalAvg: { avg: { field: "notional" } }'),
+		);
+		assert.ok(result.content.includes('rankMin: { min: { field: "rank" } }'));
+		assert.ok(result.content.includes('rankMax: { max: { field: "rank" } }'));
+
+		assert.ok(
+			result.content.includes(
+				"notionalSum: parsedBody.aggregations?.notionalSum?.value ?? null",
+			),
+		);
+		assert.ok(
+			result.content.includes(
+				"rankMax: parsedBody.aggregations?.rankMax?.value ?? null",
+			),
+		);
+	});
+
 	it("wraps aggs inside @nested sub-projection in nested+inner block", () => {
 		const subProjection = {
 			projectionModel: { name: "TagSearchDoc" },
@@ -398,7 +436,8 @@ describe("emitGraphQLResolver", () => {
 		assert.ok(
 			result.content.includes('byTag: { terms: { field: "tags.keyword" } }'),
 		);
-		assert.ok(!result.content.includes("nested: { path:"));
+		// Aggs for non-@nested fields must not be wrapped in `{ nested: ... }`.
+		assert.ok(!result.content.includes("byTag: { nested:"));
 	});
 
 	it("emits aggregations mapping in response", () => {
@@ -735,6 +774,7 @@ describe("emitGraphQLResolver search filter DSL", () => {
 					name: "species",
 					keyword: true,
 					filterables: ["term", "term_negate"],
+					aggregations: ["terms", "cardinality", "missing"],
 				}),
 				makeField({
 					name: "rank",
@@ -746,9 +786,21 @@ describe("emitGraphQLResolver search filter DSL", () => {
 					filterables: ["exists"],
 				}),
 				makeField({
+					name: "notional",
+					type: { kind: "Scalar", name: "float64" } as unknown as Type,
+					aggregations: ["sum", "avg", "min", "max"],
+				}),
+				makeField({
+					name: "counterpartyId",
+					keyword: true,
+					searchable: false,
+					filterables: ["term"],
+				}),
+				makeField({
 					name: "tags",
 					nested: true,
 					subProjection: nestedTagSubProjection(),
+					filterables: ["exists"],
 					type: {
 						kind: "Model",
 						name: "Array",
@@ -818,6 +870,66 @@ describe("emitGraphQLResolver search filter DSL", () => {
 		} finally {
 			await rm(dir, { recursive: true, force: true });
 		}
+	});
+
+	it('emits nested_exists FILTER_SPEC entry for @filterable("exists") on a @nested array field', () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "tags",
+					nested: true,
+					subProjection: nestedTagSubProjection(),
+					filterables: ["exists"],
+					type: {
+						kind: "Model",
+						name: "Array",
+						indexer: { value: { kind: "Model" } },
+					} as unknown as Type,
+				}),
+			],
+		});
+		const result = emitGraphQLResolver(projection, defaultOptions);
+		assert.ok(
+			result.content.includes(
+				'inputName: "tagsExists", kind: "nested_exists", path: "tags"',
+			),
+			"FILTER_SPEC must carry a nested_exists entry with the path",
+		);
+	});
+
+	it("buildQuery translates tagsExists: true into nested+match_all in bool.filter", () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "tags",
+					nested: true,
+					subProjection: nestedTagSubProjection(),
+					filterables: ["exists"],
+					type: {
+						kind: "Model",
+						name: "Array",
+						indexer: { value: { kind: "Model" } },
+					} as unknown as Type,
+				}),
+			],
+		});
+		const buildQuery = loadBuildQuery(
+			emitGraphQLResolver(projection, defaultOptions).content,
+		);
+
+		const truthy = buildQuery(undefined, undefined, { tagsExists: true });
+		assert.deepEqual(truthy, {
+			bool: {
+				filter: [{ nested: { path: "tags", query: { match_all: {} } } }],
+			},
+		});
+
+		const falsy = buildQuery(undefined, undefined, { tagsExists: false });
+		assert.deepEqual(falsy, {
+			bool: {
+				must_not: [{ nested: { path: "tags", query: { match_all: {} } } }],
+			},
+		});
 	});
 
 	it("buildQuery preserves nested-filter semantics for deeply structured input", () => {

--- a/src/emit-graphql-resolver.test.ts
+++ b/src/emit-graphql-resolver.test.ts
@@ -29,6 +29,7 @@ function makeField(
 		keyword: boolean;
 		nested: boolean;
 		optional: boolean;
+		searchable: boolean;
 		type: Type;
 		aggregations: ResolvedProjection["fields"][0]["aggregations"];
 		filterables: ResolvedProjection["fields"][0]["filterables"];
@@ -41,7 +42,7 @@ function makeField(
 		keyword: overrides.keyword ?? false,
 		nested: overrides.nested ?? false,
 		optional: overrides.optional ?? false,
-		searchable: true,
+		searchable: overrides.searchable ?? true,
 		type:
 			overrides.type ??
 			({
@@ -138,6 +139,53 @@ describe("emitGraphQLResolver", () => {
 		const result = emitGraphQLResolver(projection, defaultOptions);
 
 		assert.ok(result.content.includes('["name"]'));
+	});
+
+	it("excludes non-searchable filter-only fields from text_fields and keyword_fields but includes them in FILTER_SPEC", () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({ name: "name" }),
+				makeField({
+					name: "counterpartyId",
+					keyword: true,
+					searchable: false,
+					filterables: ["term"],
+				}),
+			],
+		});
+		const result = emitGraphQLResolver(projection, defaultOptions);
+
+		assert.ok(
+			result.content.includes('fields: ["name"]'),
+			"counterpartyId is not @searchable so must not appear in multi_match fields",
+		);
+		assert.ok(
+			result.content.includes(
+				'inputName: "counterpartyId", kind: "term", field: "counterpartyId"',
+			),
+			"FILTER_SPEC must carry the term filter for the non-searchable field",
+		);
+	});
+
+	it("excludes non-searchable agg-only fields from text/keyword sets but includes them in aggs", () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({ name: "name" }),
+				makeField({
+					name: "type",
+					keyword: true,
+					searchable: false,
+					aggregations: ["terms"],
+				}),
+			],
+		});
+		const result = emitGraphQLResolver(projection, defaultOptions);
+
+		assert.ok(result.content.includes('fields: ["name"]'));
+		assert.ok(
+			result.content.includes("byType:"),
+			"aggregation should still be emitted for non-searchable agg-only field",
+		);
 	});
 
 	it("respects custom page size and track_total_hits options", () => {

--- a/src/emit-graphql-resolver.ts
+++ b/src/emit-graphql-resolver.ts
@@ -43,12 +43,17 @@ export function emitGraphQLResolver(
 
 	const textFields = projection.fields
 		.filter(
-			(f) => !f.keyword && !f.nested && !f.subProjection && hasTextType(f),
+			(f) =>
+				f.searchable &&
+				!f.keyword &&
+				!f.nested &&
+				!f.subProjection &&
+				hasTextType(f),
 		)
 		.map((f) => f.projectedName ?? f.name);
 
 	const keywordFields = projection.fields
-		.filter((f) => f.keyword)
+		.filter((f) => f.searchable && f.keyword)
 		.map((f) => f.projectedName ?? f.name);
 
 	const aggregations = collectAggregations(projection);

--- a/src/emit-graphql-resolver.ts
+++ b/src/emit-graphql-resolver.ts
@@ -301,6 +301,17 @@ function applyFilterSpec(rootSpec, rootInput, rootOutFilters, rootOutMustNots) {
 								outMustNots.push({ exists: { field: node.field } });
 							}
 						}
+					} else if (node.kind === "nested_exists") {
+						if (value != null) {
+							const nestedClause = {
+								nested: { path: node.path, query: { match_all: {} } },
+							};
+							if (value === true) {
+								outFilters.push(nestedClause);
+							} else {
+								outMustNots.push(nestedClause);
+							}
+						}
 					} else if (node.kind === "range") {
 						if (value != null) {
 							const bucket = (rangeBuckets[node.field] = rangeBuckets[node.field] || {});
@@ -335,6 +346,9 @@ function stringifyNode(node: FilterSpecNode): string {
 	if (node.kind === "nested") {
 		const children = stringifySpec(node.children ?? []);
 		return `{ inputName: ${JSON.stringify(node.inputName)}, kind: "nested", path: ${JSON.stringify(node.path ?? "")}, children: ${children} }`;
+	}
+	if (node.kind === "nested_exists") {
+		return `{ inputName: ${JSON.stringify(node.inputName)}, kind: "nested_exists", path: ${JSON.stringify(node.path ?? "")} }`;
 	}
 	if (node.kind === "range") {
 		return `{ inputName: ${JSON.stringify(node.inputName)}, kind: "range", field: ${JSON.stringify(node.field ?? "")}, bound: ${JSON.stringify(node.bound ?? "")} }`;
@@ -384,6 +398,11 @@ function renderResponseAggregationLine(entry: AggregationEntry): string {
 			return `\t\t\t${entry.aggName}: ${path}?.value ?? 0,`;
 		case "missing":
 			return `\t\t\t${entry.aggName}: ${path}?.doc_count ?? 0,`;
+		case "sum":
+		case "avg":
+		case "min":
+		case "max":
+			return `\t\t\t${entry.aggName}: ${path}?.value ?? null,`;
 	}
 }
 
@@ -395,6 +414,14 @@ function osAggType(kind: AggregationEntry["kind"]): string {
 			return "cardinality";
 		case "missing":
 			return "missing";
+		case "sum":
+			return "sum";
+		case "avg":
+			return "avg";
+		case "min":
+			return "min";
+		case "max":
+			return "max";
 	}
 }
 

--- a/src/emit-graphql-sdl.test.ts
+++ b/src/emit-graphql-sdl.test.ts
@@ -266,6 +266,28 @@ describe("emitGraphQLSdl aggregations", () => {
 		);
 	});
 
+	it("emits nullable Float for sum/avg/min/max numeric metric aggs", () => {
+		const projection = makeProjection({
+			name: "TradeSearchDoc",
+			fields: [
+				makeField({
+					name: "notional",
+					type: { kind: "Scalar", name: "float64" } as unknown as Type,
+					aggregations: ["sum", "avg", "min", "max"],
+				}),
+			],
+		});
+
+		const result = emitGraphQLSdl(dummyProgram, projection, defaultOptions);
+		assert.ok(result.content.includes("type TradeSearchAggregations {"));
+		assert.ok(result.content.includes("notionalSum: Float\n"));
+		assert.ok(result.content.includes("notionalAvg: Float\n"));
+		assert.ok(result.content.includes("notionalMin: Float\n"));
+		assert.ok(result.content.includes("notionalMax: Float"));
+		// Must not be non-null — OpenSearch returns null when no docs match.
+		assert.ok(!result.content.includes("notionalSum: Float!"));
+	});
+
 	it("emits nested-aware aggregation field names from sub-projections", () => {
 		const subProjection = {
 			projectionModel: { name: "TagSearchDoc" },

--- a/src/emit-graphql-sdl.test.ts
+++ b/src/emit-graphql-sdl.test.ts
@@ -31,6 +31,7 @@ function makeField(
 		keyword: boolean;
 		nested: boolean;
 		optional: boolean;
+		searchable: boolean;
 		analyzer: string;
 		boost: number;
 		type: Type;
@@ -45,7 +46,7 @@ function makeField(
 		keyword: overrides.keyword ?? false,
 		nested: overrides.nested ?? false,
 		optional: overrides.optional ?? false,
-		searchable: true,
+		searchable: overrides.searchable ?? true,
 		analyzer: overrides.analyzer,
 		boost: overrides.boost,
 		type:
@@ -123,6 +124,55 @@ describe("emitGraphQLSdl", () => {
 
 		const result = emitGraphQLSdl(dummyProgram, projection, defaultOptions);
 		assert.ok(!result.content.includes("Filter"));
+	});
+
+	it("excludes non-searchable filter-only fields from the response object type", () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({ name: "name" }),
+				makeField({
+					name: "counterpartyId",
+					keyword: true,
+					searchable: false,
+					filterables: ["term"],
+				}),
+			],
+		});
+
+		const result = emitGraphQLSdl(dummyProgram, projection, defaultOptions);
+		const objectTypeBlock = result.content.split("\n\n")[0];
+		assert.ok(objectTypeBlock.includes("name: String!"));
+		assert.ok(
+			!objectTypeBlock.includes("counterpartyId"),
+			"filter-only field must not appear on the response object type",
+		);
+		// But it should still appear in the SearchFilter input.
+		assert.ok(result.content.includes("counterpartyId: String"));
+	});
+
+	it("excludes non-searchable @keyword fields from the legacy <Type>Filter input", () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({ name: "species", keyword: true }),
+				makeField({
+					name: "counterpartyId",
+					keyword: true,
+					searchable: false,
+					filterables: ["term"],
+				}),
+			],
+		});
+
+		const result = emitGraphQLSdl(dummyProgram, projection, defaultOptions);
+		const filterBlock = result.content.match(
+			/input PetSearchDocFilter \{[^}]*\}/,
+		)?.[0];
+		assert.ok(filterBlock, "PetSearchDocFilter block should exist");
+		assert.ok(filterBlock.includes("species: String"));
+		assert.ok(
+			!filterBlock.includes("counterpartyId"),
+			"non-searchable @keyword fields must not appear in <Type>Filter",
+		);
 	});
 
 	it("generates connection types", () => {

--- a/src/emit-graphql-sdl.ts
+++ b/src/emit-graphql-sdl.ts
@@ -140,7 +140,7 @@ function renderSearchFilterField(
 	if (node.kind === "nested") {
 		return `  ${node.inputName}: ${node.nestedTypeName ?? "String"}`;
 	}
-	if (node.kind === "exists") {
+	if (node.kind === "exists" || node.kind === "nested_exists") {
 		return `  ${node.inputName}: Boolean`;
 	}
 	const gqlType = node.sourceField
@@ -203,7 +203,7 @@ function renderAggregationTypes(
 ): string {
 	const aggregationsType = aggregationsTypeName(typeName);
 	const fieldLines = entries.map((entry) => {
-		const gqlType = entry.kind === "terms" ? "[TermBucket!]!" : "Int!";
+		const gqlType = aggregationGraphQLType(entry.kind);
 		return `  ${entry.aggName}: ${gqlType}`;
 	});
 
@@ -219,6 +219,22 @@ function renderAggregationTypes(
 	];
 
 	return lines.join("\n");
+}
+
+function aggregationGraphQLType(kind: AggregationEntry["kind"]): string {
+	switch (kind) {
+		case "terms":
+			return "[TermBucket!]!";
+		case "cardinality":
+		case "missing":
+			return "Int!";
+		case "sum":
+		case "avg":
+		case "min":
+		case "max":
+			// Nullable: OpenSearch returns null when no documents match the agg.
+			return "Float";
+	}
 }
 
 function toGraphQLType(

--- a/src/emit-graphql-sdl.ts
+++ b/src/emit-graphql-sdl.ts
@@ -71,19 +71,25 @@ function renderObjectType(
 	projection: ResolvedProjection,
 ): string {
 	const typeName = projection.projectionModel.name;
-	const fieldLines = projection.fields.map((field) => {
-		const gqlName = field.projectedName ?? field.name;
-		const gqlType = toGraphQLType(program, field.type, field);
-		const nullable = field.optional ? "" : "!";
-		return `  ${gqlName}: ${gqlType}${nullable}`;
-	});
+	// Filter-only / aggregatable-only fields exist in the OpenSearch index for
+	// query-time use but are not part of the user-facing response shape.
+	const fieldLines = projection.fields
+		.filter((field) => field.searchable)
+		.map((field) => {
+			const gqlName = field.projectedName ?? field.name;
+			const gqlType = toGraphQLType(program, field.type, field);
+			const nullable = field.optional ? "" : "!";
+			return `  ${gqlName}: ${gqlType}${nullable}`;
+		});
 
 	return `type ${typeName} {\n${fieldLines.join("\n")}\n}`;
 }
 
 function renderFilterInput(projection: ResolvedProjection): string | undefined {
 	const typeName = projection.projectionModel.name;
-	const keywordFields = projection.fields.filter((f) => f.keyword);
+	const keywordFields = projection.fields.filter(
+		(f) => f.searchable && f.keyword,
+	);
 
 	if (keywordFields.length === 0) {
 		return undefined;

--- a/src/emit-mapping.test.ts
+++ b/src/emit-mapping.test.ts
@@ -118,6 +118,45 @@ describe("mapping emitter", () => {
 		assert.equal(result.fields, undefined);
 	});
 
+	it("maps non-searchable filter-only string fields as plain keyword (no text+keyword sub-field)", () => {
+		const projection = {
+			projectionModel: { name: "PetSearchDoc" },
+			sourceModel: { name: "Pet" },
+			indexName: "pets_v1",
+			fields: [
+				{
+					name: "name",
+					searchable: true,
+					keyword: false,
+					nested: false,
+					optional: false,
+					type: { kind: "Scalar", name: "string" },
+				},
+				{
+					name: "counterpartyId",
+					searchable: false,
+					keyword: false,
+					nested: false,
+					optional: false,
+					filterables: ["term"],
+					type: { kind: "Scalar", name: "string" },
+				},
+			],
+		} as never;
+
+		const dummyProgram = {} as never;
+		const emitted = emitMapping(dummyProgram, projection);
+		const parsed = JSON.parse(emitted.content);
+
+		assert.equal(parsed.mappings.properties.name.type, "text");
+		assert.equal(
+			parsed.mappings.properties.counterpartyId.type,
+			"keyword",
+			"filter-only string fields must map directly to keyword (no text analysis)",
+		);
+		assert.equal(parsed.mappings.properties.counterpartyId.fields, undefined);
+	});
+
 	it("maps boolean fields", async () => {
 		const runner = await createRunner();
 		const diagnostics = await runner.diagnose(`

--- a/src/emit-mapping.ts
+++ b/src/emit-mapping.ts
@@ -171,7 +171,9 @@ function buildPropertiesFromFields(
 						program,
 						field.type,
 						{
-							keyword: field.keyword,
+							// A filter-only / agg-only string field has no full-text-search
+							// surface, so map it as plain keyword instead of text+keyword.
+							keyword: field.keyword || !field.searchable,
 							nested: field.nested,
 							analyzer: field.analyzer,
 							boost: field.boost,

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -183,12 +183,17 @@ export function searchFilterTypeName(projectionName: string): string {
 export interface FilterSpecNode {
 	/** Local input field name on the parent SearchFilter input. */
 	inputName: string;
-	kind: FilterableKind | "nested";
+	/**
+	 * `nested_exists` is an emit-time kind used when `@filterable("exists")` is
+	 * applied to a `@nested` array field — the resolver translates it as
+	 * `nested + match_all` (true) or `must_not nested + match_all` (false).
+	 */
+	kind: FilterableKind | "nested" | "nested_exists";
 	/** OpenSearch field path (only set on leaf kinds, not `nested`). */
 	field?: string;
 	/** Source projection field (set on leaf kinds only; SDL renders use this for GraphQL type lookup). */
 	sourceField?: ResolvedProjectionField;
-	/** Nested doc path (only set on `nested` kind). */
+	/** Nested doc path (set on `nested` and `nested_exists`). */
 	path?: string;
 	/** Children (only set on `nested` kind). */
 	children?: FilterSpecNode[];
@@ -226,12 +231,19 @@ function buildShapeRecursive(
 			if (field.filterables && field.filterables.length > 0) {
 				const entries = filterableEntriesForField(field, parentPath);
 				for (const entry of entries) {
+					// @filterable("exists") on a @nested array field becomes a
+					// nested-existence check at emit time (see FilterSpecNode.kind).
+					const isNestedPathExists =
+						entry.kind === "exists" && field.nested && !!field.subProjection;
 					nodes.push({
 						inputName: entry.inputFieldName,
-						kind: entry.kind,
+						kind: isNestedPathExists ? "nested_exists" : entry.kind,
 						field: entry.openSearchField,
 						sourceField: entry.field,
 						bound: entry.rangeBound,
+						path: isNestedPathExists
+							? joinNestedPath(parentPath, field.projectedName ?? field.name)
+							: undefined,
 					});
 				}
 			}

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -128,6 +128,9 @@ function joinNestedPath(parent: string | undefined, segment: string): string {
  */
 function needsKeywordSuffix(field: ResolvedProjectionField): boolean {
 	if (field.keyword) return false;
+	// Non-searchable string fields are mapped directly as keyword (see
+	// emit-mapping.ts), so there is no `.keyword` sub-field to address.
+	if (!field.searchable) return false;
 	if (field.subProjection) return false;
 	return isStringLikeType(field.type);
 }

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -10,10 +10,21 @@ import {
 	getIndexName,
 	getIndexSettings,
 	getSearchAs,
+	hasAggregatable,
+	hasFilterable,
 	isKeyword,
 	isNested,
 	isSearchable,
 } from "./decorators.js";
+
+function isReachable(program: Program, prop: ModelProperty): boolean {
+	return (
+		isSearchable(program, prop) ||
+		hasFilterable(program, prop) ||
+		hasAggregatable(program, prop)
+	);
+}
+
 import { reportDiagnostic } from "./lib.js";
 
 export interface ResolvedProjectionField {
@@ -84,7 +95,7 @@ export function resolveProjectionModel(
 
 	const fields: ResolvedProjectionField[] = [];
 	for (const sourceProperty of sourceModel.properties.values()) {
-		if (!isSearchable(program, sourceProperty)) {
+		if (!isReachable(program, sourceProperty)) {
 			continue;
 		}
 
@@ -127,8 +138,8 @@ export function resolveProjectionModel(
 		if (isSpreadFromOtherModel) {
 			const spreadSourceProp = projProp.sourceProperty!;
 
-			// Only include @searchable fields from the spread source
-			if (!isSearchable(program, spreadSourceProp)) {
+			// Only include reachable fields from the spread source
+			if (!isReachable(program, spreadSourceProp)) {
 				continue;
 			}
 
@@ -156,7 +167,7 @@ export function resolveProjectionModel(
 			continue;
 		}
 
-		if (!sourceProp || !isSearchable(program, sourceProp)) {
+		if (!sourceProp || !isReachable(program, sourceProp)) {
 			// Allow sub-projection fields that reference a valid source field
 			const subProj = resolveSubProjectionFromType(program, projProp.type);
 			if (!subProj || !sourceProp) {
@@ -212,7 +223,7 @@ function resolveProjectionField(
 		optional: projectionProperty?.optional ?? sourceProperty.optional,
 		sourceProperty,
 		projectionProperty,
-		searchable: true,
+		searchable: isSearchable(program, sourceProperty),
 		keyword:
 			(projectionProperty && isKeyword(program, projectionProperty)) ||
 			isKeyword(program, sourceProperty),
@@ -257,7 +268,7 @@ function resolveSubProjectionModel(
 
 	const fields: ResolvedProjectionField[] = [];
 	for (const sourceProperty of sourceModel.properties.values()) {
-		if (!isSearchable(program, sourceProperty)) {
+		if (!isReachable(program, sourceProperty)) {
 			continue;
 		}
 


### PR DESCRIPTION
Bundles the gating fix from #88 with the no-config tier of #86.

## Summary

### #88 — projection gating fix

The projection walker (`src/projection.ts`) gated field inclusion on `@searchable` only, so a source-model field with only `@filterable` or `@aggregatable` was silently dropped along with its decorator. This produced missing filter inputs and aggregation buckets at runtime with no warning.

A field is now admitted to the resolved projection if it carries any of `@searchable`, `@filterable`, or `@aggregatable`. Each role then dictates what artefact it contributes to:

| Decorator | SDL response object | `<Type>SearchFilter` input | aggregations type | OS mapping |
| --- | --- | --- | --- | --- |
| `@searchable` | yes | (only if also `@filterable`) | (only if also `@aggregatable`) | text-or-keyword |
| `@filterable` | no | yes | no | keyword |
| `@aggregatable` | no | no | yes | keyword |

Filter-only / agg-only string fields are mapped as plain `keyword` (no `text`+`keyword` sub-field) since there's no full-text search surface; the `.keyword` suffix logic in `filters.ts` and `aggregations.ts` is updated accordingly so the resolver queries the correct OS path.

### #86 — no-config aggregation/filter additions

- **Numeric metric aggs**: `@aggregatable("sum"|"avg"|"min"|"max")` on a numeric field emits a single-value metric. SDL exposes them as nullable `Float` (`<field>Sum: Float`, etc.) since OpenSearch returns `null` when no documents match.
- **Nested-path `exists` filter**: `@filterable("exists")` on a `@nested` array field becomes a path-level existence check. The resolver translates `<path>Exists: true` to `bool.filter[ nested{ path, query: match_all{} } ]` and `false` to the matching `bool.must_not[...]`. Internally this is a new `nested_exists` FilterSpecNode kind computed at emit time; user-facing decorator surface is unchanged.
- **`term_negate` on nested leaves**: already worked — confirmed by the existing _buildQuery wraps nested term_negate inside nested under outer must_not_ test. No code change needed.

### Backwards compatibility

- `@aggregatable("terms", "cardinality", "missing")` multi-arg syntax preserved.
- All current decorator combinations (everything carries `@searchable`) continue to behave identically — existing snapshot fixtures stay byte-identical.
- New kinds slot into the same multi-arg form: `@aggregatable("terms", "sum", "avg")`.

### Deferred (follow-up)

The config-bearing #86 kinds need a TypeSpec value-type second arg on `@aggregatable` and are tracked for a follow-up PR:
- `date_histogram` with `{ interval }`
- Range bucket aggregation with `{ ranges }`
- Nested sub-aggregations on `terms` with `{ sub: {...} }`

The follow-up will keep the multi-arg form for simple kinds and add a separate `@aggregatable("kind", #{options})` form for the config-bearing ones.

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint` clean (warnings unchanged)
- [x] Targeted tests across resolver/SDL/mapping/aggregations/filters: 119/119 pass (5 new for #88 + 4 new for #86)
- [x] Resolver still passes `@aws-appsync/eslint-plugin` recommended config — fixture extended to cover numeric aggs + nested_exists branch + filter-only field, the lint covers all new resolver code paths
- [x] Existing snapshot fixtures byte-identical (current decorator combos all carry `@searchable`)
- [x] README decorator reference updated for `@aggregatable` (new kinds) and `@filterable` (new row)
- [ ] CI green on Node lts/*

Closes #88. Refs #86 (partial — config-bearing kinds deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)