### PR TITLE
fix(emit-doc-type): bare kebab .ts filenames to avoid sub-projection collision

### DIFF
--- a/src/emit-doc-type.test.ts
+++ b/src/emit-doc-type.test.ts
@@ -58,12 +58,20 @@ describe("toKebabCase", () => {
 });
 
 describe("toDocTypeFileName", () => {
-	it("strips -search-doc suffix and re-adds it with .ts", () => {
+	it("kebab-cases the projection model name with .ts", () => {
 		assert.equal(toDocTypeFileName("PetSearchDoc"), "pet-search-doc.ts");
 	});
 
-	it("adds -search-doc.ts if not already present", () => {
-		assert.equal(toDocTypeFileName("PetIndex"), "pet-index-search-doc.ts");
+	it("does NOT append -search-doc to bare model names — emits `<kebab>.ts` so virtual sub-projections don't collide with a sibling top-level projection that shares a kebab base", () => {
+		assert.equal(toDocTypeFileName("PetIndex"), "pet-index.ts");
+	});
+
+	it("emits `counterparty.ts` for a virtual `Counterparty` sub-projection (no collision with sibling `CounterpartySearchDoc` → `counterparty-search-doc.ts`)", () => {
+		assert.equal(toDocTypeFileName("Counterparty"), "counterparty.ts");
+		assert.equal(
+			toDocTypeFileName("CounterpartySearchDoc"),
+			"counterparty-search-doc.ts",
+		);
 	});
 });
 

--- a/src/emit-doc-type.ts
+++ b/src/emit-doc-type.ts
@@ -226,11 +226,12 @@ function renderUnion(program: Program, union: Union, depth = 0): string {
 }
 
 export function toDocTypeFileName(projectionModelName: string): string {
-	const kebab = toKebabCase(projectionModelName);
-	const base = kebab.endsWith("-search-doc")
-		? kebab.slice(0, -"-search-doc".length)
-		: kebab;
-	return `${base}-search-doc.ts`;
+	// One file per model name. `CounterpartySearchDoc` emits to
+	// `counterparty-search-doc.ts`, `Address` emits to `address.ts`, and
+	// the virtual sub-projection of `Counterparty` (referenced from
+	// `DescribeCounterparty.counterparty`) emits to `counterparty.ts` —
+	// no longer colliding with `counterparty-search-doc.ts`.
+	return `${toKebabCase(projectionModelName)}.ts`;
 }
 
 export const __test = {


### PR DESCRIPTION
Closes #108: emits each projection's TypeScript interface to a bare `<kebab>.ts` so a top-level `<X>SearchDoc` and a virtual sub-projection `<X>` (e.g. CounterpartySearchDoc and Counterparty from DescribeCounterparty.counterparty) no longer overwrite each other's file.