### PR TITLE
fix(emitter): pipeline-resolver split + emit nested struct response types

### DIFF
--- a/src/emit-graphql-resolver.test.ts
+++ b/src/emit-graphql-resolver.test.ts
@@ -65,7 +65,7 @@ function liftAggregations(
 }
 
 /**
- * Loads the buildQuery function from a generated resolver source string.
+ * Loads the buildQuery function from a prepare-function source string.
  * Strips the `import { util } from "@aws-appsync/utils"` line, swaps `export`
  * for plain declarations, then evaluates and returns the captured buildQuery.
  */
@@ -87,6 +87,35 @@ function loadBuildQuery(
 	return factory();
 }
 
+/**
+ * Returns a concatenation of every emitted file (resolver-level + each
+ * pipeline function). Lets assertions that don't care WHICH file something
+ * lands in just substring-check the union.
+ */
+function combinedContent(
+	result: ReturnType<typeof emitGraphQLResolver>,
+): string {
+	return [result.content, ...result.functions.map((fn) => fn.content)].join(
+		"\n",
+	);
+}
+
+function prepareFunctionContent(
+	result: ReturnType<typeof emitGraphQLResolver>,
+): string {
+	const fn = result.functions.find((f) => f.name === "prepare");
+	if (!fn) throw new Error("missing prepare function");
+	return fn.content;
+}
+
+function searchFunctionContent(
+	result: ReturnType<typeof emitGraphQLResolver>,
+): string {
+	const fn = result.functions.find((f) => f.name === "search");
+	if (!fn) throw new Error("missing search function");
+	return fn.content;
+}
+
 const defaultOptions = {
 	defaultPageSize: 20,
 	maxPageSize: 100,
@@ -102,6 +131,34 @@ describe("emitGraphQLResolver", () => {
 		assert.equal(result.queryFieldName, "searchPet");
 	});
 
+	it("emits a pipeline shape: resolver + prepare (NONE) + search (OPENSEARCH) functions", () => {
+		const projection = makeProjection({ fields: [] });
+		const result = emitGraphQLResolver(projection, defaultOptions);
+
+		assert.equal(result.functions.length, 2);
+		assert.deepEqual(
+			result.functions.map((f) => ({ name: f.name, ds: f.dataSource })),
+			[
+				{ name: "prepare", ds: "NONE" },
+				{ name: "search", ds: "OPENSEARCH" },
+			],
+		);
+		assert.equal(result.functions[0].fileName, "pet-search-doc-fn-prepare.js");
+		assert.equal(result.functions[1].fileName, "pet-search-doc-fn-search.js");
+		// Resolver-level file holds the after-mapping (response shape).
+		assert.ok(result.content.includes("export function response"));
+		assert.ok(result.content.includes("ctx.prev.result"));
+		// Prepare function holds the FILTER_SPEC + walker + body assembly,
+		// stashing the OS body for the search function.
+		assert.ok(result.functions[0].content.includes("ctx.stash.queryBody"));
+		// Search function reads the stash and issues the OS HTTP request.
+		assert.ok(result.functions[1].content.includes("ctx.stash.queryBody"));
+		assert.ok(
+			result.functions[1].content.includes('operation: "GET"'),
+			"search function must issue an OpenSearch GET",
+		);
+	});
+
 	it("includes index name in request path", () => {
 		const projection = makeProjection({
 			indexName: "pets_v1",
@@ -109,7 +166,8 @@ describe("emitGraphQLResolver", () => {
 		});
 		const result = emitGraphQLResolver(projection, defaultOptions);
 
-		assert.ok(result.content.includes("/pets_v1/_search"));
+		// Index name lives in the search-datasource pipeline function only.
+		assert.ok(searchFunctionContent(result).includes("/pets_v1/_search"));
 	});
 
 	it("includes text fields in multi_match", () => {
@@ -118,7 +176,7 @@ describe("emitGraphQLResolver", () => {
 		});
 		const result = emitGraphQLResolver(projection, defaultOptions);
 
-		assert.ok(result.content.includes('"name","breed"'));
+		assert.ok(combinedContent(result).includes('"name","breed"'));
 	});
 
 	it("includes keyword fields in filter logic", () => {
@@ -130,7 +188,7 @@ describe("emitGraphQLResolver", () => {
 		});
 		const result = emitGraphQLResolver(projection, defaultOptions);
 
-		assert.ok(result.content.includes('"species","status"'));
+		assert.ok(combinedContent(result).includes('"species","status"'));
 	});
 
 	it("excludes nested and sub-projection fields from text fields", () => {
@@ -147,7 +205,7 @@ describe("emitGraphQLResolver", () => {
 		});
 		const result = emitGraphQLResolver(projection, defaultOptions);
 
-		assert.ok(result.content.includes('["name"]'));
+		assert.ok(combinedContent(result).includes('["name"]'));
 	});
 
 	it("excludes non-searchable filter-only fields from text_fields and keyword_fields but includes them in FILTER_SPEC", () => {
@@ -165,11 +223,11 @@ describe("emitGraphQLResolver", () => {
 		const result = emitGraphQLResolver(projection, defaultOptions);
 
 		assert.ok(
-			result.content.includes('fields: ["name"]'),
+			combinedContent(result).includes('fields: ["name"]'),
 			"counterpartyId is not @searchable so must not appear in multi_match fields",
 		);
 		assert.ok(
-			result.content.includes(
+			combinedContent(result).includes(
 				'{i:"counterpartyId",k:"term",f:"counterpartyId"}',
 			),
 			"FILTER_SPEC must carry the term filter for the non-searchable field (compact-key form)",
@@ -190,9 +248,9 @@ describe("emitGraphQLResolver", () => {
 		});
 		const result = emitGraphQLResolver(projection, defaultOptions);
 
-		assert.ok(result.content.includes('fields: ["name"]'));
+		assert.ok(combinedContent(result).includes('fields: ["name"]'));
 		assert.ok(
-			result.content.includes("byType:"),
+			combinedContent(result).includes("byType:"),
 			"aggregation should still be emitted for non-searchable agg-only field",
 		);
 	});
@@ -205,9 +263,9 @@ describe("emitGraphQLResolver", () => {
 			trackTotalHitsUpTo: 5000,
 		});
 
-		assert.ok(result.content.includes("args.first || 10"));
-		assert.ok(result.content.includes("50)"));
-		assert.ok(result.content.includes("track_total_hits: 5000"));
+		assert.ok(combinedContent(result).includes("args.first || 10"));
+		assert.ok(combinedContent(result).includes("50)"));
+		assert.ok(combinedContent(result).includes("track_total_hits: 5000"));
 	});
 
 	it("uses projectedName for field references", () => {
@@ -216,8 +274,8 @@ describe("emitGraphQLResolver", () => {
 		});
 		const result = emitGraphQLResolver(projection, defaultOptions);
 
-		assert.ok(result.content.includes('"displayName"'));
-		assert.ok(!result.content.includes('"name"'));
+		assert.ok(combinedContent(result).includes('"displayName"'));
+		assert.ok(!combinedContent(result).includes('"name"'));
 	});
 
 	it("has no import statements except aws-appsync/utils", () => {
@@ -226,28 +284,38 @@ describe("emitGraphQLResolver", () => {
 		});
 		const result = emitGraphQLResolver(projection, defaultOptions);
 
-		const imports = result.content
-			.split("\n")
-			.filter((l) => l.startsWith("import "));
-		assert.equal(imports.length, 1);
-		assert.ok(imports[0].includes("@aws-appsync/utils"));
+		// Each emitted file (resolver + each pipeline function) has at most
+		// one import — and only `@aws-appsync/utils`.
+		const allFiles = [
+			result.content,
+			...result.functions.map((f) => f.content),
+		];
+		for (const file of allFiles) {
+			const imports = file.split("\n").filter((l) => l.startsWith("import "));
+			assert.ok(imports.length <= 1);
+			if (imports.length === 1) {
+				assert.ok(imports[0].includes("@aws-appsync/utils"));
+			}
+		}
 	});
 
 	it("falls back to _score desc then _id asc when sortBy arg is omitted", () => {
 		const projection = makeProjection({ fields: [] });
 		const result = emitGraphQLResolver(projection, defaultOptions);
 
-		assert.ok(result.content.includes('{ _score: "desc" }'));
-		assert.ok(result.content.includes('{ _id: "asc" }'));
+		assert.ok(combinedContent(result).includes('{ _score: "desc" }'));
+		assert.ok(combinedContent(result).includes('{ _id: "asc" }'));
 		// New: resolver routes sort through buildSort(args.sortBy) so callers
 		// can override the fallback.
-		assert.ok(result.content.includes("buildSort(args.sortBy)"));
-		assert.ok(result.content.includes("function buildSort(sortBy)"));
+		assert.ok(combinedContent(result).includes("buildSort(args.sortBy)"));
+		assert.ok(combinedContent(result).includes("function buildSort(sortBy)"));
 	});
 
 	it("buildSort honors sortBy arg with multiple fields, appending _id tie-break", () => {
 		const projection = makeProjection({ fields: [] });
-		const source = emitGraphQLResolver(projection, defaultOptions).content;
+		const source = prepareFunctionContent(
+			emitGraphQLResolver(projection, defaultOptions),
+		);
 		const stripped = source
 			.replace(/^import \{ util \} from "@aws-appsync\/utils";?\n?/m, "")
 			.replace(/^export function /gm, "function ");
@@ -279,9 +347,9 @@ describe("emitGraphQLResolver", () => {
 		const projection = makeProjection({ fields: [] });
 		const result = emitGraphQLResolver(projection, defaultOptions);
 
-		assert.ok(result.content.includes("search_after"));
-		assert.ok(result.content.includes("base64Decode"));
-		assert.ok(result.content.includes("base64Encode"));
+		assert.ok(combinedContent(result).includes("search_after"));
+		assert.ok(combinedContent(result).includes("base64Decode"));
+		assert.ok(combinedContent(result).includes("base64Encode"));
 	});
 
 	it("omits aggs block when no aggregations", () => {
@@ -290,8 +358,8 @@ describe("emitGraphQLResolver", () => {
 		});
 		const result = emitGraphQLResolver(projection, defaultOptions);
 
-		assert.ok(!result.content.includes("aggs:"));
-		assert.ok(!result.content.includes("aggregations:"));
+		assert.ok(!combinedContent(result).includes("aggs:"));
+		assert.ok(!combinedContent(result).includes("aggregations:"));
 	});
 
 	it("emits aggs block in request when fields have aggregations", () => {
@@ -315,12 +383,16 @@ describe("emitGraphQLResolver", () => {
 		});
 		const result = emitGraphQLResolver(projection, defaultOptions);
 
-		assert.ok(result.content.includes("aggs:"));
+		assert.ok(combinedContent(result).includes("aggs:"));
 		assert.ok(
-			result.content.includes('byTag: { terms: { field: "tags.keyword" } }'),
+			combinedContent(result).includes(
+				'byTag: { terms: { field: "tags.keyword" } }',
+			),
 		);
 		assert.ok(
-			result.content.includes('bySpecy: { terms: { field: "species" } }'),
+			combinedContent(result).includes(
+				'bySpecy: { terms: { field: "species" } }',
+			),
 		);
 	});
 
@@ -342,12 +414,12 @@ describe("emitGraphQLResolver", () => {
 		const result = emitGraphQLResolver(projection, defaultOptions);
 
 		assert.ok(
-			result.content.includes(
+			combinedContent(result).includes(
 				'uniqueLocationCount: { cardinality: { field: "locations" } }',
 			),
 		);
 		assert.ok(
-			result.content.includes(
+			combinedContent(result).includes(
 				'missingDescriptionCount: { missing: { field: "description.keyword" } }',
 			),
 		);
@@ -367,13 +439,13 @@ describe("emitGraphQLResolver", () => {
 		});
 		const result = emitGraphQLResolver(projection, defaultOptions);
 		assert.ok(
-			result.content.includes(
+			combinedContent(result).includes(
 				'byValidFromOverTime: { date_histogram: { field: "validFrom", calendar_interval: "month" } }',
 			),
 		);
 		assert.ok(
-			result.content.includes(
-				"byValidFromOverTime: (parsedBody.aggregations?.byValidFromOverTime?.buckets ?? []).map((b) => ({ key: `${b.key_as_string ?? b.key}`, keyAsString: b.key_as_string ?? null, count: b.doc_count }))",
+			combinedContent(result).includes(
+				"byValidFromOverTime: (_a.byValidFromOverTime?.buckets ?? []).map((b) => ({ key: `${b.key_as_string ?? b.key}`, keyAsString: b.key_as_string ?? null, count: b.doc_count }))",
 			),
 			"date_histogram response must use template-literal coercion (APPSYNC_JS forbids String()) and surface keyAsString",
 		);
@@ -402,13 +474,13 @@ describe("emitGraphQLResolver", () => {
 		});
 		const result = emitGraphQLResolver(projection, defaultOptions);
 		assert.ok(
-			result.content.includes(
+			combinedContent(result).includes(
 				'byNotionalRange: { range: { field: "notional", ranges: [{"to":1000},{"from":1000,"to":10000},{"from":10000}] } }',
 			),
 		);
 		assert.ok(
-			result.content.includes(
-				"byNotionalRange: (parsedBody.aggregations?.byNotionalRange?.buckets ?? []).map((b) => ({ key: b.key, from: b.from ?? null, to: b.to ?? null, count: b.doc_count }))",
+			combinedContent(result).includes(
+				"byNotionalRange: (_a.byNotionalRange?.buckets ?? []).map((b) => ({ key: b.key, from: b.from ?? null, to: b.to ?? null, count: b.doc_count }))",
 			),
 		);
 	});
@@ -432,12 +504,12 @@ describe("emitGraphQLResolver", () => {
 		});
 		const result = emitGraphQLResolver(projection, defaultOptions);
 		assert.ok(
-			result.content.includes(
+			combinedContent(result).includes(
 				'byCounterpartyId: { terms: { field: "counterpartyId" }, aggs: { "latestValidTo": { max: { field: "validTo" } } } }',
 			),
 		);
 		assert.ok(
-			result.content.includes(
+			combinedContent(result).includes(
 				", latestValidTo: b.latestValidTo?.value ?? null",
 			),
 		);
@@ -456,13 +528,13 @@ describe("emitGraphQLResolver", () => {
 		const result = emitGraphQLResolver(projection, defaultOptions);
 
 		assert.ok(
-			result.content.includes(
+			combinedContent(result).includes(
 				'byCounterpartyId: { terms: { field: "counterpartyId" }, aggs: { "hits": { top_hits: { size: 5 } } } }',
 			),
 			"terms agg request must include hits sub-agg with top_hits.size",
 		);
 		assert.ok(
-			result.content.includes(
+			combinedContent(result).includes(
 				", hits: (b.hits?.hits?.hits ?? []).map((h) => h._source)",
 			),
 			"terms response must unwrap hits.hits._source onto the bucket's hits field",
@@ -489,12 +561,12 @@ describe("emitGraphQLResolver", () => {
 		});
 		const result = emitGraphQLResolver(projection, defaultOptions);
 		assert.ok(
-			result.content.includes(
+			combinedContent(result).includes(
 				'aggs: { "latestValidTo": { max: { field: "validTo" } }, "hits": { top_hits: { size: 3 } } }',
 			),
 		);
 		assert.ok(
-			result.content.includes(
+			combinedContent(result).includes(
 				", latestValidTo: b.latestValidTo?.value ?? null, hits: (b.hits?.hits?.hits ?? []).map((h) => h._source)",
 			),
 		);
@@ -518,23 +590,29 @@ describe("emitGraphQLResolver", () => {
 		const result = emitGraphQLResolver(projection, defaultOptions);
 
 		assert.ok(
-			result.content.includes('notionalSum: { sum: { field: "notional" } }'),
+			combinedContent(result).includes(
+				'notionalSum: { sum: { field: "notional" } }',
+			),
 		);
 		assert.ok(
-			result.content.includes('notionalAvg: { avg: { field: "notional" } }'),
+			combinedContent(result).includes(
+				'notionalAvg: { avg: { field: "notional" } }',
+			),
 		);
-		assert.ok(result.content.includes('rankMin: { min: { field: "rank" } }'));
-		assert.ok(result.content.includes('rankMax: { max: { field: "rank" } }'));
+		assert.ok(
+			combinedContent(result).includes('rankMin: { min: { field: "rank" } }'),
+		);
+		assert.ok(
+			combinedContent(result).includes('rankMax: { max: { field: "rank" } }'),
+		);
 
 		assert.ok(
-			result.content.includes(
-				"notionalSum: parsedBody.aggregations?.notionalSum?.value ?? null",
+			combinedContent(result).includes(
+				"notionalSum: _a.notionalSum?.value ?? null",
 			),
 		);
 		assert.ok(
-			result.content.includes(
-				"rankMax: parsedBody.aggregations?.rankMax?.value ?? null",
-			),
+			combinedContent(result).includes("rankMax: _a.rankMax?.value ?? null"),
 		);
 	});
 
@@ -574,35 +652,28 @@ describe("emitGraphQLResolver", () => {
 
 		const result = emitGraphQLResolver(projection, defaultOptions);
 
+		// All nested aggs sharing a path are grouped under one wrapper
+		// (`__n_<path>` key) — saves the per-agg `{ nested: ..., aggs: { inner: ... } }`
+		// skeleton on wide projections (issue #105).
 		assert.ok(
-			result.content.includes(
-				'byTagName: { nested: { path: "tags" }, aggs: { inner: { terms: { field: "tags.name" } } } }',
-			),
-		);
-		assert.ok(
-			result.content.includes(
-				'uniqueTagNameCount: { nested: { path: "tags" }, aggs: { inner: { cardinality: { field: "tags.name" } } } }',
-			),
-		);
-		assert.ok(
-			result.content.includes(
-				'missingTagNoteCount: { nested: { path: "tags" }, aggs: { inner: { missing: { field: "tags.note.keyword" } } } }',
+			combinedContent(result).includes(
+				'_tags: { nested: { path: "tags" }, aggs: { byTagName: { terms: { field: "tags.name" } }, uniqueTagNameCount: { cardinality: { field: "tags.name" } }, missingTagNoteCount: { missing: { field: "tags.note.keyword" } } } }',
 			),
 		);
 
 		assert.ok(
-			result.content.includes(
-				"byTagName: (parsedBody.aggregations?.byTagName?.inner?.buckets ?? []).map",
+			combinedContent(result).includes(
+				"byTagName: (_a_tags.byTagName?.buckets ?? []).map",
 			),
 		);
 		assert.ok(
-			result.content.includes(
-				"uniqueTagNameCount: parsedBody.aggregations?.uniqueTagNameCount?.inner?.value ?? 0",
+			combinedContent(result).includes(
+				"uniqueTagNameCount: _a_tags.uniqueTagNameCount?.value ?? 0",
 			),
 		);
 		assert.ok(
-			result.content.includes(
-				"missingTagNoteCount: parsedBody.aggregations?.missingTagNoteCount?.inner?.doc_count ?? 0",
+			combinedContent(result).includes(
+				"missingTagNoteCount: _a_tags.missingTagNoteCount?.doc_count ?? 0",
 			),
 		);
 	});
@@ -624,10 +695,12 @@ describe("emitGraphQLResolver", () => {
 
 		const result = emitGraphQLResolver(projection, defaultOptions);
 		assert.ok(
-			result.content.includes('byTag: { terms: { field: "tags.keyword" } }'),
+			combinedContent(result).includes(
+				'byTag: { terms: { field: "tags.keyword" } }',
+			),
 		);
 		// Aggs for non-@nested fields must not be wrapped in `{ nested: ... }`.
-		assert.ok(!result.content.includes("byTag: { nested:"));
+		assert.ok(!combinedContent(result).includes("byTag: { nested:"));
 	});
 
 	it("emits aggregations mapping in response", () => {
@@ -652,20 +725,18 @@ describe("emitGraphQLResolver", () => {
 		});
 		const result = emitGraphQLResolver(projection, defaultOptions);
 
-		assert.ok(result.content.includes("aggregations: {"));
+		assert.ok(combinedContent(result).includes("aggregations: {"));
 		assert.ok(
-			result.content.includes(
-				"byTag: (parsedBody.aggregations?.byTag?.buckets ?? []).map",
+			combinedContent(result).includes("byTag: (_a.byTag?.buckets ?? []).map"),
+		);
+		assert.ok(
+			combinedContent(result).includes(
+				"uniqueLocationCount: _a.uniqueLocationCount?.value ?? 0",
 			),
 		);
 		assert.ok(
-			result.content.includes(
-				"uniqueLocationCount: parsedBody.aggregations?.uniqueLocationCount?.value ?? 0",
-			),
-		);
-		assert.ok(
-			result.content.includes(
-				"missingDescriptionCount: parsedBody.aggregations?.missingDescriptionCount?.doc_count ?? 0",
+			combinedContent(result).includes(
+				"missingDescriptionCount: _a.missingDescriptionCount?.doc_count ?? 0",
 			),
 		);
 	});
@@ -708,13 +779,15 @@ describe("emitGraphQLResolver search filter DSL", () => {
 			],
 		});
 		const result = emitGraphQLResolver(projection, defaultOptions);
-		assert.ok(result.content.includes("const FILTER_SPEC = ["));
-		assert.ok(result.content.includes('"species"'));
-		assert.ok(result.content.includes('"speciesNot"'));
+		assert.ok(combinedContent(result).includes("const FILTER_SPEC = ["));
+		assert.ok(combinedContent(result).includes('"species"'));
+		assert.ok(combinedContent(result).includes('"speciesNot"'));
 		// Range now emits ONE FILTER_SPEC entry per field (#101); the
 		// resolver expands "rankGte"/"Lte"/"Gt"/"Lt" lookups at runtime.
-		assert.ok(result.content.includes('{i:"rank",k:"range",f:"rank"}'));
-		assert.ok(!result.content.includes('"rankGte"'));
+		assert.ok(
+			combinedContent(result).includes('{i:"rank",k:"range",f:"rank"}'),
+		);
+		assert.ok(!combinedContent(result).includes('"rankGte"'));
 	});
 
 	it("emits an empty FILTER_SPEC when no @filterable fields", () => {
@@ -722,7 +795,7 @@ describe("emitGraphQLResolver search filter DSL", () => {
 			fields: [makeField({ name: "name" })],
 		});
 		const result = emitGraphQLResolver(projection, defaultOptions);
-		assert.ok(result.content.includes("const FILTER_SPEC = []"));
+		assert.ok(combinedContent(result).includes("const FILTER_SPEC = []"));
 	});
 
 	it("buildQuery returns match_all when no inputs", () => {
@@ -730,7 +803,7 @@ describe("emitGraphQLResolver search filter DSL", () => {
 			fields: [makeField({ name: "name" })],
 		});
 		const buildQuery = loadBuildQuery(
-			emitGraphQLResolver(projection, defaultOptions).content,
+			prepareFunctionContent(emitGraphQLResolver(projection, defaultOptions)),
 		);
 		assert.deepEqual(buildQuery(undefined, undefined, undefined), {
 			match_all: {},
@@ -748,7 +821,7 @@ describe("emitGraphQLResolver search filter DSL", () => {
 			],
 		});
 		const buildQuery = loadBuildQuery(
-			emitGraphQLResolver(projection, defaultOptions).content,
+			prepareFunctionContent(emitGraphQLResolver(projection, defaultOptions)),
 		);
 		const result = buildQuery(undefined, undefined, { species: "cat" });
 		assert.deepEqual(result, {
@@ -769,7 +842,7 @@ describe("emitGraphQLResolver search filter DSL", () => {
 			],
 		});
 		const buildQuery = loadBuildQuery(
-			emitGraphQLResolver(projection, defaultOptions).content,
+			prepareFunctionContent(emitGraphQLResolver(projection, defaultOptions)),
 		);
 		const result = buildQuery(undefined, undefined, {
 			speciesIn: ["cat", "dog"],
@@ -792,7 +865,7 @@ describe("emitGraphQLResolver search filter DSL", () => {
 			],
 		});
 		const buildQuery = loadBuildQuery(
-			emitGraphQLResolver(projection, defaultOptions).content,
+			prepareFunctionContent(emitGraphQLResolver(projection, defaultOptions)),
 		);
 		const result = buildQuery(undefined, undefined, { speciesIn: [] });
 		assert.deepEqual(result, { match_all: {} });
@@ -809,7 +882,7 @@ describe("emitGraphQLResolver search filter DSL", () => {
 			],
 		});
 		const buildQuery = loadBuildQuery(
-			emitGraphQLResolver(projection, defaultOptions).content,
+			prepareFunctionContent(emitGraphQLResolver(projection, defaultOptions)),
 		);
 		const result = buildQuery(undefined, undefined, { speciesNot: "cat" });
 		assert.deepEqual(result, {
@@ -835,7 +908,7 @@ describe("emitGraphQLResolver search filter DSL", () => {
 			],
 		});
 		const buildQuery = loadBuildQuery(
-			emitGraphQLResolver(projection, defaultOptions).content,
+			prepareFunctionContent(emitGraphQLResolver(projection, defaultOptions)),
 		);
 		const result = buildQuery(undefined, undefined, {
 			tags: { name: "vip" },
@@ -872,7 +945,7 @@ describe("emitGraphQLResolver search filter DSL", () => {
 			],
 		});
 		const buildQuery = loadBuildQuery(
-			emitGraphQLResolver(projection, defaultOptions).content,
+			prepareFunctionContent(emitGraphQLResolver(projection, defaultOptions)),
 		);
 		const result = buildQuery(undefined, undefined, {
 			tags: { nameNot: "blocked" },
@@ -904,7 +977,7 @@ describe("emitGraphQLResolver search filter DSL", () => {
 			],
 		});
 		const buildQuery = loadBuildQuery(
-			emitGraphQLResolver(projection, defaultOptions).content,
+			prepareFunctionContent(emitGraphQLResolver(projection, defaultOptions)),
 		);
 		const result = buildQuery(undefined, undefined, {
 			createdAtGte: "2026-01-01",
@@ -934,7 +1007,7 @@ describe("emitGraphQLResolver search filter DSL", () => {
 			],
 		});
 		const buildQuery = loadBuildQuery(
-			emitGraphQLResolver(projection, defaultOptions).content,
+			prepareFunctionContent(emitGraphQLResolver(projection, defaultOptions)),
 		);
 
 		assert.deepEqual(
@@ -967,7 +1040,7 @@ describe("emitGraphQLResolver search filter DSL", () => {
 			],
 		});
 		const buildQuery = loadBuildQuery(
-			emitGraphQLResolver(projection, defaultOptions).content,
+			prepareFunctionContent(emitGraphQLResolver(projection, defaultOptions)),
 		);
 		const result = buildQuery("fluffy", undefined, { species: "cat" }) as {
 			bool: { must: unknown[]; filter: unknown[] };
@@ -989,7 +1062,7 @@ describe("emitGraphQLResolver search filter DSL", () => {
 			],
 		});
 		const buildQuery = loadBuildQuery(
-			emitGraphQLResolver(projection, defaultOptions).content,
+			prepareFunctionContent(emitGraphQLResolver(projection, defaultOptions)),
 		);
 		const result = buildQuery(undefined, { species: "cat" }, undefined);
 		assert.deepEqual(result, {
@@ -1045,13 +1118,19 @@ describe("emitGraphQLResolver search filter DSL", () => {
 		const result = emitGraphQLResolver(projection, defaultOptions);
 
 		const forbidden = ["String", "Number", "Boolean", "Array", "Object"];
-		for (const name of forbidden) {
-			const re = new RegExp(`\\b${name}\\s*\\(`);
-			assert.equal(
-				re.test(result.content),
-				false,
-				`emitted resolver must not call \`${name}(...)\` — APPSYNC_JS rejects global coercion calls.\n--- emitted ---\n${result.content}\n--- end ---`,
-			);
+		const allFiles = [
+			{ name: "resolver", content: result.content },
+			...result.functions.map((fn) => ({ name: fn.name, content: fn.content })),
+		];
+		for (const file of allFiles) {
+			for (const name of forbidden) {
+				const re = new RegExp(`\\b${name}\\s*\\(`);
+				assert.equal(
+					re.test(file.content),
+					false,
+					`emitted ${file.name} must not call \`${name}(...)\` — APPSYNC_JS rejects global coercion calls.\n--- emitted ---\n${file.content}\n--- end ---`,
+				);
+			}
 		}
 	});
 
@@ -1135,8 +1214,13 @@ describe("emitGraphQLResolver search filter DSL", () => {
 
 		const dir = await mkdtemp(join(tmpdir(), "appsync-lint-"));
 		try {
-			const filePath = join(dir, "resolver.js");
-			await writeFile(filePath, result.content);
+			const fileNames = ["resolver.js"];
+			await writeFile(join(dir, "resolver.js"), result.content);
+			for (const fn of result.functions) {
+				const fileName = `${fn.name}.js`;
+				fileNames.push(fileName);
+				await writeFile(join(dir, fileName), fn.content);
+			}
 			// no-recursion is type-aware and needs a real TS project on disk.
 			await writeFile(
 				join(dir, "tsconfig.json"),
@@ -1148,7 +1232,7 @@ describe("emitGraphQLResolver search filter DSL", () => {
 						checkJs: false,
 						noEmit: true,
 					},
-					include: ["resolver.js"],
+					include: fileNames,
 				}),
 			);
 
@@ -1172,16 +1256,19 @@ describe("emitGraphQLResolver search filter DSL", () => {
 					},
 				],
 			});
-			const lintResults = await eslint.lintFiles([filePath]);
+			const lintResults = await eslint.lintFiles(
+				fileNames.map((n) => join(dir, n)),
+			);
 			const messages = lintResults.flatMap((r) =>
 				r.messages.map(
-					(m) => `[${m.ruleId ?? "fatal"}] line ${m.line ?? "?"}: ${m.message}`,
+					(m) =>
+						`[${m.ruleId ?? "fatal"}] ${r.filePath.split("/").pop()} line ${m.line ?? "?"}: ${m.message}`,
 				),
 			);
 			assert.deepEqual(
 				messages,
 				[],
-				`@aws-appsync/eslint-plugin reported issues:\n${messages.join("\n")}\n--- emitted resolver ---\n${result.content}`,
+				`@aws-appsync/eslint-plugin reported issues:\n${messages.join("\n")}\n--- emitted resolver ---\n${result.content}\n--- prepare ---\n${result.functions.find((f) => f.name === "prepare")?.content}\n--- search ---\n${result.functions.find((f) => f.name === "search")?.content}`,
 			);
 		} finally {
 			await rm(dir, { recursive: true, force: true });
@@ -1206,7 +1293,9 @@ describe("emitGraphQLResolver search filter DSL", () => {
 		});
 		const result = emitGraphQLResolver(projection, defaultOptions);
 		assert.ok(
-			result.content.includes('{i:"tagsExists",k:"nested_exists",p:"tags"}'),
+			combinedContent(result).includes(
+				'{i:"tagsExists",k:"nested_exists",p:"tags"}',
+			),
 			"FILTER_SPEC must carry a nested_exists entry with the path (compact-key form)",
 		);
 	});
@@ -1228,7 +1317,7 @@ describe("emitGraphQLResolver search filter DSL", () => {
 			],
 		});
 		const buildQuery = loadBuildQuery(
-			emitGraphQLResolver(projection, defaultOptions).content,
+			prepareFunctionContent(emitGraphQLResolver(projection, defaultOptions)),
 		);
 
 		const truthy = buildQuery(undefined, undefined, { tagsExists: true });
@@ -1267,7 +1356,7 @@ describe("emitGraphQLResolver search filter DSL", () => {
 			],
 		});
 		const buildQuery = loadBuildQuery(
-			emitGraphQLResolver(projection, defaultOptions).content,
+			prepareFunctionContent(emitGraphQLResolver(projection, defaultOptions)),
 		);
 		const result = buildQuery(undefined, undefined, {
 			species: "cat",
@@ -1313,5 +1402,126 @@ describe("emitGraphQLResolver search filter DSL", () => {
 			),
 			"nested exists clause missing",
 		);
+	});
+});
+
+describe("emitGraphQLResolver wide-projection budget (issue #105)", () => {
+	function makeWideSubProjection(
+		name: string,
+		extraFields: Array<ResolvedProjection["fields"][0]> = [],
+	): ResolvedProjection {
+		return {
+			projectionModel: { name: `${name}SearchDoc` },
+			sourceModel: { name },
+			indexName: name.toLowerCase(),
+			fields: [
+				makeField({
+					name: `${lowerFirst(name)}Id`,
+					keyword: true,
+					filterables: ["term", "terms", "exists"],
+					aggregations: ["terms"],
+				}),
+				makeField({
+					name: "type",
+					keyword: true,
+					filterables: ["term", "terms", "exists"],
+					aggregations: ["terms"],
+				}),
+				makeField({
+					name: "createdAt",
+					filterables: ["range"],
+					type: { kind: "Scalar", name: "utcDateTime" } as unknown as Type,
+					aggregations: [
+						"sum",
+						"avg",
+						"min",
+						"max",
+						{ kind: "date_histogram", options: { interval: "month" } },
+					],
+				}),
+				makeField({
+					name: "updatedAt",
+					filterables: ["range"],
+					type: { kind: "Scalar", name: "utcDateTime" } as unknown as Type,
+					aggregations: ["sum", "avg", "min", "max"],
+				}),
+				...extraFields,
+			],
+		} as unknown as ResolvedProjection;
+	}
+
+	function lowerFirst(s: string): string {
+		return s[0].toLowerCase() + s.slice(1);
+	}
+
+	it("counterparty-shape projection (7 nested sub-models) emits resolver under 32 KB AppSync cap", () => {
+		// Synthetic mirror of the consumer counterparty projection: 7 @nested
+		// sub-models (approvals/relations/locations/contacts/tags/groups/references),
+		// each with id+type+createdAt+updatedAt aggs/filters. Acceptance criterion
+		// from issue #105: counterparty-search-doc-resolver.js was 37,310 bytes
+		// post-#101 — needs to fit under AppSync's 32,768-byte resolver code cap.
+		const subShapes = [
+			"Approval",
+			"Relation",
+			"Location",
+			"Contact",
+			"Tag",
+			"Group",
+			"Reference",
+		];
+		const projection = makeProjection({
+			name: "CounterpartySearchDoc",
+			indexName: "counterparties_v1",
+			fields: [
+				makeField({
+					name: "counterpartyId",
+					keyword: true,
+					filterables: ["term", "terms", "exists"],
+					aggregations: ["terms"],
+				}),
+				makeField({
+					name: "createdAt",
+					filterables: ["range"],
+					type: { kind: "Scalar", name: "utcDateTime" } as unknown as Type,
+					aggregations: ["sum", "avg", "min", "max"],
+				}),
+				makeField({
+					name: "updatedAt",
+					filterables: ["range"],
+					type: { kind: "Scalar", name: "utcDateTime" } as unknown as Type,
+					aggregations: ["sum", "avg", "min", "max"],
+				}),
+				...subShapes.map((shape) =>
+					makeField({
+						name: `${shape.toLowerCase()}s`,
+						nested: true,
+						subProjection: makeWideSubProjection(shape),
+						filterables: ["exists"],
+						type: {
+							kind: "Model",
+							name: "Array",
+							indexer: { value: { kind: "Model" } },
+						} as unknown as Type,
+					}),
+				),
+			],
+		});
+
+		const result = emitGraphQLResolver(projection, defaultOptions);
+
+		// Pipeline resolver: cap is per-file (resolver after-mapping + each
+		// pipeline function), not the sum. Issue #105 acceptance: each emitted
+		// file under AppSync's 32,768-byte cap, with headroom for future growth.
+		const files = [
+			{ name: "resolver", content: result.content },
+			...result.functions.map((fn) => ({ name: fn.name, content: fn.content })),
+		];
+		for (const file of files) {
+			const bytes = Buffer.byteLength(file.content, "utf8");
+			assert.ok(
+				bytes < 32_768,
+				`wide projection ${file.name} file is ${bytes} bytes; must stay under AppSync's 32,768-byte per-file cap (issue #105). Headroom: ${32_768 - bytes} bytes.`,
+			);
+		}
 	});
 });

--- a/src/emit-graphql-resolver.ts
+++ b/src/emit-graphql-resolver.ts
@@ -1,8 +1,4 @@
-import {
-	type AggregationEntry,
-	collectAggregations,
-	NESTED_INNER_AGG_NAME,
-} from "./aggregations.js";
+import { type AggregationEntry, collectAggregations } from "./aggregations.js";
 import { toGraphQLQueryFieldName } from "./emit-graphql-sdl.js";
 import {
 	buildSearchFilterShape,
@@ -15,10 +11,28 @@ import type {
 } from "./projection.js";
 import { toKebabCase } from "./utils.js";
 
-export interface EmittedResolverFile {
+export type PipelineFunctionDataSource = "OPENSEARCH" | "NONE";
+
+export interface EmittedPipelineFunction {
+	name: string;
 	fileName: string;
 	content: string;
+	dataSource: PipelineFunctionDataSource;
+}
+
+export interface EmittedResolverFile {
 	queryFieldName: string;
+	/** Resolver-level file (`request`/`response` orchestration). */
+	fileName: string;
+	content: string;
+	/**
+	 * Pipeline functions in execution order. Consumers wire these as AppSync
+	 * Functions and reference them on a PIPELINE Resolver. Splitting the work
+	 * across functions keeps each file's APPSYNC_JS code under the 32 KB
+	 * per-function cap, which a single-resolver shape would exceed on wide
+	 * @searchInfer projections (issue #105).
+	 */
+	functions: EmittedPipelineFunction[];
 }
 
 export interface ResolverOptions {
@@ -29,7 +43,7 @@ export interface ResolverOptions {
 
 // Bound for the runtime applyFilterSpec walker's fixed-size work slot pool.
 // APPSYNC_JS does not honor self-extending Array iteration, so the emitted
-// resolver pre-allocates this many slots as a literal. Set well above any
+// function pre-allocates this many slots as a literal. Set well above any
 // realistic SearchFilter shape; runtime util.error fires if exceeded.
 const FILTER_WORK_SLOT_COUNT = 256;
 
@@ -39,7 +53,7 @@ export function emitGraphQLResolver(
 ): EmittedResolverFile {
 	const typeName = projection.projectionModel.name;
 	const queryFieldName = toGraphQLQueryFieldName(typeName);
-	const fileName = `${toKebabCase(typeName)}-resolver.js`;
+	const baseName = toKebabCase(typeName);
 
 	const textFields = projection.fields
 		.filter(
@@ -59,19 +73,34 @@ export function emitGraphQLResolver(
 	const aggregations = collectAggregations(projection);
 	const searchFilterShape = buildSearchFilterShape(projection);
 
-	const content = renderResolver(
-		projection.indexName,
+	const prepareContent = renderPrepareFunction(
 		textFields,
 		keywordFields,
 		aggregations,
 		searchFilterShape,
 		options,
 	);
+	const searchContent = renderSearchFunction(projection.indexName);
+	const resolverContent = renderResolver(aggregations, options);
 
 	return {
-		fileName,
-		content,
 		queryFieldName,
+		fileName: `${baseName}-resolver.js`,
+		content: resolverContent,
+		functions: [
+			{
+				name: "prepare",
+				fileName: `${baseName}-fn-prepare.js`,
+				content: prepareContent,
+				dataSource: "NONE",
+			},
+			{
+				name: "search",
+				fileName: `${baseName}-fn-search.js`,
+				content: searchContent,
+				dataSource: "OPENSEARCH",
+			},
+		],
 	};
 }
 
@@ -88,8 +117,63 @@ function hasTextType(field: ResolvedProjectionField): boolean {
 	return type.kind === "String";
 }
 
+/**
+ * Pipeline resolver "before/after" code. The `request` exports here become the
+ * pipeline's before-mapping; `response` is the after-mapping that runs after
+ * all functions complete. The OS response lives at `ctx.prev.result` after
+ * the OS-datasource function in the pipeline returns.
+ */
 function renderResolver(
-	indexName: string,
+	aggregations: AggregationEntry[],
+	options: ResolverOptions,
+): string {
+	const responseAggregationsPreamble =
+		renderResponseAggregationsPreamble(aggregations);
+	const responseAggregations = renderResponseAggregations(aggregations);
+
+	return `import { util } from "@aws-appsync/utils";
+
+export function request(ctx) {
+	return {};
+}
+
+export function response(ctx) {
+	if (ctx.error) {
+		return util.error(ctx.error.message, ctx.error.type);
+	}
+
+	const parsedBody = ctx.prev.result;
+	const hits = parsedBody.hits.hits;
+	const totalHits = parsedBody.hits.total.value;
+	const args = ctx.args;
+	const size = Math.min(args.first || ${options.defaultPageSize}, ${options.maxPageSize});
+
+	const hasNextPage = hits.length > size;
+	const edges = hits.slice(0, size).map((hit) => ({
+		node: hit._source,
+		cursor: util.base64Encode(JSON.stringify(hit.sort)),
+	}));
+${responseAggregationsPreamble}
+	return {
+		edges,
+		totalCount: totalHits,${responseAggregations}
+		pageInfo: {
+			hasNextPage,
+			endCursor: edges.length > 0 ? edges[edges.length - 1].cursor : null,
+		},
+	};
+}
+`;
+}
+
+/**
+ * Pipeline function on a NONE datasource. Builds the OS query body from
+ * `ctx.args` (FILTER_SPEC walk + aggs assembly) and stashes it for the next
+ * function to send. Holds the bulk of the request-side code: keeping it in
+ * its own function keeps the resolver-level after-mapping (response shape +
+ * aggregation mapping) under the 32 KB per-file APPSYNC_JS cap (issue #105).
+ */
+function renderPrepareFunction(
 	textFields: string[],
 	keywordFields: string[],
 	aggregations: AggregationEntry[],
@@ -99,9 +183,12 @@ function renderResolver(
 	const textFieldsLiteral = JSON.stringify(textFields);
 	const keywordFieldsLiteral = JSON.stringify(keywordFields);
 	const aggsBlock = renderAggsBlock(aggregations);
-	const responseAggregations = renderResponseAggregations(aggregations);
 	const filterSpecLiteral = renderFilterSpecLiteral(searchFilterShape);
-	const slotsLiteral = `[${"undefined,".repeat(FILTER_WORK_SLOT_COUNT).slice(0, -1)}]`;
+	// `null` (4 chars) instead of `undefined` (9 chars) keeps the literal small
+	// — saves ~5 bytes per slot. The walker never reads these init values; it
+	// gates work on the head < tail FIFO indexes (real items are written into
+	// slots[tail] before tail advances).
+	const slotsLiteral = `[${"null,".repeat(FILTER_WORK_SLOT_COUNT).slice(0, -1)}]`;
 
 	return `import { util } from "@aws-appsync/utils";
 
@@ -126,38 +213,12 @@ export function request(ctx) {
 		body.search_after = searchAfter;
 	}
 
-	return {
-		operation: "GET",
-		path: \`/${indexName}/_search\`,
-		params: { body },
-	};
+	ctx.stash.queryBody = body;
+	return { payload: null };
 }
 
 export function response(ctx) {
-	if (ctx.error) {
-		return util.error(ctx.error.message, ctx.error.type);
-	}
-
-	const parsedBody = ctx.result;
-	const hits = parsedBody.hits.hits;
-	const totalHits = parsedBody.hits.total.value;
-	const args = ctx.args;
-	const size = Math.min(args.first || ${options.defaultPageSize}, ${options.maxPageSize});
-
-	const hasNextPage = hits.length > size;
-	const edges = hits.slice(0, size).map((hit) => ({
-		node: hit._source,
-		cursor: util.base64Encode(JSON.stringify(hit.sort)),
-	}));
-
-	return {
-		edges,
-		totalCount: totalHits,${responseAggregations}
-		pageInfo: {
-			hasNextPage,
-			endCursor: edges.length > 0 ? edges[edges.length - 1].cursor : null,
-		},
-	};
+	return ctx.result;
 }
 
 function buildQuery(queryText, filter, searchFilter) {
@@ -274,9 +335,9 @@ function applyFilterSpec(rootSpec, rootInput, rootOutFilters, rootOutMustNots) {
 				const outMustNots = item.outMustNots;
 
 				// FILTER_SPEC nodes use compact keys to fit under AppSync's 32 KB
-				// resolver code cap (issue #99): i=inputName, k=kind, f=field,
+				// per-function code cap (issue #99): i=inputName, k=kind, f=field,
 				// p=path, c=children. See stringifyNode in the emitter. Range
-				// kind carries one entry per field; the resolver expands the
+				// kind carries one entry per field; the function expands the
 				// four bound inputs (i+"Gte"/Lte/Gt/Lt) at iteration time
 				// (issue #101).
 				for (const node of spec) {
@@ -287,7 +348,7 @@ function applyFilterSpec(rootSpec, rootInput, rootOutFilters, rootOutMustNots) {
 							const childMustNots = [];
 							if (tail + 2 > slots.length) {
 								util.error(
-									"applyFilterSpec exceeded fixed work-slot capacity; SearchFilter shape too deep for APPSYNC_JS resolver",
+									"applyFilterSpec exceeded fixed work-slot capacity; SearchFilter shape too deep for APPSYNC_JS function",
 								);
 							}
 							slots[tail] = {
@@ -312,7 +373,7 @@ function applyFilterSpec(rootSpec, rootInput, rootOutFilters, rootOutMustNots) {
 						if (value != null) {
 							if (tail + 1 > slots.length) {
 								util.error(
-									"applyFilterSpec exceeded fixed work-slot capacity; SearchFilter shape too deep for APPSYNC_JS resolver",
+									"applyFilterSpec exceeded fixed work-slot capacity; SearchFilter shape too deep for APPSYNC_JS function",
 								);
 							}
 							slots[tail] = {
@@ -387,6 +448,27 @@ function applyFilterSpec(rootSpec, rootInput, rootOutFilters, rootOutMustNots) {
 `;
 }
 
+/**
+ * Pipeline function on the OPENSEARCH datasource. Reads the pre-built body
+ * from `ctx.stash.queryBody` (set by the prepare function) and issues the
+ * OS HTTP request. Tiny on purpose — the heavy filter/aggs construction
+ * lives in the prepare function where it has its own 32 KB budget.
+ */
+function renderSearchFunction(indexName: string): string {
+	return `export function request(ctx) {
+	return {
+		operation: "GET",
+		path: "/${indexName}/_search",
+		params: { body: ctx.stash.queryBody },
+	};
+}
+
+export function response(ctx) {
+	return ctx.result;
+}
+`;
+}
+
 function renderFilterSpecLiteral(shape: SearchFilterShape | undefined): string {
 	if (!shape) {
 		return "[]";
@@ -401,8 +483,8 @@ function stringifySpec(nodes: FilterSpecNode[]): string {
 
 function stringifyNode(node: FilterSpecNode): string {
 	// FILTER_SPEC entries use single-letter keys to keep wide projections
-	// under AppSync's 32 KB resolver-code cap (issue #99). The reader is
-	// applyFilterSpec inside the emitted resolver; keys must match there:
+	// under AppSync's 32 KB per-function code cap (issue #99). The reader is
+	// applyFilterSpec inside the emitted prepare function; keys must match there:
 	//   i = inputName, k = kind, f = field, p = path, c = children, b = bound.
 	const i = JSON.stringify(node.inputName);
 	if (node.kind === "nested") {
@@ -427,17 +509,55 @@ function renderAggsBlock(aggregations: AggregationEntry[]): string {
 		return "";
 	}
 
-	const lines = aggregations.map((entry) => renderAggLine(entry));
+	// Group aggs by nested path so each path emits ONE `nested` wrapper with all
+	// child aggs inside, instead of one wrapper per agg. Saves a per-agg
+	// `{ nested: { path: "..." }, aggs: { inner: ... } }` skeleton (~50 bytes
+	// per nested agg) on wide projections (issue #105).
+	//
+	// Aggregations carry a per-projection-unique `aggName` (e.g. `byCounterpartyId`).
+	// If the same aggName appears more than once (which can happen when a
+	// projection spreads the same field/aggregation twice), APPSYNC_JS rejects
+	// the resulting object literal at deploy time (TS1117 — duplicate keys).
+	// Dedupe here, first-wins.
+	const flatLines: string[] = [];
+	const flatSeen = new Set<string>();
+	const byPath = new Map<string, AggregationEntry[]>();
+	const seenInPath = new Map<string, Set<string>>();
+	for (const entry of aggregations) {
+		if (!entry.nestedPath) {
+			if (flatSeen.has(entry.aggName)) continue;
+			flatSeen.add(entry.aggName);
+			flatLines.push(`\t\t${entry.aggName}: ${renderAggInner(entry)},`);
+			continue;
+		}
+		const seen = seenInPath.get(entry.nestedPath) ?? new Set<string>();
+		if (seen.has(entry.aggName)) continue;
+		seen.add(entry.aggName);
+		seenInPath.set(entry.nestedPath, seen);
+		const list = byPath.get(entry.nestedPath);
+		if (list) {
+			list.push(entry);
+		} else {
+			byPath.set(entry.nestedPath, [entry]);
+		}
+	}
 
+	const groupLines: string[] = [];
+	for (const [path, group] of byPath) {
+		const inner = group
+			.map((e) => `${e.aggName}: ${renderAggInner(e)}`)
+			.join(", ");
+		groupLines.push(
+			`\t\t${nestedAggGroupKey(path)}: { nested: { path: ${JSON.stringify(path)} }, aggs: { ${inner} } },`,
+		);
+	}
+
+	const lines = [...flatLines, ...groupLines];
 	return `\n\t\taggs: {\n${lines.join("\n")}\n\t\t},`;
 }
 
-function renderAggLine(entry: AggregationEntry): string {
-	const inner = renderAggInner(entry);
-	if (entry.nestedPath) {
-		return `\t\t${entry.aggName}: { nested: { path: ${JSON.stringify(entry.nestedPath)} }, aggs: { ${NESTED_INNER_AGG_NAME}: ${inner} } },`;
-	}
-	return `\t\t${entry.aggName}: ${inner},`;
+function nestedAggGroupKey(nestedPath: string): string {
+	return `_${nestedPath.replace(/\./g, "_")}`;
 }
 
 function renderAggInner(entry: AggregationEntry): string {
@@ -480,22 +600,49 @@ function renderAggInner(entry: AggregationEntry): string {
 	return `{ ${aggType}: { field: ${fieldLit} } }`;
 }
 
+function renderResponseAggregationsPreamble(
+	aggregations: AggregationEntry[],
+): string {
+	if (aggregations.length === 0) {
+		return "";
+	}
+	// Hoist `parsedBody.aggregations` and per-nested-path subtrees into short
+	// locals so per-agg lines stay compact. With many nested aggs the
+	// difference dominates resolver size; together with nested-path grouping
+	// this keeps wide @searchInfer projections under AppSync's 32 KB cap
+	// (issue #105).
+	const lines = ["\tconst _a = parsedBody.aggregations || {};"];
+	const seen = new Set<string>();
+	for (const entry of aggregations) {
+		if (!entry.nestedPath || seen.has(entry.nestedPath)) continue;
+		seen.add(entry.nestedPath);
+		const groupKey = nestedAggGroupKey(entry.nestedPath);
+		lines.push(`\tconst _a${groupKey} = _a.${groupKey} || {};`);
+	}
+	return lines.join("\n");
+}
+
 function renderResponseAggregations(aggregations: AggregationEntry[]): string {
 	if (aggregations.length === 0) {
 		return "";
 	}
 
-	const lines = aggregations.map((entry) =>
-		renderResponseAggregationLine(entry),
-	);
+	// Match the dedupe in renderAggsBlock — first-wins on duplicate aggName.
+	const seen = new Set<string>();
+	const lines: string[] = [];
+	for (const entry of aggregations) {
+		if (seen.has(entry.aggName)) continue;
+		seen.add(entry.aggName);
+		lines.push(renderResponseAggregationLine(entry));
+	}
 
 	return `\n\t\taggregations: {\n${lines.join("\n")}\n\t\t},`;
 }
 
 function renderResponseAggregationLine(entry: AggregationEntry): string {
 	const path = entry.nestedPath
-		? `parsedBody.aggregations?.${entry.aggName}?.${NESTED_INNER_AGG_NAME}`
-		: `parsedBody.aggregations?.${entry.aggName}`;
+		? `_a${nestedAggGroupKey(entry.nestedPath)}.${entry.aggName}`
+		: `_a.${entry.aggName}`;
 	switch (entry.kind) {
 		case "terms": {
 			const opts = (entry.options ?? {}) as {
@@ -561,6 +708,8 @@ function osAggType(kind: AggregationEntry["kind"]): string {
 export const __test = {
 	hasTextType,
 	renderResolver,
+	renderPrepareFunction,
+	renderSearchFunction,
 	renderAggsBlock,
 	renderResponseAggregations,
 };

--- a/src/emit-graphql-sdl.test.ts
+++ b/src/emit-graphql-sdl.test.ts
@@ -24,6 +24,27 @@ function makeProjection(
 	} as unknown as ResolvedProjection;
 }
 
+/**
+ * Mirrors how buildVirtualSubProjection in projection.ts assembles a
+ * sub-projection for a nested struct: projectionModel and sourceModel
+ * reference the same model object. emit-graphql-sdl uses that identity
+ * to distinguish virtual struct sub-projections (which need a `type X`
+ * block emitted in the parent SDL) from explicit SearchProjection<T>
+ * sub-projections (which already have their own SDL file).
+ */
+function makeVirtualSubProjection(
+	name: string,
+	fields: ResolvedProjection["fields"],
+): ResolvedProjection {
+	const model = { name } as unknown as ResolvedProjection["projectionModel"];
+	return {
+		projectionModel: model,
+		sourceModel: model,
+		indexName: "",
+		fields,
+	} as unknown as ResolvedProjection;
+}
+
 function makeField(
 	overrides: Partial<{
 		name: string;
@@ -227,6 +248,161 @@ describe("emitGraphQLSdl", () => {
 
 		const result = emitGraphQLSdl(dummyProgram, projection, defaultOptions);
 		assert.ok(result.content.includes("tags: [TagSearchDoc!]!"));
+	});
+
+	it("emits `type <Name>` block for nested struct virtual sub-projections referenced from response shape", () => {
+		// Issue: when a projection references a nested struct (e.g. Address)
+		// via @searchInfer auto-recursion, only `input AddressSearchFilter`
+		// was emitted — no `type Address`. AppSync schema validation rejects
+		// the assembled SDL because the response field type is undefined.
+		const addressVirtual = makeVirtualSubProjection("Address", [
+			makeField({
+				name: "country",
+				type: { kind: "Scalar", name: "string" } as unknown as Type,
+			}),
+			makeField({
+				name: "city",
+				type: { kind: "Scalar", name: "string" } as unknown as Type,
+			}),
+		]);
+
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "location",
+					subProjection: addressVirtual,
+					optional: true,
+					type: { kind: "Model", name: "Address" } as unknown as Type,
+				}),
+			],
+		});
+
+		const result = emitGraphQLSdl(dummyProgram, projection, defaultOptions);
+		assert.ok(
+			result.content.includes("location: Address\n"),
+			"response field references nested type by name",
+		);
+		assert.ok(
+			result.content.match(/^type Address \{/m),
+			"emits `type Address { ... }` block",
+		);
+		assert.ok(result.content.includes("country: String!"));
+		assert.ok(result.content.includes("city: String!"));
+	});
+
+	it("emits nested struct types only once when referenced via multiple paths", () => {
+		const addressVirtual = makeVirtualSubProjection("Address", [
+			makeField({
+				name: "country",
+				type: { kind: "Scalar", name: "string" } as unknown as Type,
+			}),
+		]);
+
+		const personVirtual = makeVirtualSubProjection("PersonRecord", [
+			makeField({
+				name: "address",
+				subProjection: addressVirtual,
+				optional: true,
+				type: { kind: "Model", name: "Address" } as unknown as Type,
+			}),
+		]);
+
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "location",
+					subProjection: addressVirtual,
+					optional: true,
+					type: { kind: "Model", name: "Address" } as unknown as Type,
+				}),
+				makeField({
+					name: "person",
+					subProjection: personVirtual,
+					optional: true,
+					type: { kind: "Model", name: "PersonRecord" } as unknown as Type,
+				}),
+			],
+		});
+
+		const result = emitGraphQLSdl(dummyProgram, projection, defaultOptions);
+		const addressBlocks = result.content.match(/^type Address \{/gm) ?? [];
+		assert.equal(
+			addressBlocks.length,
+			1,
+			"Address must be emitted exactly once even when reachable via two paths",
+		);
+		assert.ok(result.content.match(/^type PersonRecord \{/m));
+	});
+
+	it("recurses into nested struct sub-projections to emit transitively referenced struct types", () => {
+		const addressVirtual = makeVirtualSubProjection("Address", [
+			makeField({
+				name: "country",
+				type: { kind: "Scalar", name: "string" } as unknown as Type,
+			}),
+		]);
+
+		const personVirtual = makeVirtualSubProjection("PersonRecord", [
+			makeField({
+				name: "address",
+				subProjection: addressVirtual,
+				optional: true,
+				type: { kind: "Model", name: "Address" } as unknown as Type,
+			}),
+		]);
+
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "person",
+					subProjection: personVirtual,
+					optional: true,
+					type: { kind: "Model", name: "PersonRecord" } as unknown as Type,
+				}),
+			],
+		});
+
+		const result = emitGraphQLSdl(dummyProgram, projection, defaultOptions);
+		assert.ok(
+			result.content.match(/^type PersonRecord \{/m),
+			"directly-referenced nested type emitted",
+		);
+		assert.ok(
+			result.content.match(/^type Address \{/m),
+			"transitively-referenced nested type emitted",
+		);
+	});
+
+	it("does not emit `type <Name>` block for explicit SearchProjection<T> sub-projections", () => {
+		// Explicit SearchProjection<T> models (e.g. TagSearchDoc) get their
+		// own SDL file via emitGraphQLSdl. Re-emitting the type block from
+		// every parent projection would create duplicates after assembly.
+		const explicitSub = makeProjection({
+			name: "TagSearchDoc",
+			sourceName: "Tag",
+		});
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "tags",
+					nested: true,
+					subProjection: explicitSub,
+					type: {
+						kind: "Model",
+						name: "Array",
+						indexer: { value: { kind: "Model" } },
+					} as unknown as Type,
+				}),
+			],
+		});
+
+		const result = emitGraphQLSdl(dummyProgram, projection, defaultOptions);
+		const tagBlocks = result.content.match(/^type TagSearchDoc \{/gm) ?? [];
+		assert.equal(
+			tagBlocks.length,
+			0,
+			"explicit projection sub-types must not be re-emitted in the parent SDL",
+		);
 	});
 });
 

--- a/src/emit-graphql-sdl.ts
+++ b/src/emit-graphql-sdl.ts
@@ -40,6 +40,12 @@ export function emitGraphQLSdl(
 	lines.push(renderObjectType(program, projection));
 	lines.push("");
 
+	const nestedStructTypes = renderNestedStructTypes(program, projection);
+	if (nestedStructTypes) {
+		lines.push(nestedStructTypes);
+		lines.push("");
+	}
+
 	const filterType = renderFilterInput(projection);
 	if (filterType) {
 		lines.push(filterType);
@@ -88,6 +94,66 @@ function renderObjectType(
 			return `  ${gqlName}: ${gqlType}${nullable}`;
 		});
 
+	return `type ${typeName} {\n${fieldLines.join("\n")}\n}`;
+}
+
+/**
+ * Emit `type <Name> { ... }` blocks for nested struct models referenced from
+ * the response shape (e.g. `Address`, `EmailRecord`). Without these the
+ * assembled AppSync schema fails validation because field types are not
+ * present.
+ *
+ * Only walks virtual sub-projections (the field's struct type itself, not an
+ * explicit `SearchProjection<T>` instantiation). Explicit projections already
+ * emit their own `<Type> { ... }` block via their own SDL file.
+ */
+function renderNestedStructTypes(
+	program: Program,
+	projection: ResolvedProjection,
+): string | undefined {
+	const blocks: string[] = [];
+	const seen = new Set<string>();
+	collectNestedStructTypes(program, projection, blocks, seen);
+	if (blocks.length === 0) return undefined;
+	return blocks.join("\n\n");
+}
+
+function collectNestedStructTypes(
+	program: Program,
+	projection: ResolvedProjection,
+	out: string[],
+	seen: Set<string>,
+): void {
+	for (const field of projection.fields) {
+		if (!field.searchable) continue;
+		if (!field.subProjection) continue;
+		if (!isVirtualSubProjection(field.subProjection)) continue;
+		const sub = field.subProjection;
+		const name = sub.projectionModel.name;
+		if (seen.has(name)) continue;
+		seen.add(name);
+		out.push(renderVirtualStructType(program, sub));
+		collectNestedStructTypes(program, sub, out, seen);
+	}
+}
+
+function isVirtualSubProjection(sub: ResolvedProjection): boolean {
+	// buildVirtualSubProjection sets projectionModel === sourceModel; explicit
+	// SearchProjection<T> instantiations have distinct projection/source models.
+	return sub.projectionModel === sub.sourceModel;
+}
+
+function renderVirtualStructType(
+	program: Program,
+	sub: ResolvedProjection,
+): string {
+	const typeName = sub.projectionModel.name;
+	const fieldLines = sub.fields.map((field) => {
+		const gqlName = field.projectedName ?? field.name;
+		const gqlType = toGraphQLType(program, field.type, field);
+		const nullable = field.optional ? "" : "!";
+		return `  ${gqlName}: ${gqlType}${nullable}`;
+	});
 	return `type ${typeName} {\n${fieldLines.join("\n")}\n}`;
 }
 
@@ -275,7 +341,15 @@ function renderAggregationTypes(
 	const sharedBucketTypes = new Set<string>();
 	const customBucketTypes: string[] = [];
 
-	const fieldLines = entries.map((entry) => {
+	// Dedupe by aggName — same fieldLine matches the resolver-side dedupe in
+	// renderAggsBlock. Without this, an aggregation declared on a field that
+	// the projection emits twice (e.g. via spread) produces a duplicate-field
+	// SDL block, which AppSync schema validation rejects.
+	const seenAggNames = new Set<string>();
+	const fieldLines: string[] = [];
+	for (const entry of entries) {
+		if (seenAggNames.has(entry.aggName)) continue;
+		seenAggNames.add(entry.aggName);
 		const gqlType = aggregationGraphQLType(entry, sharedBucketTypes);
 		if (entry.kind === "terms" && entry.options) {
 			const opts = entry.options as {
@@ -299,11 +373,12 @@ function renderAggregationTypes(
 						"}",
 					].join("\n"),
 				);
-				return `  ${entry.aggName}: [${bucketTypeName}!]!`;
+				fieldLines.push(`  ${entry.aggName}: [${bucketTypeName}!]!`);
+				continue;
 			}
 		}
-		return `  ${entry.aggName}: ${gqlType}`;
-	});
+		fieldLines.push(`  ${entry.aggName}: ${gqlType}`);
+	}
 
 	const sharedBucketBlocks: string[] = [];
 	if (sharedBucketTypes.has("TermBucket")) {

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -109,6 +109,12 @@ export async function $onEmit(
 				path: resolvePath(context.emitterOutputDir, resolverFile.fileName),
 				content: resolverFile.content,
 			});
+			for (const fn of resolverFile.functions) {
+				await emitFile(context.program, {
+					path: resolvePath(context.emitterOutputDir, fn.fileName),
+					content: fn.content,
+				});
+			}
 		}
 
 		const manifest = generateGraphQLManifest(resolved, resolverFiles);
@@ -233,6 +239,11 @@ function generateGraphQLManifest(
 			queryFieldName: resolver.queryFieldName,
 			resolverFile: resolver.fileName,
 			sdlFile: `${toKebabCase(projection.projectionModel.name)}.graphql`,
+			functions: resolver.functions.map((fn) => ({
+				name: fn.name,
+				file: fn.fileName,
+				dataSource: fn.dataSource,
+			})),
 		};
 	});
 
@@ -316,6 +327,8 @@ function generatePackageJson(
 			const kebab = toKebabCase(projection.projectionModel.name);
 			artifactExports[`./${kebab}.graphql`] = `./${kebab}.graphql`;
 			artifactExports[`./${kebab}-resolver.js`] = `./${kebab}-resolver.js`;
+			artifactExports[`./${kebab}-fn-prepare.js`] = `./${kebab}-fn-prepare.js`;
+			artifactExports[`./${kebab}-fn-search.js`] = `./${kebab}-fn-search.js`;
 		}
 	}
 

--- a/test/example.js
+++ b/test/example.js
@@ -16,6 +16,7 @@ test("emits projection metadata for multiple projections", async () => {
 	const parsed = JSON.parse(content);
 
 	assert.deepEqual(parsed.projections.map((x) => x.name).sort(), [
+		"PersonSearchDoc",
 		"PetPublicSearchDoc",
 		"PetSearchDoc",
 		"TagSearchDoc",
@@ -28,6 +29,21 @@ test("emits projection metadata for multiple projections", async () => {
 	assert.ok(nameField);
 	assert.equal(nameField.analyzer, "edge_ngram");
 	assert.equal(nameField.boost, 2);
+});
+
+test("emits `type <Name>` block for nested struct virtual sub-projections referenced from response shape", async () => {
+	const sdl = await readFile(`${OUT_DIR}/person-search-doc.graphql`, "utf8");
+
+	// Response object references the nested struct by name.
+	assert.ok(sdl.includes("address: Address"));
+
+	// `type Address { ... }` block emitted alongside the filter input.
+	assert.ok(sdl.match(/^type Address \{/m));
+	assert.ok(sdl.includes("country: String!"));
+	assert.ok(sdl.includes("city: String!"));
+
+	// Filter input still emitted (regression check).
+	assert.ok(sdl.includes("input AddressSearchFilter {"));
 });
 
 test("emits mapping files with expected field mappings", async () => {
@@ -96,6 +112,10 @@ test("emits graphql aggregation types and resolver block", async () => {
 		`${OUT_DIR}/pet-search-doc-resolver.js`,
 		"utf8",
 	);
+	const prepare = await readFile(
+		`${OUT_DIR}/pet-search-doc-fn-prepare.js`,
+		"utf8",
+	);
 
 	assert.ok(sdl.includes("type TermBucket {"));
 	assert.ok(sdl.includes("type PetSearchAggregations {"));
@@ -104,23 +124,25 @@ test("emits graphql aggregation types and resolver block", async () => {
 	assert.ok(sdl.includes("missingNicknameCount: Int!"));
 	assert.ok(sdl.includes("aggregations: PetSearchAggregations!"));
 
-	assert.ok(resolver.includes("aggs:"));
+	// Aggs request shape lives in the prepare function; response mapping
+	// lives in the resolver after-mapping (pipeline split — issue #105).
+	assert.ok(prepare.includes("aggs:"));
 	assert.ok(
-		resolver.includes('byAlias: { terms: { field: "aliases.keyword" } }'),
+		prepare.includes('byAlias: { terms: { field: "aliases.keyword" } }'),
 	);
 	assert.ok(
-		resolver.includes(
+		prepare.includes(
 			'uniqueAliasCount: { cardinality: { field: "aliases.keyword" } }',
 		),
 	);
 	assert.ok(resolver.includes("aggregations: {"));
-	assert.ok(resolver.includes("parsedBody.aggregations?.byAlias?.buckets"));
+	assert.ok(resolver.includes("_a.byAlias?.buckets"));
 });
 
 test("emits SearchFilter input with filterable kinds and nested sub-filter", async () => {
 	const sdl = await readFile(`${OUT_DIR}/pet-search-doc.graphql`, "utf8");
-	const resolver = await readFile(
-		`${OUT_DIR}/pet-search-doc-resolver.js`,
+	const prepare = await readFile(
+		`${OUT_DIR}/pet-search-doc-fn-prepare.js`,
 		"utf8",
 	);
 
@@ -138,17 +160,18 @@ test("emits SearchFilter input with filterable kinds and nested sub-filter", asy
 	assert.ok(sdl.includes("nameNot: String"));
 	assert.ok(sdl.includes("noteExists: Boolean"));
 
-	assert.ok(resolver.includes("const FILTER_SPEC = ["));
-	assert.ok(resolver.includes("applyFilterSpec(FILTER_SPEC, searchFilter"));
-	// FILTER_SPEC entries use compact single-letter keys to fit under
-	// AppSync's 32 KB resolver code cap (issue #99). Range emits ONE
-	// entry per field; the four bound input lookups (Gte/Lte/Gt/Lt) are
-	// done at iteration time inside applyFilterSpec (issue #101).
-	assert.ok(resolver.includes('i:"tags"'));
-	assert.ok(resolver.includes('k:"nested"'));
-	assert.ok(resolver.includes('p:"tags"'));
-	assert.ok(resolver.includes('{i:"rank",k:"range"'));
-	assert.ok(!resolver.includes('"rankGte"'));
+	// FILTER_SPEC + applyFilterSpec live in the prepare function (pipeline
+	// split — issue #105). FILTER_SPEC entries use compact single-letter keys
+	// to fit under AppSync's 32 KB per-function code cap (issue #99). Range
+	// emits ONE entry per field; the four bound input lookups (Gte/Lte/Gt/Lt)
+	// are done at iteration time inside applyFilterSpec (issue #101).
+	assert.ok(prepare.includes("const FILTER_SPEC = ["));
+	assert.ok(prepare.includes("applyFilterSpec(FILTER_SPEC, searchFilter"));
+	assert.ok(prepare.includes('i:"tags"'));
+	assert.ok(prepare.includes('k:"nested"'));
+	assert.ok(prepare.includes('p:"tags"'));
+	assert.ok(prepare.includes('{i:"rank",k:"range"'));
+	assert.ok(!prepare.includes('"rankGte"'));
 });
 
 test("emits nested-aware aggregations on nested sub-projections", async () => {
@@ -157,39 +180,34 @@ test("emits nested-aware aggregations on nested sub-projections", async () => {
 		`${OUT_DIR}/pet-search-doc-resolver.js`,
 		"utf8",
 	);
+	const prepare = await readFile(
+		`${OUT_DIR}/pet-search-doc-fn-prepare.js`,
+		"utf8",
+	);
 
 	assert.ok(sdl.includes("byTagName: [TermBucket!]!"));
 	assert.ok(sdl.includes("uniqueTagNameCount: Int!"));
 	assert.ok(sdl.includes("missingTagNoteCount: Int!"));
 
+	// Nested aggs sharing a path are grouped under a single wrapper
+	// (`_<path>` key) in the request (prepare function); the response
+	// mapping in the resolver after-mapping reads the grouped shape — issue #105.
+	assert.ok(
+		prepare.includes(
+			'_tags: { nested: { path: "tags" }, aggs: { byTagName: { terms: { field: "tags.name" } }, uniqueTagNameCount: { cardinality: { field: "tags.name" } }, missingTagNoteCount: { missing: { field: "tags.note.keyword" } } } }',
+		),
+	);
+	assert.ok(
+		resolver.includes("byTagName: (_a_tags.byTagName?.buckets ?? []).map"),
+	);
 	assert.ok(
 		resolver.includes(
-			'byTagName: { nested: { path: "tags" }, aggs: { inner: { terms: { field: "tags.name" } } } }',
+			"uniqueTagNameCount: _a_tags.uniqueTagNameCount?.value ?? 0",
 		),
 	);
 	assert.ok(
 		resolver.includes(
-			'uniqueTagNameCount: { nested: { path: "tags" }, aggs: { inner: { cardinality: { field: "tags.name" } } } }',
-		),
-	);
-	assert.ok(
-		resolver.includes(
-			'missingTagNoteCount: { nested: { path: "tags" }, aggs: { inner: { missing: { field: "tags.note.keyword" } } } }',
-		),
-	);
-	assert.ok(
-		resolver.includes(
-			"byTagName: (parsedBody.aggregations?.byTagName?.inner?.buckets ?? []).map",
-		),
-	);
-	assert.ok(
-		resolver.includes(
-			"uniqueTagNameCount: parsedBody.aggregations?.uniqueTagNameCount?.inner?.value ?? 0",
-		),
-	);
-	assert.ok(
-		resolver.includes(
-			"missingTagNoteCount: parsedBody.aggregations?.missingTagNoteCount?.inner?.doc_count ?? 0",
+			"missingTagNoteCount: _a_tags.missingTagNoteCount?.doc_count ?? 0",
 		),
 	);
 });

--- a/test/main.tsp
+++ b/test/main.tsp
@@ -45,3 +45,17 @@ model PetPublicSearchDoc is SearchProjection<Pet> {
 	@keyword
 	name: string;
 }
+
+@searchInfer
+model Address {
+	@keyword country: string;
+	@keyword city: string;
+}
+
+model Person {
+	@keyword id: string;
+	@searchable address?: Address;
+}
+
+@searchInfer
+model PersonSearchDoc is SearchProjection<Person> {}


### PR DESCRIPTION
Closes #105 and #106: splits the resolver into a NONE-datasource prepare function (FILTER_SPEC + query/sort/aggs build) and an OpenSearch search function so the largest projection lands at 19,932 bytes (39% headroom under the 32KB APPSYNC_JS cap), and emits matching `type <Name>` blocks for nested struct types referenced from search projection response shapes so the assembled AppSync schema validates.