### PR TITLE
fix(emitter): collapse range FILTER_SPEC, type-identity recursion, SDL dedup

### DIFF
--- a/src/emit-graphql-resolver.test.ts
+++ b/src/emit-graphql-resolver.test.ts
@@ -711,8 +711,10 @@ describe("emitGraphQLResolver search filter DSL", () => {
 		assert.ok(result.content.includes("const FILTER_SPEC = ["));
 		assert.ok(result.content.includes('"species"'));
 		assert.ok(result.content.includes('"speciesNot"'));
-		assert.ok(result.content.includes('"rankGte"'));
-		assert.ok(result.content.includes('"rankLte"'));
+		// Range now emits ONE FILTER_SPEC entry per field (#101); the
+		// resolver expands "rankGte"/"Lte"/"Gt"/"Lt" lookups at runtime.
+		assert.ok(result.content.includes('{i:"rank",k:"range",f:"rank"}'));
+		assert.ok(!result.content.includes('"rankGte"'));
 	});
 
 	it("emits an empty FILTER_SPEC when no @filterable fields", () => {

--- a/src/emit-graphql-resolver.ts
+++ b/src/emit-graphql-resolver.ts
@@ -272,11 +272,13 @@ function applyFilterSpec(rootSpec, rootInput, rootOutFilters, rootOutMustNots) {
 				const input = item.input;
 				const outFilters = item.outFilters;
 				const outMustNots = item.outMustNots;
-				const rangeBuckets = {};
 
 				// FILTER_SPEC nodes use compact keys to fit under AppSync's 32 KB
 				// resolver code cap (issue #99): i=inputName, k=kind, f=field,
-				// p=path, c=children, b=bound. See stringifyNode in the emitter.
+				// p=path, c=children. See stringifyNode in the emitter. Range
+				// kind carries one entry per field; the resolver expands the
+				// four bound inputs (i+"Gte"/Lte/Gt/Lt) at iteration time
+				// (issue #101).
 				for (const node of spec) {
 					const value = input[node.i];
 					if (node.k === "nested") {
@@ -354,15 +356,29 @@ function applyFilterSpec(rootSpec, rootInput, rootOutFilters, rootOutMustNots) {
 							}
 						}
 					} else if (node.k === "range") {
-						if (value != null) {
-							const bucket = (rangeBuckets[node.f] = rangeBuckets[node.f] || {});
-							bucket[node.b] = value;
+						const base = node.i;
+						const bounds = {};
+						let any = false;
+						if (input[base + "Gte"] != null) {
+							bounds.gte = input[base + "Gte"];
+							any = true;
+						}
+						if (input[base + "Lte"] != null) {
+							bounds.lte = input[base + "Lte"];
+							any = true;
+						}
+						if (input[base + "Gt"] != null) {
+							bounds.gt = input[base + "Gt"];
+							any = true;
+						}
+						if (input[base + "Lt"] != null) {
+							bounds.lt = input[base + "Lt"];
+							any = true;
+						}
+						if (any) {
+							outFilters.push({ range: { [node.f]: bounds } });
 						}
 					}
-				}
-
-				for (const field in rangeBuckets) {
-					outFilters.push({ range: { [field]: rangeBuckets[field] } });
 				}
 			}
 		}
@@ -401,7 +417,7 @@ function stringifyNode(node: FilterSpecNode): string {
 		return `{i:${i},k:"nested_exists",p:${JSON.stringify(node.path ?? "")}}`;
 	}
 	if (node.kind === "range") {
-		return `{i:${i},k:"range",f:${JSON.stringify(node.field ?? "")},b:${JSON.stringify(node.bound ?? "")}}`;
+		return `{i:${i},k:"range",f:${JSON.stringify(node.field ?? "")}}`;
 	}
 	return `{i:${i},k:${JSON.stringify(node.kind)},f:${JSON.stringify(node.field ?? "")}}`;
 }

--- a/src/emit-graphql-sdl.test.ts
+++ b/src/emit-graphql-sdl.test.ts
@@ -453,6 +453,50 @@ describe("emitGraphQLSdl SearchFilter input", () => {
 		assert.ok(!result.content.includes("SearchFilter"));
 	});
 
+	it("emits each <Type>SearchFilter input at most once even when reachable via multiple paths (issue #103)", () => {
+		// Construct a shape where the same nested filter type is reachable
+		// via two different parent fields; without dedup the SDL emits two
+		// `input AddressSearchFilter { ... }` blocks.
+		const addressSub = {
+			projectionModel: { name: "AddressSearchDoc" },
+			sourceModel: { name: "Address" },
+			indexName: "addresses",
+			fields: [
+				makeField({
+					name: "country",
+					keyword: true,
+					filterables: ["term"],
+				}),
+			],
+		} as unknown as ResolvedProjection;
+
+		const projection = makeProjection({
+			name: "CounterpartySearchDoc",
+			fields: [
+				makeField({
+					name: "homeAddress",
+					subProjection: addressSub,
+					type: { kind: "Model" } as unknown as Type,
+				}),
+				makeField({
+					name: "billingAddress",
+					subProjection: addressSub,
+					type: { kind: "Model" } as unknown as Type,
+				}),
+			],
+		});
+
+		const result = emitGraphQLSdl(dummyProgram, projection, defaultOptions);
+		const addressInputCount = (
+			result.content.match(/^input AddressSearchFilter \{/gm) ?? []
+		).length;
+		assert.equal(
+			addressInputCount,
+			1,
+			"AddressSearchFilter must be declared exactly once in the SDL",
+		);
+	});
+
 	it("emits term, term_negate, exists, range fields with proper suffixes", () => {
 		const projection = makeProjection({
 			name: "PetSearchDoc",

--- a/src/emit-graphql-sdl.ts
+++ b/src/emit-graphql-sdl.ts
@@ -114,7 +114,12 @@ function renderSearchFilterInputs(
 	shape: SearchFilterShape,
 ): string {
 	const blocks: string[] = [];
-	renderSearchFilterShapeRecursive(program, shape, blocks);
+	// Dedup `<Type>SearchFilter` declarations by typeName (issue #103). The
+	// same nested shape can be reachable via multiple paths in the recursion
+	// graph; without dedup the SDL ends up with two `input X { ... }` blocks
+	// for the same X, which is ill-formed.
+	const seen = new Set<string>();
+	renderSearchFilterShapeRecursive(program, shape, blocks, seen);
 	return blocks.join("\n\n");
 }
 
@@ -122,10 +127,13 @@ function renderSearchFilterShapeRecursive(
 	program: Program,
 	shape: SearchFilterShape,
 	out: string[],
+	seen: Set<string>,
 ): void {
+	if (seen.has(shape.typeName)) return;
+	seen.add(shape.typeName);
 	out.push(renderSearchFilterInputBlock(program, shape));
 	for (const sub of shape.nestedShapes) {
-		renderSearchFilterShapeRecursive(program, sub, out);
+		renderSearchFilterShapeRecursive(program, sub, out, seen);
 	}
 }
 
@@ -155,6 +163,16 @@ function renderSearchFilterField(
 	const baseScalar = stripListWrap(gqlType);
 	if (node.kind === "terms") {
 		return `  ${node.inputName}: [${baseScalar}!]`;
+	}
+	if (node.kind === "range") {
+		// FILTER_SPEC carries one entry per range field; SDL still renders
+		// four bound inputs (issue #101).
+		return [
+			`  ${node.inputName}Gte: ${baseScalar}`,
+			`  ${node.inputName}Lte: ${baseScalar}`,
+			`  ${node.inputName}Gt: ${baseScalar}`,
+			`  ${node.inputName}Lt: ${baseScalar}`,
+		].join("\n");
 	}
 	return `  ${node.inputName}: ${baseScalar}`;
 }

--- a/src/filters.test.ts
+++ b/src/filters.test.ts
@@ -67,7 +67,7 @@ describe("collectFilterables", () => {
 		assert.deepEqual(collectFilterables(projection), []);
 	});
 
-	it("expands range into four bound entries", () => {
+	it("emits a single range entry per field; the resolver expands to 4 bound checks at runtime (issue #101)", () => {
 		const projection = makeProjection({
 			fields: [
 				makeField({
@@ -79,16 +79,11 @@ describe("collectFilterables", () => {
 		});
 
 		const entries = collectFilterables(projection);
-		assert.equal(entries.length, 4);
-		assert.deepEqual(
-			entries.map((e) => e.inputFieldName),
-			["rankGte", "rankLte", "rankGt", "rankLt"],
-		);
-		for (const entry of entries) {
-			assert.equal(entry.kind, "range");
-			assert.equal(entry.openSearchField, "rank");
-			assert.equal(entry.nestedPath, undefined);
-		}
+		assert.equal(entries.length, 1);
+		assert.equal(entries[0].kind, "range");
+		assert.equal(entries[0].inputFieldName, "rank");
+		assert.equal(entries[0].openSearchField, "rank");
+		assert.equal(entries[0].nestedPath, undefined);
 	});
 
 	it("emits term and term_negate as separate input fields", () => {
@@ -249,17 +244,17 @@ describe("buildSearchFilterShape", () => {
 		assert.ok(shape);
 		assert.equal(shape.typeName, "PetSearchFilter");
 		const inputNames = shape.nodes.map((n) => n.inputName);
+		// Range collapses to a single entry; SDL renderer expands the four
+		// bound inputs from it (issue #101).
 		assert.deepEqual(inputNames, [
 			"species",
 			"speciesNot",
 			"nicknameExists",
-			"rankGte",
-			"rankLte",
-			"rankGt",
-			"rankLt",
+			"rank",
 		]);
 		const range = shape.nodes.filter((n) => n.kind === "range");
-		assert.equal(range.length, 4);
+		assert.equal(range.length, 1);
+		assert.equal(range[0].inputName, "rank");
 	});
 
 	it("emits a nested node + a separate sub-shape for @nested sub-projection", () => {

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -80,16 +80,20 @@ function filterableEntriesForField(
 
 	for (const kind of field.filterables ?? []) {
 		if (kind === "range") {
-			for (const bound of RANGE_BOUNDS) {
-				entries.push({
-					field,
-					kind,
-					openSearchField,
-					nestedPath,
-					inputFieldName: `${projectedName}${RANGE_BOUND_SUFFIX[bound]}`,
-					rangeBound: bound,
-				});
-			}
+			// Single FILTER_SPEC entry per range field; the resolver expands
+			// the four bound checks (Gte/Lte/Gt/Lt) at iteration time. Saves
+			// ~3 entries per range-filterable field on wide projections
+			// (issue #101 — keeps the inline FILTER_SPEC under the AppSync
+			// 32 KB cap on the consumer's 8-sub-model shape). The SDL emitter
+			// still renders the four bound input fields by expanding this
+			// single entry — see renderSearchFilterField.
+			entries.push({
+				field,
+				kind,
+				openSearchField,
+				nestedPath,
+				inputFieldName: projectedName,
+			});
 			continue;
 		}
 		entries.push({

--- a/src/projection.test.ts
+++ b/src/projection.test.ts
@@ -900,6 +900,41 @@ describe("@searchInfer", () => {
 		assert.deepEqual(coordsFieldNames, ["latitude", "longitude"]);
 	});
 
+	it("recurses into a nested type whose model has @searchInfer, even when the parent projection lacks it (issue #102)", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      @searchInfer
+      model Address {
+        @keyword country: string;
+        @keyword city: string;
+      }
+      model Location {
+        @keyword name: string;
+        address: Address;
+      }
+      model LocationSearchDoc is SearchProjection<Location> {}
+    `);
+		assert.equal(diagnostics.length, 0);
+
+		const projection = runner.program
+			.getGlobalNamespaceType()
+			.models.get("LocationSearchDoc");
+		assert.ok(projection);
+		const resolved = resolveProjectionModel(runner.program, projection);
+		assert.ok(resolved);
+
+		// LocationSearchDoc has no @searchInfer of its own. Without #102,
+		// the address sub-projection wouldn't be built at all because the
+		// parent walker only recurses when the parent is @searchInfer.
+		const address = resolved.fields.find((f) => f.name === "address");
+		assert.ok(
+			address?.subProjection,
+			"address should auto-recurse because Address has @searchInfer",
+		);
+		const subFieldNames = address.subProjection.fields.map((f) => f.name);
+		assert.deepEqual(subFieldNames, ["country", "city"]);
+	});
+
 	it("@searchSkip on a struct field opts the entire sub-tree out of recursion", async () => {
 		const runner = await createRunner();
 		const diagnostics = await runner.diagnose(`
@@ -958,17 +993,24 @@ describe("@searchInfer", () => {
 });
 
 describe("emitted resolver size budget", () => {
-	it("stays under AppSync's 32 KB code cap on a wide @searchInfer projection (issue #99)", async () => {
+	it("stays under AppSync's 32 KB code cap on a wide @searchInfer projection (issues #99, #101)", async () => {
+		// Consumer's shape from the v1.22.0 incident: 4 nested-record types
+		// each carrying @searchInfer (Address / PhoneNumberRecord / EmailRecord
+		// / PersonRecord), plus 4 simpler sub-models, all reachable from the
+		// root Counterparty projection. Pre-#101 this hit 38 KB and the
+		// AppSync deploy was rejected.
 		const runner = await createRunner();
 		const diagnostics = await runner.diagnose(`
-      model Address { @keyword country: string; @keyword city: string; postalCode: string; }
-      model Phone { @keyword number: string; @keyword countryCode: string; }
+      @searchInfer model Address { @keyword country: string; @keyword city: string; postalCode: string; }
+      @searchInfer model PhoneNumberRecord { @keyword number: string; @keyword countryCode: string; }
+      @searchInfer model EmailRecord { @keyword email: string; @keyword type: string; }
+      @searchInfer model PersonRecord { @keyword name: string; @keyword role: string; }
       model Tag { @keyword tagId: string; @keyword label: string; }
       model Group { @keyword groupId: string; @keyword name: string; }
       model Approval { @keyword type: string; validFrom: utcDateTime; validTo: utcDateTime; }
       model Reference { @keyword refId: string; @keyword source: string; }
       model Location { address: Address; @keyword name: string; }
-      model Contact { @keyword name: string; phones: Phone[]; }
+      model Contact { name: PersonRecord; phone: PhoneNumberRecord; email: EmailRecord; }
       model Counterparty {
         @keyword id: string;
         @keyword name: string;

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -32,10 +32,14 @@ function isReachable(
 	) {
 		return true;
 	}
-	// On a @searchInfer model, every source-model field is reachable unless
-	// the field opts out with @searchSkip. Inference (see inferDirectives)
-	// fills in the filterable/aggregatable axes per field type.
-	return inferOnModel && !isSearchSkip(program, prop);
+	if (isSearchSkip(program, prop)) return false;
+	// On a @searchInfer model, every source-model field is reachable.
+	if (inferOnModel) return true;
+	// Issue #102: even if the parent projection lacks @searchInfer, admit a
+	// field whose type model carries @searchInfer — it'll auto-recurse into
+	// a virtual sub-projection.
+	const typeModel = unwrapStructModel(prop.type);
+	return !!typeModel && isSearchInfer(program, typeModel);
 }
 
 import { reportDiagnostic } from "./lib.js";
@@ -141,9 +145,9 @@ export function resolveProjectionModel(
 		// SearchProjection<T>), build a virtual sub-projection so the parent
 		// SearchFilter can reference <NestedType>SearchFilter.
 		if (
-			inferOnModel &&
 			!field.subProjection &&
-			!isSearchSkip(program, sourceProperty)
+			!isSearchSkip(program, sourceProperty) &&
+			shouldVirtualRecurse(program, field.type, inferOnModel)
 		) {
 			const virtual = buildVirtualSubProjection(
 				program,
@@ -462,6 +466,40 @@ function isNumericRootName(name: string | undefined): boolean {
  * `<fieldName>: <NestedType>SearchFilter`, and FILTER_SPEC dispatch threads
  * the dotted path (or nested wrapper if the field is `@nested`).
  */
+/**
+ * Per #102: a struct field should auto-recurse into a virtual sub-projection
+ * when EITHER (a) the parent's projection model has @searchInfer, OR (b) the
+ * field's underlying model carries @searchInfer itself. Recursion follows
+ * model identity, not the emit root — so an `Address` model with @searchInfer
+ * gets its nested filter input even when emitted inside a parent that lacks
+ * @searchInfer (e.g. an explicit `LocationSearchDoc is SearchProjection<Location>`
+ * embedded in a `@searchInfer`-decorated `CounterpartySearchDoc`).
+ */
+function shouldVirtualRecurse(
+	program: Program,
+	type: Type,
+	parentInfersInferContext: boolean,
+): boolean {
+	if (parentInfersInferContext) return true;
+	const model = unwrapStructModel(type);
+	return !!model && isSearchInfer(program, model);
+}
+
+function unwrapStructModel(type: Type): Model | undefined {
+	if (type.kind !== "Model") return undefined;
+	if (
+		type.name === "Array" &&
+		type.indexer?.value?.kind === "Model" &&
+		type.indexer.value.name !== "Array"
+	) {
+		return type.indexer.value;
+	}
+	if (type.name && type.name !== "Array" && type.properties) {
+		return type;
+	}
+	return undefined;
+}
+
 function buildVirtualSubProjection(
 	program: Program,
 	type: Type,
@@ -571,6 +609,24 @@ function resolveSubProjectionModel(
 			);
 			if (subProj) {
 				field.subProjection = subProj;
+			}
+		}
+
+		// Type-identity recursion (issue #102): even when this projection
+		// model lacks @searchInfer, recurse into a struct field whose own
+		// model carries @searchInfer.
+		if (
+			!field.subProjection &&
+			!isSearchSkip(program, sourceProperty) &&
+			shouldVirtualRecurse(program, field.type, inferOnModel)
+		) {
+			const virtual = buildVirtualSubProjection(
+				program,
+				field.type,
+				new Set([model.name]),
+			);
+			if (virtual) {
+				field.subProjection = virtual;
 			}
 		}
 

--- a/test/example.js
+++ b/test/example.js
@@ -141,12 +141,14 @@ test("emits SearchFilter input with filterable kinds and nested sub-filter", asy
 	assert.ok(resolver.includes("const FILTER_SPEC = ["));
 	assert.ok(resolver.includes("applyFilterSpec(FILTER_SPEC, searchFilter"));
 	// FILTER_SPEC entries use compact single-letter keys to fit under
-	// AppSync's 32 KB resolver code cap (issue #99).
+	// AppSync's 32 KB resolver code cap (issue #99). Range emits ONE
+	// entry per field; the four bound input lookups (Gte/Lte/Gt/Lt) are
+	// done at iteration time inside applyFilterSpec (issue #101).
 	assert.ok(resolver.includes('i:"tags"'));
 	assert.ok(resolver.includes('k:"nested"'));
 	assert.ok(resolver.includes('p:"tags"'));
-	assert.ok(resolver.includes('i:"rankGte"'));
-	assert.ok(resolver.includes('b:"gte"'));
+	assert.ok(resolver.includes('{i:"rank",k:"range"'));
+	assert.ok(!resolver.includes('"rankGte"'));
 });
 
 test("emits nested-aware aggregations on nested sub-projections", async () => {


### PR DESCRIPTION
Closes #101, #102, #103. Three fallout fixes from #100's nested-recursion landing on a real consumer projection.

## #101 — collapse range entries

Each range-filterable field used to emit four FILTER_SPEC entries (\`<field>Gte\` / \`Lte\` / \`Gt\` / \`Lt\`). Now emits **one entry per field**; the resolver expands the four bound input lookups at iteration time inside \`applyFilterSpec\`. SDL still renders four bound inputs from the single entry — caller-facing GraphQL is unchanged.

On the consumer's 8-sub-model shape (4 with \`@searchInfer\` + 4 plain), the wide fixture now emits at **19,804 bytes** — well under AppSync's 32 KB cap (was 38,301 pre-fix).

## #102 — type-identity-driven recursion

\`@searchInfer\` recursion previously only fired when the parent's projection model carried \`@searchInfer\`. With an explicit \`SearchProjection<Location>\` embedded in a \`@searchInfer\` parent, fields on \`Location\` that referenced an \`@searchInfer\`-decorated model (e.g. \`Address\`) didn't get the nested filter input.

Recursion now follows **model identity**: a struct field auto-recurses when EITHER the parent has \`@searchInfer\` OR the field's type model itself carries \`@searchInfer\`. The reachability gate is updated in lockstep so non-\`@searchable\` struct fields still survive when their type carries \`@searchInfer\`.

## #103 — SDL dedup

Same nested filter shape reachable via multiple paths in the recursion graph used to emit two \`input <Type>SearchFilter { ... }\` blocks. Added a typeName-keyed \`Set\` in \`renderSearchFilterShapeRecursive\` — each input declared at most once per SDL file.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm run lint\` clean (warnings unchanged)
- [x] **Full** \`npm test\`: 239 unit + 7 example tests pass (incl. \`test:emit\` and \`test:example\` — caught the FILTER_SPEC shape change in the example fixture)
- [x] Resolver still passes \`@aws-appsync/eslint-plugin\` recommended config
- [x] Wide budget fixture rebuilt to match the consumer's 4×\`@searchInfer\` + 4×plain sub-models. Pre-#101 hit 38,301 bytes; post-#101 emits at 19,804 bytes.
- [x] New tests: issue-#102 reproducer (\`SearchProjection<Location>\` with \`@searchInfer Address\`), issue-#103 reproducer (same nested type reached twice → exactly one input declaration), updated filters/resolver tests for the single-range-entry shape.
- [ ] CI green on Node lts/*

🤖 Generated with [Claude Code](https://claude.com/claude-code)