### PR TITLE
fix(emitter): date_histogram resolver uses template literal, not String() — APPSYNC_JS deploy fix

### DIFF
--- a/src/emit-graphql-resolver.test.ts
+++ b/src/emit-graphql-resolver.test.ts
@@ -339,8 +339,9 @@ describe("emitGraphQLResolver", () => {
 		);
 		assert.ok(
 			result.content.includes(
-				"byValidFromOverTime: (parsedBody.aggregations?.byValidFromOverTime?.buckets ?? []).map((b) => ({ key: b.key_as_string ?? String(b.key), count: b.doc_count }))",
+				"byValidFromOverTime: (parsedBody.aggregations?.byValidFromOverTime?.buckets ?? []).map((b) => ({ key: `${b.key_as_string ?? b.key}`, keyAsString: b.key_as_string ?? null, count: b.doc_count }))",
 			),
+			"date_histogram response must use template-literal coercion (APPSYNC_JS forbids String()) and surface keyAsString",
 		);
 	});
 
@@ -863,6 +864,60 @@ describe("emitGraphQLResolver search filter DSL", () => {
 				filter: [{ term: { species: "cat" } }],
 			},
 		});
+	});
+
+	it("emitted resolver contains no forbidden global coercion calls (String, Number, Boolean, Array, Object)", () => {
+		// APPSYNC_JS rejects these globals at deploy time even though
+		// @aws-appsync/eslint-plugin doesn't flag them (no rule covers
+		// global function calls). Use template literals (\`${x}\`) for
+		// string coercion and arithmetic / comparisons for the others.
+		const projection = makeProjection({
+			fields: [
+				makeField({ name: "name" }),
+				makeField({
+					name: "validFrom",
+					type: { kind: "Scalar", name: "utcDateTime" } as unknown as Type,
+					aggregations: [
+						{ kind: "date_histogram", options: { interval: "month" } },
+					],
+				}),
+				makeField({
+					name: "notional",
+					type: { kind: "Scalar", name: "float64" } as unknown as Type,
+					aggregations: [
+						{
+							kind: "range",
+							options: { ranges: [{ to: 1000 }, { from: 1000 }] },
+						},
+						"sum",
+						"avg",
+					],
+				}),
+				makeField({
+					name: "counterpartyId",
+					keyword: true,
+					aggregations: [
+						{
+							kind: "terms",
+							options: {
+								sub: { latestValidTo: { kind: "max", field: "validTo" } },
+							},
+						},
+					],
+				}),
+			],
+		});
+		const result = emitGraphQLResolver(projection, defaultOptions);
+
+		const forbidden = ["String", "Number", "Boolean", "Array", "Object"];
+		for (const name of forbidden) {
+			const re = new RegExp(`\\b${name}\\s*\\(`);
+			assert.equal(
+				re.test(result.content),
+				false,
+				`emitted resolver must not call \`${name}(...)\` — APPSYNC_JS rejects global coercion calls.\n--- emitted ---\n${result.content}\n--- end ---`,
+			);
+		}
 	});
 
 	it("emitted resolver passes @aws-appsync/eslint-plugin recommended config", async () => {

--- a/src/emit-graphql-resolver.ts
+++ b/src/emit-graphql-resolver.ts
@@ -448,7 +448,11 @@ function renderResponseAggregationLine(entry: AggregationEntry): string {
 		case "max":
 			return `\t\t\t${entry.aggName}: ${path}?.value ?? null,`;
 		case "date_histogram":
-			return `\t\t\t${entry.aggName}: (${path}?.buckets ?? []).map((b) => ({ key: b.key_as_string ?? String(b.key), count: b.doc_count })),`;
+			// Template-literal coercion only — APPSYNC_JS rejects String() at
+			// deploy time, and the eslint-plugin doesn't flag global function
+			// calls. Both `key` and `keyAsString` are surfaced so callers can
+			// access the formatted-date form OS provides for calendar_interval.
+			return `\t\t\t${entry.aggName}: (${path}?.buckets ?? []).map((b) => ({ key: \`\${b.key_as_string ?? b.key}\`, keyAsString: b.key_as_string ?? null, count: b.doc_count })),`;
 		case "range":
 			return `\t\t\t${entry.aggName}: (${path}?.buckets ?? []).map((b) => ({ key: b.key, from: b.from ?? null, to: b.to ?? null, count: b.doc_count })),`;
 	}

--- a/src/emit-graphql-sdl.test.ts
+++ b/src/emit-graphql-sdl.test.ts
@@ -291,6 +291,10 @@ describe("emitGraphQLSdl aggregations", () => {
 		const result = emitGraphQLSdl(dummyProgram, projection, defaultOptions);
 		assert.ok(result.content.includes("type DateHistogramBucket {"));
 		assert.ok(
+			result.content.includes("keyAsString: String"),
+			"DateHistogramBucket must surface keyAsString so callers can read OS's formatted date string",
+		);
+		assert.ok(
 			result.content.includes("byValidFromOverTime: [DateHistogramBucket!]!"),
 		);
 	});

--- a/src/emit-graphql-sdl.ts
+++ b/src/emit-graphql-sdl.ts
@@ -241,6 +241,7 @@ function renderAggregationTypes(
 			[
 				"type DateHistogramBucket {",
 				"  key: String!",
+				"  keyAsString: String",
 				"  count: Int!",
 				"}",
 			].join("\n"),


### PR DESCRIPTION
Closes #93. Deploy-blocking — fixes the date_histogram resolver shipped in #91.

## Bug

PR #91's date_histogram response unwrap called \`String(b.key)\` as a fallback when OS doesn't provide \`key_as_string\`. APPSYNC_JS rejects \`String()\` at deploy time:

\`\`\`
INVALID_FUNCTION_INVOCATION: Invalid function: String
\`\`\`

The \`@aws-appsync/eslint-plugin\` recommended config (added in #87) didn't flag it because no rule covers global function calls — \`no-disallowed-methods\` only covers method calls on objects. Same class of footgun as #80 / #82 / #84: forbidden constructs that only the AWS code validator catches.

## Fix

- **Template-literal coercion**: \`\\\`\\\${b.key_as_string ?? b.key}\\\`\` instead of \`String(b.key)\`. APPSYNC_JS allows template literals.
- **Expose \`keyAsString\` on \`DateHistogramBucket\`**: Per option 1 of the issue. \`key\` always carries a string (whatever OS gave us, coerced); \`keyAsString\` is the raw \`key_as_string\` from OS (only populated when OS provides it via \`calendar_interval\` formatting). This is more honest to the underlying OS response.
- **New programmatic forbidden-globals test**: Greps the emitted resolver for \`String(\`, \`Number(\`, \`Boolean(\`, \`Array(\`, \`Object(\` invocations. Complements the \`@aws-appsync/eslint-plugin\` test (which doesn't catch these). Verified the test fails when the bug is re-injected.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm run lint\` clean (warnings unchanged)
- [x] Targeted suite: 61/61 pass in resolver + SDL tests
- [x] Negative check: temporarily re-injected \`String(b.key)\` → new forbidden-globals test fails as expected
- [ ] CI green on Node lts/*

🤖 Generated with [Claude Code](https://claude.com/claude-code)