### PR TITLE
feat(emitter): @searchInfer recurses into nested structs + shrink resolver bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,15 @@ Stacking `@filterable` and `@aggregatable` per field becomes noisy on a typical 
 | Enum / scalar union | `term`, `terms`, `exists` | `terms` | yes |
 | `bytes` | (none) | (none) | no |
 
+### Nested struct recursion
+
+When a field's type is a TypeSpec model (struct) — either inline (`address: Address`) or as an array (`tags: Tag[]`) — `@searchInfer` recurses into the nested model's properties and applies the same inference table. The parent's `<Type>SearchFilter` exposes `<fieldName>: <NestedType>SearchFilter`, and a separate `<NestedType>SearchFilter` input is emitted alongside.
+
+- **`@nested` array** (OS-nested mapping): filter clauses wrap in `bool.filter[ nested + inner ]`.
+- **Inline struct** (no `@nested`): children carry dotted OS field paths (`address.country`) — no nested wrapper.
+- **Recursion depth**: unbounded; cycles are guarded by a visited-name set.
+- **Opt-out**: `@searchSkip` on the parent's field suppresses the virtual sub-projection (and the parent skips the field when no other decorator keeps it in the projection).
+
 ### Override semantics
 
 - **No decorators on the field**: gets the inferred set from the table.

--- a/src/emit-graphql-resolver.test.ts
+++ b/src/emit-graphql-resolver.test.ts
@@ -170,9 +170,9 @@ describe("emitGraphQLResolver", () => {
 		);
 		assert.ok(
 			result.content.includes(
-				'inputName: "counterpartyId", kind: "term", field: "counterpartyId"',
+				'{i:"counterpartyId",k:"term",f:"counterpartyId"}',
 			),
-			"FILTER_SPEC must carry the term filter for the non-searchable field",
+			"FILTER_SPEC must carry the term filter for the non-searchable field (compact-key form)",
 		);
 	});
 
@@ -1204,10 +1204,8 @@ describe("emitGraphQLResolver search filter DSL", () => {
 		});
 		const result = emitGraphQLResolver(projection, defaultOptions);
 		assert.ok(
-			result.content.includes(
-				'inputName: "tagsExists", kind: "nested_exists", path: "tags"',
-			),
-			"FILTER_SPEC must carry a nested_exists entry with the path",
+			result.content.includes('{i:"tagsExists",k:"nested_exists",p:"tags"}'),
+			"FILTER_SPEC must carry a nested_exists entry with the path (compact-key form)",
 		);
 	});
 

--- a/src/emit-graphql-resolver.ts
+++ b/src/emit-graphql-resolver.ts
@@ -274,9 +274,12 @@ function applyFilterSpec(rootSpec, rootInput, rootOutFilters, rootOutMustNots) {
 				const outMustNots = item.outMustNots;
 				const rangeBuckets = {};
 
+				// FILTER_SPEC nodes use compact keys to fit under AppSync's 32 KB
+				// resolver code cap (issue #99): i=inputName, k=kind, f=field,
+				// p=path, c=children, b=bound. See stringifyNode in the emitter.
 				for (const node of spec) {
-					const value = input[node.inputName];
-					if (node.kind === "nested") {
+					const value = input[node.i];
+					if (node.k === "nested") {
 						if (value != null) {
 							const childFilters = [];
 							const childMustNots = [];
@@ -287,7 +290,7 @@ function applyFilterSpec(rootSpec, rootInput, rootOutFilters, rootOutMustNots) {
 							}
 							slots[tail] = {
 								kind: "process",
-								spec: node.children,
+								spec: node.c,
 								input: value,
 								outFilters: childFilters,
 								outMustNots: childMustNots,
@@ -295,7 +298,7 @@ function applyFilterSpec(rootSpec, rootInput, rootOutFilters, rootOutMustNots) {
 							tail = tail + 1;
 							slots[tail] = {
 								kind: "finalize",
-								path: node.path,
+								path: node.p,
 								childFilters,
 								childMustNots,
 								parentFilters: outFilters,
@@ -303,30 +306,46 @@ function applyFilterSpec(rootSpec, rootInput, rootOutFilters, rootOutMustNots) {
 							};
 							tail = tail + 1;
 						}
-					} else if (node.kind === "term") {
+					} else if (node.k === "object") {
 						if (value != null) {
-							outFilters.push({ term: { [node.field]: value } });
+							if (tail + 1 > slots.length) {
+								util.error(
+									"applyFilterSpec exceeded fixed work-slot capacity; SearchFilter shape too deep for APPSYNC_JS resolver",
+								);
+							}
+							slots[tail] = {
+								kind: "process",
+								spec: node.c,
+								input: value,
+								outFilters,
+								outMustNots,
+							};
+							tail = tail + 1;
 						}
-					} else if (node.kind === "term_negate") {
+					} else if (node.k === "term") {
 						if (value != null) {
-							outMustNots.push({ term: { [node.field]: value } });
+							outFilters.push({ term: { [node.f]: value } });
 						}
-					} else if (node.kind === "terms") {
+					} else if (node.k === "term_negate") {
+						if (value != null) {
+							outMustNots.push({ term: { [node.f]: value } });
+						}
+					} else if (node.k === "terms") {
 						if (value != null && value.length > 0) {
-							outFilters.push({ terms: { [node.field]: value } });
+							outFilters.push({ terms: { [node.f]: value } });
 						}
-					} else if (node.kind === "exists") {
+					} else if (node.k === "exists") {
 						if (value != null) {
 							if (value === true) {
-								outFilters.push({ exists: { field: node.field } });
+								outFilters.push({ exists: { field: node.f } });
 							} else {
-								outMustNots.push({ exists: { field: node.field } });
+								outMustNots.push({ exists: { field: node.f } });
 							}
 						}
-					} else if (node.kind === "nested_exists") {
+					} else if (node.k === "nested_exists") {
 						if (value != null) {
 							const nestedClause = {
-								nested: { path: node.path, query: { match_all: {} } },
+								nested: { path: node.p, query: { match_all: {} } },
 							};
 							if (value === true) {
 								outFilters.push(nestedClause);
@@ -334,10 +353,10 @@ function applyFilterSpec(rootSpec, rootInput, rootOutFilters, rootOutMustNots) {
 								outMustNots.push(nestedClause);
 							}
 						}
-					} else if (node.kind === "range") {
+					} else if (node.k === "range") {
 						if (value != null) {
-							const bucket = (rangeBuckets[node.field] = rangeBuckets[node.field] || {});
-							bucket[node.bound] = value;
+							const bucket = (rangeBuckets[node.f] = rangeBuckets[node.f] || {});
+							bucket[node.b] = value;
 						}
 					}
 				}
@@ -365,17 +384,26 @@ function stringifySpec(nodes: FilterSpecNode[]): string {
 }
 
 function stringifyNode(node: FilterSpecNode): string {
+	// FILTER_SPEC entries use single-letter keys to keep wide projections
+	// under AppSync's 32 KB resolver-code cap (issue #99). The reader is
+	// applyFilterSpec inside the emitted resolver; keys must match there:
+	//   i = inputName, k = kind, f = field, p = path, c = children, b = bound.
+	const i = JSON.stringify(node.inputName);
 	if (node.kind === "nested") {
 		const children = stringifySpec(node.children ?? []);
-		return `{ inputName: ${JSON.stringify(node.inputName)}, kind: "nested", path: ${JSON.stringify(node.path ?? "")}, children: ${children} }`;
+		return `{i:${i},k:"nested",p:${JSON.stringify(node.path ?? "")},c:${children}}`;
+	}
+	if (node.kind === "object") {
+		const children = stringifySpec(node.children ?? []);
+		return `{i:${i},k:"object",c:${children}}`;
 	}
 	if (node.kind === "nested_exists") {
-		return `{ inputName: ${JSON.stringify(node.inputName)}, kind: "nested_exists", path: ${JSON.stringify(node.path ?? "")} }`;
+		return `{i:${i},k:"nested_exists",p:${JSON.stringify(node.path ?? "")}}`;
 	}
 	if (node.kind === "range") {
-		return `{ inputName: ${JSON.stringify(node.inputName)}, kind: "range", field: ${JSON.stringify(node.field ?? "")}, bound: ${JSON.stringify(node.bound ?? "")} }`;
+		return `{i:${i},k:"range",f:${JSON.stringify(node.field ?? "")},b:${JSON.stringify(node.bound ?? "")}}`;
 	}
-	return `{ inputName: ${JSON.stringify(node.inputName)}, kind: ${JSON.stringify(node.kind)}, field: ${JSON.stringify(node.field ?? "")} }`;
+	return `{i:${i},k:${JSON.stringify(node.kind)},f:${JSON.stringify(node.field ?? "")}}`;
 }
 
 function renderAggsBlock(aggregations: AggregationEntry[]): string {

--- a/src/emit-graphql-sdl.ts
+++ b/src/emit-graphql-sdl.ts
@@ -143,7 +143,7 @@ function renderSearchFilterField(
 	program: Program,
 	node: FilterSpecNode,
 ): string {
-	if (node.kind === "nested") {
+	if (node.kind === "nested" || node.kind === "object") {
 		return `  ${node.inputName}: ${node.nestedTypeName ?? "String"}`;
 	}
 	if (node.kind === "exists" || node.kind === "nested_exists") {

--- a/src/filters.test.ts
+++ b/src/filters.test.ts
@@ -305,7 +305,7 @@ describe("buildSearchFilterShape", () => {
 		assert.equal(shape.nestedShapes[0].typeName, "TagSearchFilter");
 	});
 
-	it("inlines non-nested object sub-projections at the parent level", () => {
+	it("emits non-nested object sub-projections as a separate input type with dotted-path children (issue #98)", () => {
 		const ownerSub = {
 			projectionModel: { name: "OwnerSearchDoc" },
 			sourceModel: { name: "Owner" },
@@ -332,10 +332,17 @@ describe("buildSearchFilterShape", () => {
 
 		const shape = buildSearchFilterShape(projection);
 		assert.ok(shape);
-		// owner.name shows up as a flat leaf, not under a nested node.
+		// Parent input has one entry: `owner: OwnerSearchFilter`.
 		assert.equal(shape.nodes.length, 1);
-		assert.equal(shape.nodes[0].kind, "term");
-		assert.equal(shape.nodes[0].inputName, "name");
-		assert.equal(shape.nestedShapes.length, 0);
+		assert.equal(shape.nodes[0].kind, "object");
+		assert.equal(shape.nodes[0].inputName, "owner");
+		assert.equal(shape.nodes[0].nestedTypeName, "OwnerSearchFilter");
+		// Children carry dotted OS field paths.
+		assert.equal(shape.nodes[0].children?.[0].kind, "term");
+		assert.equal(shape.nodes[0].children?.[0].inputName, "name");
+		assert.equal(shape.nodes[0].children?.[0].field, "owner.name");
+		// Sub-shape is emitted as a separate input.
+		assert.equal(shape.nestedShapes.length, 1);
+		assert.equal(shape.nestedShapes[0].typeName, "OwnerSearchFilter");
 	});
 });

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -190,18 +190,18 @@ export interface FilterSpecNode {
 	 * applied to a `@nested` array field — the resolver translates it as
 	 * `nested + match_all` (true) or `must_not nested + match_all` (false).
 	 */
-	kind: FilterableKind | "nested" | "nested_exists";
-	/** OpenSearch field path (only set on leaf kinds, not `nested`). */
+	kind: FilterableKind | "nested" | "nested_exists" | "object";
+	/** OpenSearch field path (only set on leaf kinds). */
 	field?: string;
 	/** Source projection field (set on leaf kinds only; SDL renders use this for GraphQL type lookup). */
 	sourceField?: ResolvedProjectionField;
 	/** Nested doc path (set on `nested` and `nested_exists`). */
 	path?: string;
-	/** Children (only set on `nested` kind). */
+	/** Children (set on `nested` and `object`). */
 	children?: FilterSpecNode[];
 	/** Range bound (only set on `kind === "range"`). */
 	bound?: RangeBound;
-	/** GraphQL input type for nested kind (e.g. "TagSearchFilter"). */
+	/** GraphQL input type for `nested` / `object` kinds (e.g. "TagSearchFilter"). */
 	nestedTypeName?: string;
 }
 
@@ -275,9 +275,31 @@ function buildShapeRecursive(
 						});
 					}
 				} else {
-					const subShape = buildShapeRecursive(field.subProjection, parentPath);
-					nodes.push(...subShape.nodes);
-					nestedShapes.push(...subShape.nestedShapes);
+					// Non-`@nested` struct sub-projection: thread the dotted path
+					// into children's OS field paths and emit as a separate input
+					// type (issue #98). The parent's filter input references it as
+					// `<fieldName>: <NestedType>SearchFilter`.
+					const objectPath = joinNestedPath(
+						parentPath,
+						field.projectedName ?? field.name,
+					);
+					const subShape = buildShapeRecursive(field.subProjection, objectPath);
+					if (subShape.nodes.length > 0 || subShape.nestedShapes.length > 0) {
+						const subTypeName = searchFilterTypeName(
+							field.subProjection.projectionModel.name,
+						);
+						nodes.push({
+							inputName: field.projectedName ?? field.name,
+							kind: "object",
+							children: subShape.nodes,
+							nestedTypeName: subTypeName,
+						});
+						nestedShapes.push({
+							typeName: subTypeName,
+							nodes: subShape.nodes,
+							nestedShapes: subShape.nestedShapes,
+						});
+					}
 				}
 			}
 		}

--- a/src/projection.test.ts
+++ b/src/projection.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 
 import { createTestHost, createTestWrapper } from "@typespec/compiler/testing";
 import { isSearchable } from "./decorators.js";
+import { emitGraphQLResolver } from "./emit-graphql-resolver.js";
 import { resolveProjectionModel } from "./projection.js";
 import { OpenSearchEmitterTestLibrary } from "./testing/index.js";
 
@@ -791,6 +792,145 @@ describe("@searchInfer", () => {
 		);
 	});
 
+	it("auto-recurses into struct fields when parent is @searchInfer (issue #98)", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Address {
+        @keyword country: string;
+        @keyword city: string;
+        postalCode: string;
+      }
+      model Counterparty {
+        @keyword id: string;
+        address: Address;
+      }
+      @searchInfer
+      model CounterpartySearchDoc is SearchProjection<Counterparty> {}
+    `);
+		assert.equal(diagnostics.length, 0);
+
+		const projection = runner.program
+			.getGlobalNamespaceType()
+			.models.get("CounterpartySearchDoc");
+		assert.ok(projection);
+		const resolved = resolveProjectionModel(runner.program, projection);
+		assert.ok(resolved);
+
+		const address = resolved.fields.find((f) => f.name === "address");
+		assert.ok(address);
+		assert.ok(
+			address.subProjection,
+			"struct field should get an auto-built virtual sub-projection",
+		);
+		assert.equal(address.subProjection.projectionModel.name, "Address");
+		const subFieldNames = address.subProjection.fields.map((f) => f.name);
+		assert.deepEqual(subFieldNames, ["country", "city", "postalCode"]);
+
+		const country = address.subProjection.fields.find(
+			(f) => f.name === "country",
+		);
+		assert.ok(country);
+		assert.deepEqual(country.filterables, ["term", "terms", "exists"]);
+	});
+
+	it("recurses through @nested struct arrays when parent is @searchInfer", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Tag {
+        @keyword tagId: string;
+        @keyword label: string;
+      }
+      model Counterparty {
+        @keyword id: string;
+        @nested tags: Tag[];
+      }
+      @searchInfer
+      model CounterpartySearchDoc is SearchProjection<Counterparty> {}
+    `);
+		assert.equal(diagnostics.length, 0);
+
+		const projection = runner.program
+			.getGlobalNamespaceType()
+			.models.get("CounterpartySearchDoc");
+		assert.ok(projection);
+		const resolved = resolveProjectionModel(runner.program, projection);
+		assert.ok(resolved);
+
+		const tags = resolved.fields.find((f) => f.name === "tags");
+		assert.ok(tags);
+		assert.equal(tags.nested, true);
+		assert.ok(tags.subProjection);
+		const subFieldNames = tags.subProjection.fields.map((f) => f.name);
+		assert.deepEqual(subFieldNames, ["tagId", "label"]);
+	});
+
+	it("two-level struct recursion with @searchInfer", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Coordinates {
+        latitude: float64;
+        longitude: float64;
+      }
+      model Address {
+        @keyword country: string;
+        coords: Coordinates;
+      }
+      model Place {
+        address: Address;
+      }
+      @searchInfer
+      model PlaceSearchDoc is SearchProjection<Place> {}
+    `);
+		assert.equal(diagnostics.length, 0);
+
+		const projection = runner.program
+			.getGlobalNamespaceType()
+			.models.get("PlaceSearchDoc");
+		assert.ok(projection);
+		const resolved = resolveProjectionModel(runner.program, projection);
+		assert.ok(resolved);
+
+		const address = resolved.fields.find((f) => f.name === "address");
+		assert.ok(address?.subProjection);
+		const coords = address.subProjection.fields.find(
+			(f) => f.name === "coords",
+		);
+		assert.ok(coords?.subProjection, "second-level struct recursion");
+		const coordsFieldNames = coords.subProjection.fields.map((f) => f.name);
+		assert.deepEqual(coordsFieldNames, ["latitude", "longitude"]);
+	});
+
+	it("@searchSkip on a struct field opts the entire sub-tree out of recursion", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model SecretBlock {
+        @keyword token: string;
+      }
+      model Counterparty {
+        @keyword id: string;
+        @searchable @searchSkip secret: SecretBlock;
+      }
+      @searchInfer
+      model CounterpartySearchDoc is SearchProjection<Counterparty> {}
+    `);
+		assert.equal(diagnostics.length, 0);
+
+		const projection = runner.program
+			.getGlobalNamespaceType()
+			.models.get("CounterpartySearchDoc");
+		assert.ok(projection);
+		const resolved = resolveProjectionModel(runner.program, projection);
+		assert.ok(resolved);
+
+		const secret = resolved.fields.find((f) => f.name === "secret");
+		assert.ok(secret, "@searchable field stays in the projection");
+		assert.equal(
+			secret.subProjection,
+			undefined,
+			"@searchSkip suppresses virtual sub-projection",
+		);
+	});
+
 	it("without @searchInfer, fields with no decorators stay excluded", async () => {
 		const runner = await createRunner();
 		await runner.diagnose(`
@@ -813,6 +953,59 @@ describe("@searchInfer", () => {
 		assert.deepEqual(
 			resolved.fields.map((f) => f.name),
 			["name"],
+		);
+	});
+});
+
+describe("emitted resolver size budget", () => {
+	it("stays under AppSync's 32 KB code cap on a wide @searchInfer projection (issue #99)", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Address { @keyword country: string; @keyword city: string; postalCode: string; }
+      model Phone { @keyword number: string; @keyword countryCode: string; }
+      model Tag { @keyword tagId: string; @keyword label: string; }
+      model Group { @keyword groupId: string; @keyword name: string; }
+      model Approval { @keyword type: string; validFrom: utcDateTime; validTo: utcDateTime; }
+      model Reference { @keyword refId: string; @keyword source: string; }
+      model Location { address: Address; @keyword name: string; }
+      model Contact { @keyword name: string; phones: Phone[]; }
+      model Counterparty {
+        @keyword id: string;
+        @keyword name: string;
+        notional: float64;
+        rank: int32;
+        active: boolean;
+        createdAt: utcDateTime;
+        @nested locations: Location[];
+        @nested contacts: Contact[];
+        @nested tags: Tag[];
+        @nested groups: Group[];
+        @nested approvals: Approval[];
+        @nested references: Reference[];
+      }
+      @searchInfer
+      model CounterpartySearchDoc is SearchProjection<Counterparty> {}
+    `);
+		assert.equal(diagnostics.length, 0);
+
+		const projection = runner.program
+			.getGlobalNamespaceType()
+			.models.get("CounterpartySearchDoc");
+		assert.ok(projection);
+		const resolved = resolveProjectionModel(runner.program, projection);
+		assert.ok(resolved);
+
+		const result = emitGraphQLResolver(resolved, {
+			defaultPageSize: 20,
+			maxPageSize: 100,
+			trackTotalHitsUpTo: 10000,
+		});
+
+		// AppSync APPSYNC_JS hard cap on resolver source code.
+		const APPSYNC_CODE_CAP = 32 * 1024;
+		assert.ok(
+			result.content.length < APPSYNC_CODE_CAP,
+			`emitted resolver is ${result.content.length} bytes — exceeds AppSync's ${APPSYNC_CODE_CAP}-byte cap. Wide projections need further shrink work.`,
 		);
 	});
 });

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -136,6 +136,25 @@ export function resolveProjectionModel(
 			}
 		}
 
+		// @searchInfer auto-recurses into struct fields (issue #98). When the
+		// field's type resolves to a plain TypeSpec model (no explicit
+		// SearchProjection<T>), build a virtual sub-projection so the parent
+		// SearchFilter can reference <NestedType>SearchFilter.
+		if (
+			inferOnModel &&
+			!field.subProjection &&
+			!isSearchSkip(program, sourceProperty)
+		) {
+			const virtual = buildVirtualSubProjection(
+				program,
+				field.type,
+				new Set([projectionModel.name]),
+			);
+			if (virtual) {
+				field.subProjection = virtual;
+			}
+		}
+
 		fields.push(field);
 	}
 
@@ -434,6 +453,71 @@ function isNumericRootName(name: string | undefined): boolean {
 		"numeric",
 		"number",
 	].includes(name);
+}
+
+/**
+ * Build a virtual sub-projection for a struct or array-of-struct field on a
+ * `@searchInfer` parent (issue #98). Recurses into the model's properties,
+ * applying the inference table to each. The parent's SearchFilter exposes
+ * `<fieldName>: <NestedType>SearchFilter`, and FILTER_SPEC dispatch threads
+ * the dotted path (or nested wrapper if the field is `@nested`).
+ */
+function buildVirtualSubProjection(
+	program: Program,
+	type: Type,
+	visited: Set<string>,
+): ResolvedProjection | undefined {
+	let model: Model | undefined;
+	if (type.kind === "Model") {
+		if (
+			type.name === "Array" &&
+			type.indexer?.value?.kind === "Model" &&
+			type.indexer.value.name !== "Array"
+		) {
+			model = type.indexer.value;
+		} else if (type.name && type.name !== "Array" && type.properties) {
+			model = type;
+		}
+	}
+	if (!model || !model.properties || model.properties.size === 0) {
+		return undefined;
+	}
+	// Skip explicit SearchProjection<T> instantiations — those are handled
+	// by resolveSubProjectionFromType.
+	if (getProjectionSourceModel(program, model)) {
+		return undefined;
+	}
+	if (visited.has(model.name)) {
+		return undefined;
+	}
+	const childVisited = new Set(visited);
+	childVisited.add(model.name);
+
+	const fields: ResolvedProjectionField[] = [];
+	for (const prop of model.properties.values()) {
+		if (isSearchSkip(program, prop)) continue;
+		const field = resolveProjectionField(program, prop, undefined, true);
+		if (!field.subProjection) {
+			const nestedVirtual = buildVirtualSubProjection(
+				program,
+				field.type,
+				childVisited,
+			);
+			if (nestedVirtual) {
+				field.subProjection = nestedVirtual;
+			}
+		}
+		fields.push(field);
+	}
+
+	if (fields.length === 0) return undefined;
+
+	return {
+		projectionModel: model,
+		sourceModel: model,
+		indexName: getIndexName(program, model),
+		fields,
+	};
 }
 
 /**

--- a/test/example.js
+++ b/test/example.js
@@ -140,11 +140,13 @@ test("emits SearchFilter input with filterable kinds and nested sub-filter", asy
 
 	assert.ok(resolver.includes("const FILTER_SPEC = ["));
 	assert.ok(resolver.includes("applyFilterSpec(FILTER_SPEC, searchFilter"));
-	assert.ok(resolver.includes('inputName: "tags"'));
-	assert.ok(resolver.includes('kind: "nested"'));
-	assert.ok(resolver.includes('path: "tags"'));
-	assert.ok(resolver.includes('inputName: "rankGte"'));
-	assert.ok(resolver.includes('bound: "gte"'));
+	// FILTER_SPEC entries use compact single-letter keys to fit under
+	// AppSync's 32 KB resolver code cap (issue #99).
+	assert.ok(resolver.includes('i:"tags"'));
+	assert.ok(resolver.includes('k:"nested"'));
+	assert.ok(resolver.includes('p:"tags"'));
+	assert.ok(resolver.includes('i:"rankGte"'));
+	assert.ok(resolver.includes('b:"gte"'));
 });
 
 test("emits nested-aware aggregations on nested sub-projections", async () => {


### PR DESCRIPTION
Bundles #98 (nested recursion) and #99 (32 KB cap headroom). The original hypothesis was that #98 might shrink resolvers — actually it's the opposite, nested recursion enlarges them. Pairing the two ensures #98 ships with enough byte budget for real-world projections.

## #98 — \`@searchInfer\` recurses into struct fields

When a parent has \`@searchInfer\` and a field's type resolves to a TypeSpec model (struct or array-of-struct) without an explicit \`SearchProjection<T>\`, the walker now auto-builds a virtual sub-projection and applies the inference table to its properties. The parent's SearchFilter exposes \`<fieldName>: <NestedType>SearchFilter\`, and a separate \`<NestedType>SearchFilter\` input is emitted alongside.

- \`@nested\` array: existing OS \`nested + inner\` dispatch.
- Inline struct (no \`@nested\`): new \"object\" FilterSpecNode kind that descends without an OS wrapper. Children carry dotted OS field paths (\`address.country\`) so OS object-mapping semantics work.
- Cycle-safe: visited-name set prevents infinite recursion.
- \`@searchSkip\` on the parent's field suppresses the virtual sub-projection.

The previous \"inline children at parent level\" behavior for non-\`@nested\` sub-projections is replaced by the separate-input form. Existing test that asserted the old shape is updated; ergonomics improve — callers write \`searchFilter: { address: { country: \"PT\" } }\` instead of relying on flat hand-named keys.

## #99 — shrink FILTER_SPEC literal

FILTER_SPEC entries now use single-letter keys (\`i\`=inputName, \`k\`=kind, \`f\`=field, \`p\`=path, \`c\`=children, \`b\`=bound). The reader inside \`applyFilterSpec\` is updated in lockstep. Saves ~10% on a wide synthetic projection (20,971 → 18,961 bytes for a 6-sub-model fixture with \`@searchInfer\` + nested recursion enabled).

A new \"emitted resolver size budget\" test asserts the wide-projection emit stays under AppSync's 32 KB hard cap; it acts as a regression guard for future surface additions. Strategies #2 (per-axis split) and #3 (pipeline resolvers) from #99 are deferred until the budget test starts failing on a realistic fixture.

## Backwards compatibility

- Multi-arg \`@filterable\` / \`@aggregatable\` syntax preserved.
- Models without \`@searchInfer\` are unchanged — no virtual sub-projections are built.
- The compact-key FILTER_SPEC is internal to the emitted resolver; no external API or runtime contract changes.
- The behavior change for non-\`@nested\` sub-projections (now a separate input instead of inline) only affects users who explicitly authored \`projectionField: SubSearchDoc\` without \`@nested\` — the new shape is more ergonomic and matches the issue's contract.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm run lint\` clean (warnings unchanged)
- [x] 165/165 targeted tests pass — 4 new recursion tests, 1 new budget test, 1 updated filter-shape test
- [x] Resolver still passes \`@aws-appsync/eslint-plugin\` recommended config
- [x] README updated with a \"Nested struct recursion\" subsection under \`@searchInfer\`
- [ ] CI green on Node lts/*

Closes #98. Closes #99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)