### PR TITLE
fix(emitter): walk nested struct refs in FILTER_SPEC dispatch (closes #110)

### DIFF
--- a/src/emit-graphql-resolver.test.ts
+++ b/src/emit-graphql-resolver.test.ts
@@ -1403,6 +1403,260 @@ describe("emitGraphQLResolver search filter DSL", () => {
 			"nested exists clause missing",
 		);
 	});
+
+	// Issue #110: a SearchFilter input that traverses two levels of nested
+	// struct (e.g. `locations.address.country` on a counterparty projection,
+	// where `locations` is @nested and `address` is a non-@nested struct
+	// sub-projection) was silently dropped. The SDL accepted the input but
+	// the prepare function emitted no clause, so OS returned the unfiltered
+	// total instead of the filtered subset.
+	it("buildQuery walks non-@nested struct (object kind) inside a @nested array — locations.address.country (issue #110)", () => {
+		const addressSubProjection = {
+			projectionModel: { name: "AddressSearchDoc" },
+			sourceModel: { name: "Address" },
+			indexName: "addresses",
+			fields: [
+				makeField({
+					name: "country",
+					keyword: true,
+					filterables: ["term"],
+				}),
+				makeField({
+					name: "city",
+					keyword: true,
+					filterables: ["term"],
+				}),
+			],
+		} as unknown as ResolvedProjection;
+
+		const locationSubProjection = {
+			projectionModel: { name: "LocationSearchDoc" },
+			sourceModel: { name: "Location" },
+			indexName: "locations",
+			fields: [
+				makeField({
+					name: "type",
+					keyword: true,
+					filterables: ["term"],
+				}),
+				makeField({
+					name: "address",
+					subProjection: addressSubProjection,
+				}),
+			],
+		} as unknown as ResolvedProjection;
+
+		const projection = makeProjection({
+			name: "CounterpartySearchDoc",
+			fields: [
+				makeField({
+					name: "locations",
+					nested: true,
+					subProjection: locationSubProjection,
+					type: {
+						kind: "Model",
+						name: "Array",
+						indexer: { value: { kind: "Model" } },
+					} as unknown as Type,
+				}),
+			],
+		});
+
+		const buildQuery = loadBuildQuery(
+			prepareFunctionContent(emitGraphQLResolver(projection, defaultOptions)),
+		);
+
+		const result = buildQuery(undefined, undefined, {
+			locations: { address: { country: "PT" } },
+		});
+
+		assert.deepEqual(result, {
+			bool: {
+				filter: [
+					{
+						nested: {
+							path: "locations",
+							query: {
+								bool: {
+									filter: [
+										{
+											term: { "locations.address.country": "PT" },
+										},
+									],
+								},
+							},
+						},
+					},
+				],
+			},
+		});
+	});
+
+	// Issue #110: same hazard, two-level @nested. Outer finalize used to run
+	// before inner finalize had populated its parent's child-clause array,
+	// silently dropping the inner term.
+	it("buildQuery walks @nested inside @nested — addresses.country wrapped in two nested clauses", () => {
+		const addressSubProjection = {
+			projectionModel: { name: "AddressSearchDoc" },
+			sourceModel: { name: "Address" },
+			indexName: "addresses",
+			fields: [
+				makeField({
+					name: "country",
+					keyword: true,
+					filterables: ["term"],
+				}),
+			],
+		} as unknown as ResolvedProjection;
+
+		const locationSubProjection = {
+			projectionModel: { name: "LocationSearchDoc" },
+			sourceModel: { name: "Location" },
+			indexName: "locations",
+			fields: [
+				makeField({
+					name: "addresses",
+					nested: true,
+					subProjection: addressSubProjection,
+					type: {
+						kind: "Model",
+						name: "Array",
+						indexer: { value: { kind: "Model" } },
+					} as unknown as Type,
+				}),
+			],
+		} as unknown as ResolvedProjection;
+
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "locations",
+					nested: true,
+					subProjection: locationSubProjection,
+					type: {
+						kind: "Model",
+						name: "Array",
+						indexer: { value: { kind: "Model" } },
+					} as unknown as Type,
+				}),
+			],
+		});
+
+		const buildQuery = loadBuildQuery(
+			prepareFunctionContent(emitGraphQLResolver(projection, defaultOptions)),
+		);
+
+		const result = buildQuery(undefined, undefined, {
+			locations: { addresses: { country: "PT" } },
+		});
+
+		assert.deepEqual(result, {
+			bool: {
+				filter: [
+					{
+						nested: {
+							path: "locations",
+							query: {
+								bool: {
+									filter: [
+										{
+											nested: {
+												path: "locations.addresses",
+												query: {
+													bool: {
+														filter: [
+															{
+																term: {
+																	"locations.addresses.country": "PT",
+																},
+															},
+														],
+													},
+												},
+											},
+										},
+									],
+								},
+							},
+						},
+					},
+				],
+			},
+		});
+	});
+
+	// Issue #110: term_negate inside an object-in-nested descent must end up
+	// on bool.must_not at the outer query level (mirrors the term path).
+	it("buildQuery routes term_negate from inside object-in-nested to outer bool.must_not", () => {
+		const addressSubProjection = {
+			projectionModel: { name: "AddressSearchDoc" },
+			sourceModel: { name: "Address" },
+			indexName: "addresses",
+			fields: [
+				makeField({
+					name: "country",
+					keyword: true,
+					filterables: ["term_negate"],
+				}),
+			],
+		} as unknown as ResolvedProjection;
+
+		const locationSubProjection = {
+			projectionModel: { name: "LocationSearchDoc" },
+			sourceModel: { name: "Location" },
+			indexName: "locations",
+			fields: [
+				makeField({
+					name: "address",
+					subProjection: addressSubProjection,
+				}),
+			],
+		} as unknown as ResolvedProjection;
+
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "locations",
+					nested: true,
+					subProjection: locationSubProjection,
+					type: {
+						kind: "Model",
+						name: "Array",
+						indexer: { value: { kind: "Model" } },
+					} as unknown as Type,
+				}),
+			],
+		});
+
+		const buildQuery = loadBuildQuery(
+			prepareFunctionContent(emitGraphQLResolver(projection, defaultOptions)),
+		);
+
+		const result = buildQuery(undefined, undefined, {
+			locations: { address: { countryNot: "PT" } },
+		});
+
+		assert.deepEqual(result, {
+			bool: {
+				must_not: [
+					{
+						nested: {
+							path: "locations",
+							query: {
+								bool: {
+									filter: [
+										{
+											term: { "locations.address.country": "PT" },
+										},
+									],
+								},
+							},
+						},
+					},
+				],
+			},
+		});
+	});
 });
 
 describe("emitGraphQLResolver wide-projection budget (issue #105)", () => {

--- a/src/emit-graphql-resolver.ts
+++ b/src/emit-graphql-resolver.ts
@@ -285,162 +285,187 @@ function applyFilterSpec(rootSpec, rootInput, rootOutFilters, rootOutMustNots) {
 	// APPSYNC_JS forbids while, continue, C-style for(init;cond;update), and
 	// the increment/decrement unary operators (lint rules @aws-appsync/no-while,
 	// @aws-appsync/no-continue, @aws-appsync/no-for,
-	// @aws-appsync/no-disallowed-unary-operators). It also does not honor the
-	// ECMA spec for Array's @@iterator: items pushed during \`for...of\`
-	// iteration are NOT visited (verified via aws appsync evaluate-code). We
-	// drive iteration with a fixed-length slot pool and a FIFO head/tail
-	// index pair: the \`for...of\` runs exactly slots.length times (its
-	// bound), and the body checks head < tail to act on real work. FIFO
-	// ordering is fine because filter semantics are conjunctive. Each
-	// "nested" node enqueues a "process" item then a "finalize" item; the
-	// child's clauses are populated before finalize wraps them onto the
-	// parent. The slot count is set well above any realistic SearchFilter
-	// shape; exceeding it raises util.error at runtime.
-	const slots = ${slotsLiteral};
-	slots[0] = {
-		kind: "process",
+	// @aws-appsync/no-disallowed-unary-operators), and recursion
+	// (@aws-appsync/no-recursion). It also does not honor the ECMA spec for
+	// Array's @@iterator: items pushed during \`for...of\` iteration are NOT
+	// visited (verified via aws appsync evaluate-code). Iteration is driven
+	// by fixed-length slot pools whose \`for...of\` runs exactly slots.length
+	// times; bodies check head/tail indexes to act on real work.
+	//
+	// Two pools, two phases (issue #110):
+	//   procSlots — FIFO process queue. Each process item walks a spec list,
+	//     enqueueing more process items for nested/object descents.
+	//   finSlots — finalize stack drained LIFO after all processing is done.
+	//     Each "nested" descent pushes one finalize item carrying the
+	//     child-clause arrays and the path to wrap them with. LIFO ordering
+	//     guarantees deepest-first wrapping, so an inner nested's clauses
+	//     are wrapped onto its outer parent's child-clause array BEFORE
+	//     that outer parent's finalize runs.
+	//
+	// The previous single-FIFO design ran a parent's finalize before
+	// descendant processing finished whenever a non-nested struct ("object"
+	// kind) sat between two leaves and a nested ancestor — the descendant
+	// term clause landed in childFilters AFTER finalize had already drained
+	// it, silently dropping the filter (issue #110). The same hazard
+	// applies to nested-of-nested: outer finalize ran before inner finalize
+	// populated its parent's child-clause array. Splitting process and
+	// finalize into separate pools fixes both.
+	const procSlots = ${slotsLiteral};
+	const finSlots = ${slotsLiteral};
+	procSlots[0] = {
 		spec: rootSpec,
 		input: rootInput,
 		outFilters: rootOutFilters,
 		outMustNots: rootOutMustNots,
 	};
-	let head = 0;
-	let tail = 1;
+	let procHead = 0;
+	let procTail = 1;
+	let finTail = 0;
 
-	for (const _slot of slots) {
-		if (head < tail) {
-			const item = slots[head];
-			head = head + 1;
-			if (item.kind === "finalize") {
-				for (const clause of item.childFilters) {
-					item.parentFilters.push({
-						nested: {
-							path: item.path,
-							query: { bool: { filter: [clause] } },
-						},
-					});
-				}
-				for (const clause of item.childMustNots) {
-					item.parentMustNots.push({
-						nested: {
-							path: item.path,
-							query: { bool: { filter: [clause] } },
-						},
-					});
-				}
-			} else {
-				const spec = item.spec;
-				const input = item.input;
-				const outFilters = item.outFilters;
-				const outMustNots = item.outMustNots;
+	for (const _slot of procSlots) {
+		if (procHead < procTail) {
+			const item = procSlots[procHead];
+			procHead = procHead + 1;
+			const spec = item.spec;
+			const input = item.input;
+			const outFilters = item.outFilters;
+			const outMustNots = item.outMustNots;
 
-				// FILTER_SPEC nodes use compact keys to fit under AppSync's 32 KB
-				// per-function code cap (issue #99): i=inputName, k=kind, f=field,
-				// p=path, c=children. See stringifyNode in the emitter. Range
-				// kind carries one entry per field; the function expands the
-				// four bound inputs (i+"Gte"/Lte/Gt/Lt) at iteration time
-				// (issue #101).
-				for (const node of spec) {
-					const value = input[node.i];
-					if (node.k === "nested") {
-						if (value != null) {
-							const childFilters = [];
-							const childMustNots = [];
-							if (tail + 2 > slots.length) {
-								util.error(
-									"applyFilterSpec exceeded fixed work-slot capacity; SearchFilter shape too deep for APPSYNC_JS function",
-								);
-							}
-							slots[tail] = {
-								kind: "process",
-								spec: node.c,
-								input: value,
-								outFilters: childFilters,
-								outMustNots: childMustNots,
-							};
-							tail = tail + 1;
-							slots[tail] = {
-								kind: "finalize",
-								path: node.p,
-								childFilters,
-								childMustNots,
-								parentFilters: outFilters,
-								parentMustNots: outMustNots,
-							};
-							tail = tail + 1;
+			// FILTER_SPEC nodes use compact keys to fit under AppSync's 32 KB
+			// per-function code cap (issue #99): i=inputName, k=kind, f=field,
+			// p=path, c=children. See stringifyNode in the emitter. Range
+			// kind carries one entry per field; the function expands the
+			// four bound inputs (i+"Gte"/Lte/Gt/Lt) at iteration time
+			// (issue #101).
+			for (const node of spec) {
+				const value = input[node.i];
+				if (node.k === "nested") {
+					if (value != null) {
+						const childFilters = [];
+						const childMustNots = [];
+						if (procTail + 1 > procSlots.length) {
+							util.error(
+								"applyFilterSpec exceeded fixed work-slot capacity; SearchFilter shape too deep for APPSYNC_JS function",
+							);
 						}
-					} else if (node.k === "object") {
-						if (value != null) {
-							if (tail + 1 > slots.length) {
-								util.error(
-									"applyFilterSpec exceeded fixed work-slot capacity; SearchFilter shape too deep for APPSYNC_JS function",
-								);
-							}
-							slots[tail] = {
-								kind: "process",
-								spec: node.c,
-								input: value,
-								outFilters,
-								outMustNots,
-							};
-							tail = tail + 1;
+						if (finTail + 1 > finSlots.length) {
+							util.error(
+								"applyFilterSpec exceeded fixed finalize-slot capacity; SearchFilter shape too deep for APPSYNC_JS function",
+							);
 						}
-					} else if (node.k === "term") {
-						if (value != null) {
-							outFilters.push({ term: { [node.f]: value } });
+						procSlots[procTail] = {
+							spec: node.c,
+							input: value,
+							outFilters: childFilters,
+							outMustNots: childMustNots,
+						};
+						procTail = procTail + 1;
+						finSlots[finTail] = {
+							path: node.p,
+							childFilters,
+							childMustNots,
+							parentFilters: outFilters,
+							parentMustNots: outMustNots,
+						};
+						finTail = finTail + 1;
+					}
+				} else if (node.k === "object") {
+					if (value != null) {
+						if (procTail + 1 > procSlots.length) {
+							util.error(
+								"applyFilterSpec exceeded fixed work-slot capacity; SearchFilter shape too deep for APPSYNC_JS function",
+							);
 						}
-					} else if (node.k === "term_negate") {
-						if (value != null) {
-							outMustNots.push({ term: { [node.f]: value } });
-						}
-					} else if (node.k === "terms") {
-						if (value != null && value.length > 0) {
-							outFilters.push({ terms: { [node.f]: value } });
-						}
-					} else if (node.k === "exists") {
-						if (value != null) {
-							if (value === true) {
-								outFilters.push({ exists: { field: node.f } });
-							} else {
-								outMustNots.push({ exists: { field: node.f } });
-							}
-						}
-					} else if (node.k === "nested_exists") {
-						if (value != null) {
-							const nestedClause = {
-								nested: { path: node.p, query: { match_all: {} } },
-							};
-							if (value === true) {
-								outFilters.push(nestedClause);
-							} else {
-								outMustNots.push(nestedClause);
-							}
-						}
-					} else if (node.k === "range") {
-						const base = node.i;
-						const bounds = {};
-						let any = false;
-						if (input[base + "Gte"] != null) {
-							bounds.gte = input[base + "Gte"];
-							any = true;
-						}
-						if (input[base + "Lte"] != null) {
-							bounds.lte = input[base + "Lte"];
-							any = true;
-						}
-						if (input[base + "Gt"] != null) {
-							bounds.gt = input[base + "Gt"];
-							any = true;
-						}
-						if (input[base + "Lt"] != null) {
-							bounds.lt = input[base + "Lt"];
-							any = true;
-						}
-						if (any) {
-							outFilters.push({ range: { [node.f]: bounds } });
+						procSlots[procTail] = {
+							spec: node.c,
+							input: value,
+							outFilters,
+							outMustNots,
+						};
+						procTail = procTail + 1;
+					}
+				} else if (node.k === "term") {
+					if (value != null) {
+						outFilters.push({ term: { [node.f]: value } });
+					}
+				} else if (node.k === "term_negate") {
+					if (value != null) {
+						outMustNots.push({ term: { [node.f]: value } });
+					}
+				} else if (node.k === "terms") {
+					if (value != null && value.length > 0) {
+						outFilters.push({ terms: { [node.f]: value } });
+					}
+				} else if (node.k === "exists") {
+					if (value != null) {
+						if (value === true) {
+							outFilters.push({ exists: { field: node.f } });
+						} else {
+							outMustNots.push({ exists: { field: node.f } });
 						}
 					}
+				} else if (node.k === "nested_exists") {
+					if (value != null) {
+						const nestedClause = {
+							nested: { path: node.p, query: { match_all: {} } },
+						};
+						if (value === true) {
+							outFilters.push(nestedClause);
+						} else {
+							outMustNots.push(nestedClause);
+						}
+					}
+				} else if (node.k === "range") {
+					const base = node.i;
+					const bounds = {};
+					let any = false;
+					if (input[base + "Gte"] != null) {
+						bounds.gte = input[base + "Gte"];
+						any = true;
+					}
+					if (input[base + "Lte"] != null) {
+						bounds.lte = input[base + "Lte"];
+						any = true;
+					}
+					if (input[base + "Gt"] != null) {
+						bounds.gt = input[base + "Gt"];
+						any = true;
+					}
+					if (input[base + "Lt"] != null) {
+						bounds.lt = input[base + "Lt"];
+						any = true;
+					}
+					if (any) {
+						outFilters.push({ range: { [node.f]: bounds } });
+					}
 				}
+			}
+		}
+	}
+
+	// Finalize phase: drain LIFO. Deepest finalize first wraps its child
+	// clauses onto its parent's childFilters/childMustNots array; that
+	// parent's finalize, popped later, then sees those wrapped clauses and
+	// wraps them in its own nested+path on the way to the grandparent.
+	for (const _slot of finSlots) {
+		if (finTail > 0) {
+			finTail = finTail - 1;
+			const item = finSlots[finTail];
+			for (const clause of item.childFilters) {
+				item.parentFilters.push({
+					nested: {
+						path: item.path,
+						query: { bool: { filter: [clause] } },
+					},
+				});
+			}
+			for (const clause of item.childMustNots) {
+				item.parentMustNots.push({
+					nested: {
+						path: item.path,
+						query: { bool: { filter: [clause] } },
+					},
+				});
 			}
 		}
 	}


### PR DESCRIPTION
Walks nested struct field references in the runtime FILTER_SPEC dispatcher so multi-level filters like locations.address.country actually reach OpenSearch (was silently dropped — GraphQL accepted the input but the prepare function emitted no clause).