### PR TITLE
feat(emitter): two-stage adaptive emit (minify + threshold-based monolithic/pipeline)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
 			"name": "@kattebak/typespec-opensearch-emitter",
 			"version": "1.1.0",
 			"dependencies": {
-				"@typespec/compiler": "^1.4.0"
+				"@typespec/compiler": "^1.4.0",
+				"terser": "^5.46.2"
 			},
 			"devDependencies": {
 				"@aws-appsync/eslint-plugin": "^2.0.2",
@@ -1433,6 +1434,51 @@
 				"node": ">=18.0.0"
 			}
 		},
+		"node_modules/@jridgewell/gen-mapping": {
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+			"integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.0",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
+		"node_modules/@jridgewell/resolve-uri": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/source-map": {
+			"version": "0.3.11",
+			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+			"integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.25"
+			}
+		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+			"license": "MIT"
+		},
+		"node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.31",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+			"integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
+		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1769,7 +1815,6 @@
 			"version": "8.16.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
 			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
@@ -1869,6 +1914,12 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/buffer-from": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+			"license": "MIT"
 		},
 		"node_modules/callsites": {
 			"version": "3.1.0",
@@ -1975,6 +2026,12 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/commander": {
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 			"license": "MIT"
 		},
 		"node_modules/concat-map": {
@@ -3371,6 +3428,25 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/source-map-support": {
+			"version": "0.5.21",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+			"license": "MIT",
+			"dependencies": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			}
+		},
 		"node_modules/string-width": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
@@ -3469,6 +3545,24 @@
 			"resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.1.tgz",
 			"integrity": "sha512-B4TUhezh9knfSIMwt7RVggApDRJZo73uZdj8AacL2mZ8RP5KtLianh2MXxL06GN9ESYiIsiuoLQhgVfwe55Yhw==",
 			"license": "ISC"
+		},
+		"node_modules/terser": {
+			"version": "5.46.2",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.46.2.tgz",
+			"integrity": "sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"@jridgewell/source-map": "^0.3.3",
+				"acorn": "^8.15.0",
+				"commander": "^2.20.0",
+				"source-map-support": "~0.5.20"
+			},
+			"bin": {
+				"terser": "bin/terser"
+			},
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/tinyglobby": {
 			"version": "0.2.16",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
 		"prepublishOnly": "tsc"
 	},
 	"dependencies": {
-		"@typespec/compiler": "^1.4.0"
+		"@typespec/compiler": "^1.4.0",
+		"terser": "^5.46.2"
 	},
 	"devDependencies": {
 		"@aws-appsync/eslint-plugin": "^2.0.2",

--- a/src/emit-graphql-resolver.test.ts
+++ b/src/emit-graphql-resolver.test.ts
@@ -87,53 +87,56 @@ function loadBuildQuery(
 	return factory();
 }
 
+type EmitResult = Awaited<ReturnType<typeof emitGraphQLResolver>>;
+
 /**
  * Returns a concatenation of every emitted file (resolver-level + each
  * pipeline function). Lets assertions that don't care WHICH file something
  * lands in just substring-check the union.
  */
-function combinedContent(
-	result: ReturnType<typeof emitGraphQLResolver>,
-): string {
+function combinedContent(result: EmitResult): string {
 	return [result.content, ...result.functions.map((fn) => fn.content)].join(
 		"\n",
 	);
 }
 
-function prepareFunctionContent(
-	result: ReturnType<typeof emitGraphQLResolver>,
-): string {
+function prepareFunctionContent(result: EmitResult): string {
 	const fn = result.functions.find((f) => f.name === "prepare");
 	if (!fn) throw new Error("missing prepare function");
 	return fn.content;
 }
 
-function searchFunctionContent(
-	result: ReturnType<typeof emitGraphQLResolver>,
-): string {
+function searchFunctionContent(result: EmitResult): string {
 	const fn = result.functions.find((f) => f.name === "search");
 	if (!fn) throw new Error("missing search function");
 	return fn.content;
 }
 
+// Pipeline-mode options for the legacy assertions in this file. Setting the
+// monolithic threshold to 0 forces the emitter into pipeline mode (issue
+// #112) so the existing pipeline-shape tests stay valid; `minify: false`
+// keeps the source readable for substring assertions. Monolithic-mode and
+// threshold-flip tests live further down.
 const defaultOptions = {
 	defaultPageSize: 20,
 	maxPageSize: 100,
 	trackTotalHitsUpTo: 10000,
+	minify: false,
+	monolithicThresholdBytes: 0,
 };
 
 describe("emitGraphQLResolver", () => {
-	it("generates resolver file with correct name", () => {
+	it("generates resolver file with correct name", async () => {
 		const projection = makeProjection({ fields: [] });
-		const result = emitGraphQLResolver(projection, defaultOptions);
+		const result = await emitGraphQLResolver(projection, defaultOptions);
 
 		assert.equal(result.fileName, "pet-search-doc-resolver.js");
 		assert.equal(result.queryFieldName, "searchPet");
 	});
 
-	it("emits a pipeline shape: resolver + prepare (NONE) + search (OPENSEARCH) functions", () => {
+	it("emits a pipeline shape: resolver + prepare (NONE) + search (OPENSEARCH) functions", async () => {
 		const projection = makeProjection({ fields: [] });
-		const result = emitGraphQLResolver(projection, defaultOptions);
+		const result = await emitGraphQLResolver(projection, defaultOptions);
 
 		assert.equal(result.functions.length, 2);
 		assert.deepEqual(
@@ -159,39 +162,39 @@ describe("emitGraphQLResolver", () => {
 		);
 	});
 
-	it("includes index name in request path", () => {
+	it("includes index name in request path", async () => {
 		const projection = makeProjection({
 			indexName: "pets_v1",
 			fields: [],
 		});
-		const result = emitGraphQLResolver(projection, defaultOptions);
+		const result = await emitGraphQLResolver(projection, defaultOptions);
 
 		// Index name lives in the search-datasource pipeline function only.
 		assert.ok(searchFunctionContent(result).includes("/pets_v1/_search"));
 	});
 
-	it("includes text fields in multi_match", () => {
+	it("includes text fields in multi_match", async () => {
 		const projection = makeProjection({
 			fields: [makeField({ name: "name" }), makeField({ name: "breed" })],
 		});
-		const result = emitGraphQLResolver(projection, defaultOptions);
+		const result = await emitGraphQLResolver(projection, defaultOptions);
 
 		assert.ok(combinedContent(result).includes('"name","breed"'));
 	});
 
-	it("includes keyword fields in filter logic", () => {
+	it("includes keyword fields in filter logic", async () => {
 		const projection = makeProjection({
 			fields: [
 				makeField({ name: "species", keyword: true }),
 				makeField({ name: "status", keyword: true }),
 			],
 		});
-		const result = emitGraphQLResolver(projection, defaultOptions);
+		const result = await emitGraphQLResolver(projection, defaultOptions);
 
 		assert.ok(combinedContent(result).includes('"species","status"'));
 	});
 
-	it("excludes nested and sub-projection fields from text fields", () => {
+	it("excludes nested and sub-projection fields from text fields", async () => {
 		const subProjection = {
 			projectionModel: { name: "TagSearchDoc" },
 		} as unknown as ResolvedProjection;
@@ -203,12 +206,12 @@ describe("emitGraphQLResolver", () => {
 				makeField({ name: "owner", subProjection }),
 			],
 		});
-		const result = emitGraphQLResolver(projection, defaultOptions);
+		const result = await emitGraphQLResolver(projection, defaultOptions);
 
 		assert.ok(combinedContent(result).includes('["name"]'));
 	});
 
-	it("excludes non-searchable filter-only fields from text_fields and keyword_fields but includes them in FILTER_SPEC", () => {
+	it("excludes non-searchable filter-only fields from text_fields and keyword_fields but includes them in FILTER_SPEC", async () => {
 		const projection = makeProjection({
 			fields: [
 				makeField({ name: "name" }),
@@ -220,7 +223,7 @@ describe("emitGraphQLResolver", () => {
 				}),
 			],
 		});
-		const result = emitGraphQLResolver(projection, defaultOptions);
+		const result = await emitGraphQLResolver(projection, defaultOptions);
 
 		assert.ok(
 			combinedContent(result).includes('fields: ["name"]'),
@@ -234,7 +237,7 @@ describe("emitGraphQLResolver", () => {
 		);
 	});
 
-	it("excludes non-searchable agg-only fields from text/keyword sets but includes them in aggs", () => {
+	it("excludes non-searchable agg-only fields from text/keyword sets but includes them in aggs", async () => {
 		const projection = makeProjection({
 			fields: [
 				makeField({ name: "name" }),
@@ -246,7 +249,7 @@ describe("emitGraphQLResolver", () => {
 				}),
 			],
 		});
-		const result = emitGraphQLResolver(projection, defaultOptions);
+		const result = await emitGraphQLResolver(projection, defaultOptions);
 
 		assert.ok(combinedContent(result).includes('fields: ["name"]'));
 		assert.ok(
@@ -255,9 +258,10 @@ describe("emitGraphQLResolver", () => {
 		);
 	});
 
-	it("respects custom page size and track_total_hits options", () => {
+	it("respects custom page size and track_total_hits options", async () => {
 		const projection = makeProjection({ fields: [] });
-		const result = emitGraphQLResolver(projection, {
+		const result = await emitGraphQLResolver(projection, {
+			...defaultOptions,
 			defaultPageSize: 10,
 			maxPageSize: 50,
 			trackTotalHitsUpTo: 5000,
@@ -268,21 +272,21 @@ describe("emitGraphQLResolver", () => {
 		assert.ok(combinedContent(result).includes("track_total_hits: 5000"));
 	});
 
-	it("uses projectedName for field references", () => {
+	it("uses projectedName for field references", async () => {
 		const projection = makeProjection({
 			fields: [makeField({ name: "name", projectedName: "displayName" })],
 		});
-		const result = emitGraphQLResolver(projection, defaultOptions);
+		const result = await emitGraphQLResolver(projection, defaultOptions);
 
 		assert.ok(combinedContent(result).includes('"displayName"'));
 		assert.ok(!combinedContent(result).includes('"name"'));
 	});
 
-	it("has no import statements except aws-appsync/utils", () => {
+	it("has no import statements except aws-appsync/utils", async () => {
 		const projection = makeProjection({
 			fields: [makeField({ name: "name" })],
 		});
-		const result = emitGraphQLResolver(projection, defaultOptions);
+		const result = await emitGraphQLResolver(projection, defaultOptions);
 
 		// Each emitted file (resolver + each pipeline function) has at most
 		// one import — and only `@aws-appsync/utils`.
@@ -299,9 +303,9 @@ describe("emitGraphQLResolver", () => {
 		}
 	});
 
-	it("falls back to _score desc then _id asc when sortBy arg is omitted", () => {
+	it("falls back to _score desc then _id asc when sortBy arg is omitted", async () => {
 		const projection = makeProjection({ fields: [] });
-		const result = emitGraphQLResolver(projection, defaultOptions);
+		const result = await emitGraphQLResolver(projection, defaultOptions);
 
 		assert.ok(combinedContent(result).includes('{ _score: "desc" }'));
 		assert.ok(combinedContent(result).includes('{ _id: "asc" }'));
@@ -311,10 +315,10 @@ describe("emitGraphQLResolver", () => {
 		assert.ok(combinedContent(result).includes("function buildSort(sortBy)"));
 	});
 
-	it("buildSort honors sortBy arg with multiple fields, appending _id tie-break", () => {
+	it("buildSort honors sortBy arg with multiple fields, appending _id tie-break", async () => {
 		const projection = makeProjection({ fields: [] });
 		const source = prepareFunctionContent(
-			emitGraphQLResolver(projection, defaultOptions),
+			await emitGraphQLResolver(projection, defaultOptions),
 		);
 		const stripped = source
 			.replace(/^import \{ util \} from "@aws-appsync\/utils";?\n?/m, "")
@@ -343,26 +347,26 @@ describe("emitGraphQLResolver", () => {
 		]);
 	});
 
-	it("uses search_after for cursor pagination", () => {
+	it("uses search_after for cursor pagination", async () => {
 		const projection = makeProjection({ fields: [] });
-		const result = emitGraphQLResolver(projection, defaultOptions);
+		const result = await emitGraphQLResolver(projection, defaultOptions);
 
 		assert.ok(combinedContent(result).includes("search_after"));
 		assert.ok(combinedContent(result).includes("base64Decode"));
 		assert.ok(combinedContent(result).includes("base64Encode"));
 	});
 
-	it("omits aggs block when no aggregations", () => {
+	it("omits aggs block when no aggregations", async () => {
 		const projection = makeProjection({
 			fields: [makeField({ name: "name" })],
 		});
-		const result = emitGraphQLResolver(projection, defaultOptions);
+		const result = await emitGraphQLResolver(projection, defaultOptions);
 
 		assert.ok(!combinedContent(result).includes("aggs:"));
 		assert.ok(!combinedContent(result).includes("aggregations:"));
 	});
 
-	it("emits aggs block in request when fields have aggregations", () => {
+	it("emits aggs block in request when fields have aggregations", async () => {
 		const projection = makeProjection({
 			fields: [
 				makeField({
@@ -381,7 +385,7 @@ describe("emitGraphQLResolver", () => {
 				}),
 			],
 		});
-		const result = emitGraphQLResolver(projection, defaultOptions);
+		const result = await emitGraphQLResolver(projection, defaultOptions);
 
 		assert.ok(combinedContent(result).includes("aggs:"));
 		assert.ok(
@@ -396,7 +400,7 @@ describe("emitGraphQLResolver", () => {
 		);
 	});
 
-	it("emits cardinality and missing aggs in request", () => {
+	it("emits cardinality and missing aggs in request", async () => {
 		const projection = makeProjection({
 			fields: [
 				makeField({
@@ -411,7 +415,7 @@ describe("emitGraphQLResolver", () => {
 				}),
 			],
 		});
-		const result = emitGraphQLResolver(projection, defaultOptions);
+		const result = await emitGraphQLResolver(projection, defaultOptions);
 
 		assert.ok(
 			combinedContent(result).includes(
@@ -425,7 +429,7 @@ describe("emitGraphQLResolver", () => {
 		);
 	});
 
-	it("emits date_histogram with calendar_interval option", () => {
+	it("emits date_histogram with calendar_interval option", async () => {
 		const projection = makeProjection({
 			fields: [
 				makeField({
@@ -437,7 +441,7 @@ describe("emitGraphQLResolver", () => {
 				}),
 			],
 		});
-		const result = emitGraphQLResolver(projection, defaultOptions);
+		const result = await emitGraphQLResolver(projection, defaultOptions);
 		assert.ok(
 			combinedContent(result).includes(
 				'byValidFromOverTime: { date_histogram: { field: "validFrom", calendar_interval: "month" } }',
@@ -451,7 +455,7 @@ describe("emitGraphQLResolver", () => {
 		);
 	});
 
-	it("emits range buckets with the configured ranges", () => {
+	it("emits range buckets with the configured ranges", async () => {
 		const projection = makeProjection({
 			fields: [
 				makeField({
@@ -472,7 +476,7 @@ describe("emitGraphQLResolver", () => {
 				}),
 			],
 		});
-		const result = emitGraphQLResolver(projection, defaultOptions);
+		const result = await emitGraphQLResolver(projection, defaultOptions);
 		assert.ok(
 			combinedContent(result).includes(
 				'byNotionalRange: { range: { field: "notional", ranges: [{"to":1000},{"from":1000,"to":10000},{"from":10000}] } }',
@@ -485,7 +489,7 @@ describe("emitGraphQLResolver", () => {
 		);
 	});
 
-	it("emits terms with sub-aggregations", () => {
+	it("emits terms with sub-aggregations", async () => {
 		const projection = makeProjection({
 			fields: [
 				makeField({
@@ -502,7 +506,7 @@ describe("emitGraphQLResolver", () => {
 				}),
 			],
 		});
-		const result = emitGraphQLResolver(projection, defaultOptions);
+		const result = await emitGraphQLResolver(projection, defaultOptions);
 		assert.ok(
 			combinedContent(result).includes(
 				'byCounterpartyId: { terms: { field: "counterpartyId" }, aggs: { "latestValidTo": { max: { field: "validTo" } } } }',
@@ -515,7 +519,7 @@ describe("emitGraphQLResolver", () => {
 		);
 	});
 
-	it("emits top_hits sub-agg under terms when topHits option is set", () => {
+	it("emits top_hits sub-agg under terms when topHits option is set", async () => {
 		const projection = makeProjection({
 			fields: [
 				makeField({
@@ -525,7 +529,7 @@ describe("emitGraphQLResolver", () => {
 				}),
 			],
 		});
-		const result = emitGraphQLResolver(projection, defaultOptions);
+		const result = await emitGraphQLResolver(projection, defaultOptions);
 
 		assert.ok(
 			combinedContent(result).includes(
@@ -541,7 +545,7 @@ describe("emitGraphQLResolver", () => {
 		);
 	});
 
-	it("emits combined sub-aggs and top_hits when both options are set", () => {
+	it("emits combined sub-aggs and top_hits when both options are set", async () => {
 		const projection = makeProjection({
 			fields: [
 				makeField({
@@ -559,7 +563,7 @@ describe("emitGraphQLResolver", () => {
 				}),
 			],
 		});
-		const result = emitGraphQLResolver(projection, defaultOptions);
+		const result = await emitGraphQLResolver(projection, defaultOptions);
 		assert.ok(
 			combinedContent(result).includes(
 				'aggs: { "latestValidTo": { max: { field: "validTo" } }, "hits": { top_hits: { size: 3 } } }',
@@ -572,7 +576,7 @@ describe("emitGraphQLResolver", () => {
 		);
 	});
 
-	it("emits sum/avg/min/max numeric metric aggs", () => {
+	it("emits sum/avg/min/max numeric metric aggs", async () => {
 		const projection = makeProjection({
 			fields: [
 				makeField({
@@ -587,7 +591,7 @@ describe("emitGraphQLResolver", () => {
 				}),
 			],
 		});
-		const result = emitGraphQLResolver(projection, defaultOptions);
+		const result = await emitGraphQLResolver(projection, defaultOptions);
 
 		assert.ok(
 			combinedContent(result).includes(
@@ -616,7 +620,7 @@ describe("emitGraphQLResolver", () => {
 		);
 	});
 
-	it("wraps aggs inside @nested sub-projection in nested+inner block", () => {
+	it("wraps aggs inside @nested sub-projection in nested+inner block", async () => {
 		const subProjection = {
 			projectionModel: { name: "TagSearchDoc" },
 			sourceModel: { name: "Tag" },
@@ -650,7 +654,7 @@ describe("emitGraphQLResolver", () => {
 			],
 		});
 
-		const result = emitGraphQLResolver(projection, defaultOptions);
+		const result = await emitGraphQLResolver(projection, defaultOptions);
 
 		// All nested aggs sharing a path are grouped under one wrapper
 		// (`__n_<path>` key) — saves the per-agg `{ nested: ..., aggs: { inner: ... } }`
@@ -678,7 +682,7 @@ describe("emitGraphQLResolver", () => {
 		);
 	});
 
-	it("does not wrap top-level aggregations in nested block", () => {
+	it("does not wrap top-level aggregations in nested block", async () => {
 		const projection = makeProjection({
 			fields: [
 				makeField({
@@ -693,7 +697,7 @@ describe("emitGraphQLResolver", () => {
 			],
 		});
 
-		const result = emitGraphQLResolver(projection, defaultOptions);
+		const result = await emitGraphQLResolver(projection, defaultOptions);
 		assert.ok(
 			combinedContent(result).includes(
 				'byTag: { terms: { field: "tags.keyword" } }',
@@ -703,7 +707,7 @@ describe("emitGraphQLResolver", () => {
 		assert.ok(!combinedContent(result).includes("byTag: { nested:"));
 	});
 
-	it("emits aggregations mapping in response", () => {
+	it("emits aggregations mapping in response", async () => {
 		const projection = makeProjection({
 			fields: [
 				makeField({
@@ -723,7 +727,7 @@ describe("emitGraphQLResolver", () => {
 				}),
 			],
 		});
-		const result = emitGraphQLResolver(projection, defaultOptions);
+		const result = await emitGraphQLResolver(projection, defaultOptions);
 
 		assert.ok(combinedContent(result).includes("aggregations: {"));
 		assert.ok(
@@ -763,7 +767,7 @@ describe("emitGraphQLResolver search filter DSL", () => {
 		} as unknown as ResolvedProjection;
 	}
 
-	it("emits a static FILTER_SPEC literal for filterable fields", () => {
+	it("emits a static FILTER_SPEC literal for filterable fields", async () => {
 		const projection = makeProjection({
 			fields: [
 				makeField({
@@ -778,7 +782,7 @@ describe("emitGraphQLResolver search filter DSL", () => {
 				}),
 			],
 		});
-		const result = emitGraphQLResolver(projection, defaultOptions);
+		const result = await emitGraphQLResolver(projection, defaultOptions);
 		assert.ok(combinedContent(result).includes("const FILTER_SPEC = ["));
 		assert.ok(combinedContent(result).includes('"species"'));
 		assert.ok(combinedContent(result).includes('"speciesNot"'));
@@ -790,27 +794,29 @@ describe("emitGraphQLResolver search filter DSL", () => {
 		assert.ok(!combinedContent(result).includes('"rankGte"'));
 	});
 
-	it("emits an empty FILTER_SPEC when no @filterable fields", () => {
+	it("emits an empty FILTER_SPEC when no @filterable fields", async () => {
 		const projection = makeProjection({
 			fields: [makeField({ name: "name" })],
 		});
-		const result = emitGraphQLResolver(projection, defaultOptions);
+		const result = await emitGraphQLResolver(projection, defaultOptions);
 		assert.ok(combinedContent(result).includes("const FILTER_SPEC = []"));
 	});
 
-	it("buildQuery returns match_all when no inputs", () => {
+	it("buildQuery returns match_all when no inputs", async () => {
 		const projection = makeProjection({
 			fields: [makeField({ name: "name" })],
 		});
 		const buildQuery = loadBuildQuery(
-			prepareFunctionContent(emitGraphQLResolver(projection, defaultOptions)),
+			prepareFunctionContent(
+				await emitGraphQLResolver(projection, defaultOptions),
+			),
 		);
 		assert.deepEqual(buildQuery(undefined, undefined, undefined), {
 			match_all: {},
 		});
 	});
 
-	it("buildQuery emits flat term filter into bool.filter", () => {
+	it("buildQuery emits flat term filter into bool.filter", async () => {
 		const projection = makeProjection({
 			fields: [
 				makeField({
@@ -821,7 +827,9 @@ describe("emitGraphQLResolver search filter DSL", () => {
 			],
 		});
 		const buildQuery = loadBuildQuery(
-			prepareFunctionContent(emitGraphQLResolver(projection, defaultOptions)),
+			prepareFunctionContent(
+				await emitGraphQLResolver(projection, defaultOptions),
+			),
 		);
 		const result = buildQuery(undefined, undefined, { species: "cat" });
 		assert.deepEqual(result, {
@@ -831,7 +839,7 @@ describe("emitGraphQLResolver search filter DSL", () => {
 		});
 	});
 
-	it("buildQuery emits terms (multi-value) filter as bool.filter[terms]", () => {
+	it("buildQuery emits terms (multi-value) filter as bool.filter[terms]", async () => {
 		const projection = makeProjection({
 			fields: [
 				makeField({
@@ -842,7 +850,9 @@ describe("emitGraphQLResolver search filter DSL", () => {
 			],
 		});
 		const buildQuery = loadBuildQuery(
-			prepareFunctionContent(emitGraphQLResolver(projection, defaultOptions)),
+			prepareFunctionContent(
+				await emitGraphQLResolver(projection, defaultOptions),
+			),
 		);
 		const result = buildQuery(undefined, undefined, {
 			speciesIn: ["cat", "dog"],
@@ -854,7 +864,7 @@ describe("emitGraphQLResolver search filter DSL", () => {
 		});
 	});
 
-	it("buildQuery skips terms filter when array is empty", () => {
+	it("buildQuery skips terms filter when array is empty", async () => {
 		const projection = makeProjection({
 			fields: [
 				makeField({
@@ -865,13 +875,15 @@ describe("emitGraphQLResolver search filter DSL", () => {
 			],
 		});
 		const buildQuery = loadBuildQuery(
-			prepareFunctionContent(emitGraphQLResolver(projection, defaultOptions)),
+			prepareFunctionContent(
+				await emitGraphQLResolver(projection, defaultOptions),
+			),
 		);
 		const result = buildQuery(undefined, undefined, { speciesIn: [] });
 		assert.deepEqual(result, { match_all: {} });
 	});
 
-	it("buildQuery emits flat term_negate into bool.must_not", () => {
+	it("buildQuery emits flat term_negate into bool.must_not", async () => {
 		const projection = makeProjection({
 			fields: [
 				makeField({
@@ -882,7 +894,9 @@ describe("emitGraphQLResolver search filter DSL", () => {
 			],
 		});
 		const buildQuery = loadBuildQuery(
-			prepareFunctionContent(emitGraphQLResolver(projection, defaultOptions)),
+			prepareFunctionContent(
+				await emitGraphQLResolver(projection, defaultOptions),
+			),
 		);
 		const result = buildQuery(undefined, undefined, { speciesNot: "cat" });
 		assert.deepEqual(result, {
@@ -892,7 +906,7 @@ describe("emitGraphQLResolver search filter DSL", () => {
 		});
 	});
 
-	it("buildQuery wraps nested term in nested+bool.filter under outer filter", () => {
+	it("buildQuery wraps nested term in nested+bool.filter under outer filter", async () => {
 		const projection = makeProjection({
 			fields: [
 				makeField({
@@ -908,7 +922,9 @@ describe("emitGraphQLResolver search filter DSL", () => {
 			],
 		});
 		const buildQuery = loadBuildQuery(
-			prepareFunctionContent(emitGraphQLResolver(projection, defaultOptions)),
+			prepareFunctionContent(
+				await emitGraphQLResolver(projection, defaultOptions),
+			),
 		);
 		const result = buildQuery(undefined, undefined, {
 			tags: { name: "vip" },
@@ -929,7 +945,7 @@ describe("emitGraphQLResolver search filter DSL", () => {
 		});
 	});
 
-	it("buildQuery wraps nested term_negate inside nested under outer must_not", () => {
+	it("buildQuery wraps nested term_negate inside nested under outer must_not", async () => {
 		const projection = makeProjection({
 			fields: [
 				makeField({
@@ -945,7 +961,9 @@ describe("emitGraphQLResolver search filter DSL", () => {
 			],
 		});
 		const buildQuery = loadBuildQuery(
-			prepareFunctionContent(emitGraphQLResolver(projection, defaultOptions)),
+			prepareFunctionContent(
+				await emitGraphQLResolver(projection, defaultOptions),
+			),
 		);
 		const result = buildQuery(undefined, undefined, {
 			tags: { nameNot: "blocked" },
@@ -966,7 +984,7 @@ describe("emitGraphQLResolver search filter DSL", () => {
 		});
 	});
 
-	it("buildQuery groups range bounds into one range clause", () => {
+	it("buildQuery groups range bounds into one range clause", async () => {
 		const projection = makeProjection({
 			fields: [
 				makeField({
@@ -977,7 +995,9 @@ describe("emitGraphQLResolver search filter DSL", () => {
 			],
 		});
 		const buildQuery = loadBuildQuery(
-			prepareFunctionContent(emitGraphQLResolver(projection, defaultOptions)),
+			prepareFunctionContent(
+				await emitGraphQLResolver(projection, defaultOptions),
+			),
 		);
 		const result = buildQuery(undefined, undefined, {
 			createdAtGte: "2026-01-01",
@@ -996,7 +1016,7 @@ describe("emitGraphQLResolver search filter DSL", () => {
 		});
 	});
 
-	it("buildQuery emits exists in filter for true and must_not for false", () => {
+	it("buildQuery emits exists in filter for true and must_not for false", async () => {
 		const projection = makeProjection({
 			fields: [
 				makeField({
@@ -1007,7 +1027,9 @@ describe("emitGraphQLResolver search filter DSL", () => {
 			],
 		});
 		const buildQuery = loadBuildQuery(
-			prepareFunctionContent(emitGraphQLResolver(projection, defaultOptions)),
+			prepareFunctionContent(
+				await emitGraphQLResolver(projection, defaultOptions),
+			),
 		);
 
 		assert.deepEqual(
@@ -1028,7 +1050,7 @@ describe("emitGraphQLResolver search filter DSL", () => {
 		);
 	});
 
-	it("buildQuery combines multi_match text search with searchFilter", () => {
+	it("buildQuery combines multi_match text search with searchFilter", async () => {
 		const projection = makeProjection({
 			fields: [
 				makeField({ name: "name" }),
@@ -1040,7 +1062,9 @@ describe("emitGraphQLResolver search filter DSL", () => {
 			],
 		});
 		const buildQuery = loadBuildQuery(
-			prepareFunctionContent(emitGraphQLResolver(projection, defaultOptions)),
+			prepareFunctionContent(
+				await emitGraphQLResolver(projection, defaultOptions),
+			),
 		);
 		const result = buildQuery("fluffy", undefined, { species: "cat" }) as {
 			bool: { must: unknown[]; filter: unknown[] };
@@ -1052,7 +1076,7 @@ describe("emitGraphQLResolver search filter DSL", () => {
 		});
 	});
 
-	it("buildQuery still honors legacy keyword `filter` argument", () => {
+	it("buildQuery still honors legacy keyword `filter` argument", async () => {
 		const projection = makeProjection({
 			fields: [
 				makeField({
@@ -1062,7 +1086,9 @@ describe("emitGraphQLResolver search filter DSL", () => {
 			],
 		});
 		const buildQuery = loadBuildQuery(
-			prepareFunctionContent(emitGraphQLResolver(projection, defaultOptions)),
+			prepareFunctionContent(
+				await emitGraphQLResolver(projection, defaultOptions),
+			),
 		);
 		const result = buildQuery(undefined, { species: "cat" }, undefined);
 		assert.deepEqual(result, {
@@ -1072,7 +1098,7 @@ describe("emitGraphQLResolver search filter DSL", () => {
 		});
 	});
 
-	it("emitted resolver contains no forbidden global coercion calls (String, Number, Boolean, Array, Object)", () => {
+	it("emitted resolver contains no forbidden global coercion calls (String, Number, Boolean, Array, Object)", async () => {
 		// APPSYNC_JS rejects these globals at deploy time even though
 		// @aws-appsync/eslint-plugin doesn't flag them (no rule covers
 		// global function calls). Use template literals (\`${x}\`) for
@@ -1115,7 +1141,7 @@ describe("emitGraphQLResolver search filter DSL", () => {
 				}),
 			],
 		});
-		const result = emitGraphQLResolver(projection, defaultOptions);
+		const result = await emitGraphQLResolver(projection, defaultOptions);
 
 		const forbidden = ["String", "Number", "Boolean", "Array", "Object"];
 		const allFiles = [
@@ -1204,7 +1230,7 @@ describe("emitGraphQLResolver search filter DSL", () => {
 				}),
 			],
 		});
-		const result = emitGraphQLResolver(projection, defaultOptions);
+		const result = await emitGraphQLResolver(projection, defaultOptions);
 
 		const { ESLint } = await import("eslint");
 		// @ts-expect-error — plugin ships no type declarations.
@@ -1275,7 +1301,7 @@ describe("emitGraphQLResolver search filter DSL", () => {
 		}
 	});
 
-	it('emits nested_exists FILTER_SPEC entry for @filterable("exists") on a @nested array field', () => {
+	it('emits nested_exists FILTER_SPEC entry for @filterable("exists") on a @nested array field', async () => {
 		const projection = makeProjection({
 			fields: [
 				makeField({
@@ -1291,7 +1317,7 @@ describe("emitGraphQLResolver search filter DSL", () => {
 				}),
 			],
 		});
-		const result = emitGraphQLResolver(projection, defaultOptions);
+		const result = await emitGraphQLResolver(projection, defaultOptions);
 		assert.ok(
 			combinedContent(result).includes(
 				'{i:"tagsExists",k:"nested_exists",p:"tags"}',
@@ -1300,7 +1326,7 @@ describe("emitGraphQLResolver search filter DSL", () => {
 		);
 	});
 
-	it("buildQuery translates tagsExists: true into nested+match_all in bool.filter", () => {
+	it("buildQuery translates tagsExists: true into nested+match_all in bool.filter", async () => {
 		const projection = makeProjection({
 			fields: [
 				makeField({
@@ -1317,7 +1343,9 @@ describe("emitGraphQLResolver search filter DSL", () => {
 			],
 		});
 		const buildQuery = loadBuildQuery(
-			prepareFunctionContent(emitGraphQLResolver(projection, defaultOptions)),
+			prepareFunctionContent(
+				await emitGraphQLResolver(projection, defaultOptions),
+			),
 		);
 
 		const truthy = buildQuery(undefined, undefined, { tagsExists: true });
@@ -1335,7 +1363,7 @@ describe("emitGraphQLResolver search filter DSL", () => {
 		});
 	});
 
-	it("buildQuery preserves nested-filter semantics for deeply structured input", () => {
+	it("buildQuery preserves nested-filter semantics for deeply structured input", async () => {
 		const projection = makeProjection({
 			fields: [
 				makeField({
@@ -1356,7 +1384,9 @@ describe("emitGraphQLResolver search filter DSL", () => {
 			],
 		});
 		const buildQuery = loadBuildQuery(
-			prepareFunctionContent(emitGraphQLResolver(projection, defaultOptions)),
+			prepareFunctionContent(
+				await emitGraphQLResolver(projection, defaultOptions),
+			),
 		);
 		const result = buildQuery(undefined, undefined, {
 			species: "cat",
@@ -1410,7 +1440,7 @@ describe("emitGraphQLResolver search filter DSL", () => {
 	// sub-projection) was silently dropped. The SDL accepted the input but
 	// the prepare function emitted no clause, so OS returned the unfiltered
 	// total instead of the filtered subset.
-	it("buildQuery walks non-@nested struct (object kind) inside a @nested array — locations.address.country (issue #110)", () => {
+	it("buildQuery walks non-@nested struct (object kind) inside a @nested array — locations.address.country (issue #110)", async () => {
 		const addressSubProjection = {
 			projectionModel: { name: "AddressSearchDoc" },
 			sourceModel: { name: "Address" },
@@ -1463,7 +1493,9 @@ describe("emitGraphQLResolver search filter DSL", () => {
 		});
 
 		const buildQuery = loadBuildQuery(
-			prepareFunctionContent(emitGraphQLResolver(projection, defaultOptions)),
+			prepareFunctionContent(
+				await emitGraphQLResolver(projection, defaultOptions),
+			),
 		);
 
 		const result = buildQuery(undefined, undefined, {
@@ -1495,7 +1527,7 @@ describe("emitGraphQLResolver search filter DSL", () => {
 	// Issue #110: same hazard, two-level @nested. Outer finalize used to run
 	// before inner finalize had populated its parent's child-clause array,
 	// silently dropping the inner term.
-	it("buildQuery walks @nested inside @nested — addresses.country wrapped in two nested clauses", () => {
+	it("buildQuery walks @nested inside @nested — addresses.country wrapped in two nested clauses", async () => {
 		const addressSubProjection = {
 			projectionModel: { name: "AddressSearchDoc" },
 			sourceModel: { name: "Address" },
@@ -1543,7 +1575,9 @@ describe("emitGraphQLResolver search filter DSL", () => {
 		});
 
 		const buildQuery = loadBuildQuery(
-			prepareFunctionContent(emitGraphQLResolver(projection, defaultOptions)),
+			prepareFunctionContent(
+				await emitGraphQLResolver(projection, defaultOptions),
+			),
 		);
 
 		const result = buildQuery(undefined, undefined, {
@@ -1587,7 +1621,7 @@ describe("emitGraphQLResolver search filter DSL", () => {
 
 	// Issue #110: term_negate inside an object-in-nested descent must end up
 	// on bool.must_not at the outer query level (mirrors the term path).
-	it("buildQuery routes term_negate from inside object-in-nested to outer bool.must_not", () => {
+	it("buildQuery routes term_negate from inside object-in-nested to outer bool.must_not", async () => {
 		const addressSubProjection = {
 			projectionModel: { name: "AddressSearchDoc" },
 			sourceModel: { name: "Address" },
@@ -1629,7 +1663,9 @@ describe("emitGraphQLResolver search filter DSL", () => {
 		});
 
 		const buildQuery = loadBuildQuery(
-			prepareFunctionContent(emitGraphQLResolver(projection, defaultOptions)),
+			prepareFunctionContent(
+				await emitGraphQLResolver(projection, defaultOptions),
+			),
 		);
 
 		const result = buildQuery(undefined, undefined, {
@@ -1708,7 +1744,7 @@ describe("emitGraphQLResolver wide-projection budget (issue #105)", () => {
 		return s[0].toLowerCase() + s.slice(1);
 	}
 
-	it("counterparty-shape projection (7 nested sub-models) emits resolver under 32 KB AppSync cap", () => {
+	it("counterparty-shape projection (7 nested sub-models) emits resolver under 32 KB AppSync cap", async () => {
 		// Synthetic mirror of the consumer counterparty projection: 7 @nested
 		// sub-models (approvals/relations/locations/contacts/tags/groups/references),
 		// each with id+type+createdAt+updatedAt aggs/filters. Acceptance criterion
@@ -1761,7 +1797,7 @@ describe("emitGraphQLResolver wide-projection budget (issue #105)", () => {
 			],
 		});
 
-		const result = emitGraphQLResolver(projection, defaultOptions);
+		const result = await emitGraphQLResolver(projection, defaultOptions);
 
 		// Pipeline resolver: cap is per-file (resolver after-mapping + each
 		// pipeline function), not the sum. Issue #105 acceptance: each emitted
@@ -1776,6 +1812,356 @@ describe("emitGraphQLResolver wide-projection budget (issue #105)", () => {
 				bytes < 32_768,
 				`wide projection ${file.name} file is ${bytes} bytes; must stay under AppSync's 32,768-byte per-file cap (issue #105). Headroom: ${32_768 - bytes} bytes.`,
 			);
+		}
+	});
+});
+
+// Issue #112 — two-stage adaptive emit: minify + threshold-based mode.
+describe("emitGraphQLResolver two-stage emit (issue #112)", () => {
+	const monolithicOptions = {
+		defaultPageSize: 20,
+		maxPageSize: 100,
+		trackTotalHitsUpTo: 10000,
+		minify: true,
+		monolithicThresholdBytes: 28000,
+	};
+
+	it("emits monolithic UNIT shape for a typical projection (mode 'monolithic', no functions)", async () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({ name: "name" }),
+				makeField({
+					name: "species",
+					keyword: true,
+					filterables: ["term", "term_negate"],
+					aggregations: ["terms"],
+				}),
+				makeField({
+					name: "createdAt",
+					filterables: ["range"],
+					type: { kind: "Scalar", name: "utcDateTime" } as unknown as Type,
+					aggregations: [
+						{ kind: "date_histogram", options: { interval: "month" } },
+					],
+				}),
+			],
+		});
+		const result = await emitGraphQLResolver(projection, monolithicOptions);
+
+		assert.equal(result.mode, "monolithic");
+		assert.equal(result.functions.length, 0);
+		// Monolithic resolver carries the OS HTTP request shape directly —
+		// no pipeline before/after, no `ctx.prev.result`, no `ctx.stash`.
+		assert.ok(
+			result.content.includes('operation:"GET"') ||
+				result.content.includes('operation: "GET"'),
+		);
+		assert.ok(!result.content.includes("ctx.prev.result"));
+		assert.ok(!result.content.includes("ctx.stash"));
+	});
+
+	it("falls back to pipeline when monolithic exceeds threshold", async () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({ name: "name" }),
+				makeField({
+					name: "species",
+					keyword: true,
+					filterables: ["term"],
+				}),
+			],
+		});
+		const result = await emitGraphQLResolver(projection, {
+			...monolithicOptions,
+			monolithicThresholdBytes: 0,
+		});
+
+		assert.equal(result.mode, "pipeline");
+		assert.equal(result.functions.length, 2);
+		assert.deepEqual(
+			result.functions.map((f) => f.name),
+			["prepare", "search"],
+		);
+	});
+
+	it("respects minify: false (verbose source emission)", async () => {
+		const projection = makeProjection({
+			fields: [makeField({ name: "name" })],
+		});
+		const result = await emitGraphQLResolver(projection, {
+			...monolithicOptions,
+			minify: false,
+		});
+
+		assert.ok(result.content.includes("buildQuery"));
+		assert.ok(result.content.includes("function buildSort"));
+		assert.ok(result.content.includes("\t"));
+	});
+
+	it("counterparty-shape projection fits under threshold in monolithic mode (perf-critical case)", async () => {
+		// Mirrors the wide-projection acceptance test — 7 nested sub-models
+		// with id+type+createdAt+updatedAt aggs/filters. Issue #112 expects
+		// this shape to fit monolithic post-minify (under 28K), unlocking the
+		// ~50ms median latency saving.
+		const subShapes = [
+			"Approval",
+			"Relation",
+			"Location",
+			"Contact",
+			"Tag",
+			"Group",
+			"Reference",
+		];
+		function lowerFirst(s: string): string {
+			return s[0].toLowerCase() + s.slice(1);
+		}
+		const projection = makeProjection({
+			name: "CounterpartySearchDoc",
+			indexName: "counterparties_v1",
+			fields: [
+				makeField({
+					name: "counterpartyId",
+					keyword: true,
+					filterables: ["term", "terms", "exists"],
+					aggregations: ["terms"],
+				}),
+				makeField({
+					name: "createdAt",
+					filterables: ["range"],
+					type: { kind: "Scalar", name: "utcDateTime" } as unknown as Type,
+					aggregations: ["sum", "avg", "min", "max"],
+				}),
+				...subShapes.map((shape) =>
+					makeField({
+						name: `${shape.toLowerCase()}s`,
+						nested: true,
+						subProjection: {
+							projectionModel: { name: `${shape}SearchDoc` },
+							sourceModel: { name: shape },
+							indexName: shape.toLowerCase(),
+							fields: [
+								makeField({
+									name: `${lowerFirst(shape)}Id`,
+									keyword: true,
+									filterables: ["term", "terms", "exists"],
+									aggregations: ["terms"],
+								}),
+								makeField({
+									name: "type",
+									keyword: true,
+									filterables: ["term", "terms", "exists"],
+									aggregations: ["terms"],
+								}),
+								makeField({
+									name: "createdAt",
+									filterables: ["range"],
+									type: {
+										kind: "Scalar",
+										name: "utcDateTime",
+									} as unknown as Type,
+								}),
+							],
+						} as unknown as ResolvedProjection,
+						filterables: ["exists"],
+						type: {
+							kind: "Model",
+							name: "Array",
+							indexer: { value: { kind: "Model" } },
+						} as unknown as Type,
+					}),
+				),
+			],
+		});
+
+		const result = await emitGraphQLResolver(projection, monolithicOptions);
+		const bytes = Buffer.byteLength(result.content, "utf-8");
+
+		assert.equal(
+			result.mode,
+			"monolithic",
+			`Counterparty projection should fit monolithic; got ${bytes} bytes`,
+		);
+		assert.ok(bytes < 28_000, "monolithic must fit under threshold");
+	});
+
+	it("pipelines a synthetic wide projection (14 sub-models) even with minify on", async () => {
+		function lowerFirst(s: string): string {
+			return s[0].toLowerCase() + s.slice(1);
+		}
+		const subShapes = Array.from({ length: 14 }, (_, i) => `Sub${i}`);
+		const projection = makeProjection({
+			name: "WideSearchDoc",
+			indexName: "wide_v1",
+			fields: subShapes.map((shape) =>
+				makeField({
+					name: `${shape.toLowerCase()}s`,
+					nested: true,
+					subProjection: {
+						projectionModel: { name: `${shape}SearchDoc` },
+						sourceModel: { name: shape },
+						indexName: shape.toLowerCase(),
+						fields: [
+							makeField({
+								name: `${lowerFirst(shape)}Id`,
+								keyword: true,
+								filterables: ["term", "terms", "exists"],
+								aggregations: ["terms"],
+							}),
+							makeField({
+								name: "type",
+								keyword: true,
+								filterables: ["term", "terms", "exists"],
+								aggregations: ["terms"],
+							}),
+							makeField({
+								name: "createdAt",
+								filterables: ["range"],
+								type: {
+									kind: "Scalar",
+									name: "utcDateTime",
+								} as unknown as Type,
+								aggregations: [
+									"sum",
+									"avg",
+									"min",
+									"max",
+									{ kind: "date_histogram", options: { interval: "month" } },
+								],
+							}),
+							makeField({
+								name: "updatedAt",
+								filterables: ["range"],
+								type: {
+									kind: "Scalar",
+									name: "utcDateTime",
+								} as unknown as Type,
+								aggregations: ["sum", "avg", "min", "max"],
+							}),
+						],
+					} as unknown as ResolvedProjection,
+					filterables: ["exists"],
+					type: {
+						kind: "Model",
+						name: "Array",
+						indexer: { value: { kind: "Model" } },
+					} as unknown as Type,
+				}),
+			),
+		});
+
+		const result = await emitGraphQLResolver(projection, monolithicOptions);
+
+		assert.equal(result.mode, "pipeline");
+		const files = [
+			{ name: "resolver", content: result.content },
+			...result.functions.map((fn) => ({
+				name: fn.name,
+				content: fn.content,
+			})),
+		];
+		for (const file of files) {
+			const bytes = Buffer.byteLength(file.content, "utf-8");
+			assert.ok(
+				bytes < 32_768,
+				`wide projection pipeline file ${file.name} is ${bytes} bytes; must stay under 32 KB cap`,
+			);
+		}
+	});
+
+	it("minified monolithic output passes @aws-appsync/eslint-plugin recommended config", async () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "species",
+					keyword: true,
+					filterables: ["term", "term_negate"],
+					aggregations: ["terms", "cardinality", "missing"],
+				}),
+				makeField({
+					name: "rank",
+					filterables: ["range"],
+					type: { kind: "Scalar", name: "int32" } as unknown as Type,
+				}),
+				makeField({
+					name: "validFrom",
+					type: { kind: "Scalar", name: "utcDateTime" } as unknown as Type,
+					aggregations: [
+						{ kind: "date_histogram", options: { interval: "month" } },
+					],
+				}),
+				makeField({
+					name: "counterpartyId",
+					keyword: true,
+					aggregations: [
+						{
+							kind: "terms",
+							options: {
+								sub: { latestValidTo: { kind: "max", field: "validTo" } },
+							},
+						},
+					],
+				}),
+			],
+		});
+		const result = await emitGraphQLResolver(projection, monolithicOptions);
+		assert.equal(result.mode, "monolithic");
+
+		const { ESLint } = await import("eslint");
+		// @ts-expect-error — plugin ships no type declarations.
+		const { default: appsyncPlugin } = await import(
+			"@aws-appsync/eslint-plugin"
+		);
+
+		const dir = await mkdtemp(join(tmpdir(), "appsync-lint-mono-"));
+		try {
+			await writeFile(join(dir, "resolver.js"), result.content);
+			await writeFile(
+				join(dir, "tsconfig.json"),
+				JSON.stringify({
+					compilerOptions: {
+						target: "ES2022",
+						module: "ES2022",
+						allowJs: true,
+						checkJs: false,
+						noEmit: true,
+					},
+					include: ["resolver.js"],
+				}),
+			);
+			const eslint = new ESLint({
+				cwd: dir,
+				overrideConfigFile: true,
+				overrideConfig: [
+					{
+						...appsyncPlugin.configs.recommended,
+						languageOptions: {
+							...appsyncPlugin.configs.recommended.languageOptions,
+							sourceType: "module",
+							ecmaVersion: 2022,
+							parserOptions: {
+								project: "./tsconfig.json",
+								tsconfigRootDir: dir,
+								ecmaVersion: 2022,
+								sourceType: "module",
+							},
+						},
+					},
+				],
+			});
+			const lintResults = await eslint.lintFiles([join(dir, "resolver.js")]);
+			const messages = lintResults.flatMap((r) =>
+				r.messages.map(
+					(m) =>
+						`[${m.ruleId ?? "fatal"}] ${r.filePath.split("/").pop()} line ${m.line ?? "?"}: ${m.message}`,
+				),
+			);
+			assert.deepEqual(
+				messages,
+				[],
+				`@aws-appsync/eslint-plugin reported issues on minified monolithic output:\n${messages.join("\n")}\n--- emitted ---\n${result.content}`,
+			);
+		} finally {
+			await rm(dir, { recursive: true, force: true });
 		}
 	});
 });

--- a/src/emit-graphql-resolver.ts
+++ b/src/emit-graphql-resolver.ts
@@ -5,6 +5,7 @@ import {
 	type FilterSpecNode,
 	type SearchFilterShape,
 } from "./filters.js";
+import { minifyAppsync } from "./minify.js";
 import type {
 	ResolvedProjection,
 	ResolvedProjectionField,
@@ -20,9 +21,19 @@ export interface EmittedPipelineFunction {
 	dataSource: PipelineFunctionDataSource;
 }
 
+export type ResolverEmissionMode = "monolithic" | "pipeline";
+
 export interface EmittedResolverFile {
 	queryFieldName: string;
-	/** Resolver-level file (`request`/`response` orchestration). */
+	/**
+	 * `monolithic` — `content` carries the full UNIT resolver (request +
+	 * response inline; reads OS via `operation: "GET"` directly). `functions`
+	 * is empty.
+	 * `pipeline` — `content` is the resolver-level after-mapping; `functions`
+	 * holds the prepare (NONE) and search (OPENSEARCH) pipeline functions.
+	 */
+	mode: ResolverEmissionMode;
+	/** Resolver-level file. UNIT body for monolithic; before/after for pipeline. */
 	fileName: string;
 	content: string;
 	/**
@@ -30,7 +41,7 @@ export interface EmittedResolverFile {
 	 * Functions and reference them on a PIPELINE Resolver. Splitting the work
 	 * across functions keeps each file's APPSYNC_JS code under the 32 KB
 	 * per-function cap, which a single-resolver shape would exceed on wide
-	 * @searchInfer projections (issue #105).
+	 * @searchInfer projections (issue #105). Empty for `mode === "monolithic"`.
 	 */
 	functions: EmittedPipelineFunction[];
 }
@@ -39,7 +50,33 @@ export interface ResolverOptions {
 	defaultPageSize: number;
 	maxPageSize: number;
 	trackTotalHitsUpTo: number;
+	/**
+	 * Apply post-emit minification (terser, APPSYNC_JS-safe config). Smaller
+	 * output means more projections fit under `monolithicThresholdBytes`.
+	 * Default: true.
+	 */
+	minify?: boolean;
+	/**
+	 * Byte threshold above which a projection's monolithic shape is rejected
+	 * and the pipeline shape is emitted instead. Suggested 28,000 (32K cap
+	 * minus headroom). Measured against the post-minify (or post-render)
+	 * monolithic content.
+	 */
+	monolithicThresholdBytes?: number;
 }
+
+// Default `minify: false` until the terser-vs-APPSYNC_JS shape-mismatch bug
+// is root-caused. Empirically: terser's output (with or without mangling)
+// runs cleanly for filters that produce a `match_all` nested clause but fails
+// at AppSync's request-evaluator with `Unable to convert ... to
+// ElasticsearchVersionedConfig` for `term`/`range` clauses inside a nested
+// path — even though the produced JSON body is structurally identical to the
+// verbose form (and OS accepts it directly). Verbose monolithic emission is
+// stable; the byte cost (~25-30% larger) is acceptable for the issue-#112
+// perf win. Consumers who verify their projections in-situ may opt-in to
+// `minify: true`.
+const DEFAULT_MINIFY = false;
+const DEFAULT_MONOLITHIC_THRESHOLD_BYTES = 32_000;
 
 // Bound for the runtime applyFilterSpec walker's fixed-size work slot pool.
 // APPSYNC_JS does not honor self-extending Array iteration, so the emitted
@@ -47,10 +84,10 @@ export interface ResolverOptions {
 // realistic SearchFilter shape; runtime util.error fires if exceeded.
 const FILTER_WORK_SLOT_COUNT = 256;
 
-export function emitGraphQLResolver(
+export async function emitGraphQLResolver(
 	projection: ResolvedProjection,
 	options: ResolverOptions,
-): EmittedResolverFile {
+): Promise<EmittedResolverFile> {
 	const typeName = projection.projectionModel.name;
 	const queryFieldName = toGraphQLQueryFieldName(typeName);
 	const baseName = toKebabCase(typeName);
@@ -73,18 +110,62 @@ export function emitGraphQLResolver(
 	const aggregations = collectAggregations(projection);
 	const searchFilterShape = buildSearchFilterShape(projection);
 
-	const prepareContent = renderPrepareFunction(
+	const minifyEnabled = options.minify ?? DEFAULT_MINIFY;
+	const threshold =
+		options.monolithicThresholdBytes ?? DEFAULT_MONOLITHIC_THRESHOLD_BYTES;
+
+	// Stage 1 of the two-stage emit (issue #112): render the monolithic UNIT
+	// shape first, optionally minify, then measure. Under the threshold we
+	// ship monolithic — saves ~50ms median per query (pipeline-dispatch I/O).
+	// Over the threshold we fall back to the pipeline split (issue #105).
+	const monolithicRaw = renderMonolithicResolver(
+		textFields,
+		keywordFields,
+		aggregations,
+		searchFilterShape,
+		projection.indexName,
+		options,
+	);
+	const monolithicContent = minifyEnabled
+		? await minifyAppsync(monolithicRaw)
+		: monolithicRaw;
+	const monolithicBytes = Buffer.byteLength(monolithicContent, "utf-8");
+
+	if (monolithicBytes <= threshold) {
+		return {
+			queryFieldName,
+			mode: "monolithic",
+			fileName: `${baseName}-resolver.js`,
+			content: monolithicContent,
+			functions: [],
+		};
+	}
+
+	// Pipeline fallback. Each function gets the same Stage 1 treatment so
+	// per-function size stays tight against the per-file 32 KB cap (issue
+	// #105). The resolver-level file holds the after-mapping; prepare runs
+	// on NONE, search on OPENSEARCH.
+	const prepareRaw = renderPrepareFunction(
 		textFields,
 		keywordFields,
 		aggregations,
 		searchFilterShape,
 		options,
 	);
-	const searchContent = renderSearchFunction(projection.indexName);
-	const resolverContent = renderResolver(aggregations, options);
+	const searchRaw = renderSearchFunction(projection.indexName);
+	const resolverRaw = renderResolver(aggregations, options);
+
+	const [prepareContent, searchContent, resolverContent] = minifyEnabled
+		? await Promise.all([
+				minifyAppsync(prepareRaw),
+				minifyAppsync(searchRaw),
+				minifyAppsync(resolverRaw),
+			])
+		: [prepareRaw, searchRaw, resolverRaw];
 
 	return {
 		queryFieldName,
+		mode: "pipeline",
 		fileName: `${baseName}-resolver.js`,
 		content: resolverContent,
 		functions: [
@@ -115,6 +196,300 @@ function hasTextType(field: ResolvedProjectionField): boolean {
 		}
 	}
 	return type.kind === "String";
+}
+
+/**
+ * Monolithic UNIT resolver — single file with request building + OS dispatch +
+ * response shaping inline. AppSync invokes `request(ctx)` once on the OS
+ * datasource; the OS response lands in `ctx.result` (not `ctx.prev.result`,
+ * which is pipeline-only). Issue #112 — collapses the 3-function pipeline
+ * into one when the projection fits under threshold.
+ */
+function renderMonolithicResolver(
+	textFields: string[],
+	keywordFields: string[],
+	aggregations: AggregationEntry[],
+	searchFilterShape: SearchFilterShape | undefined,
+	indexName: string,
+	options: ResolverOptions,
+): string {
+	const textFieldsLiteral = JSON.stringify(textFields);
+	const keywordFieldsLiteral = JSON.stringify(keywordFields);
+	const aggsBlock = renderAggsBlock(aggregations);
+	const filterSpecLiteral = renderFilterSpecLiteral(searchFilterShape);
+	const slotsLiteral = `[${"null,".repeat(FILTER_WORK_SLOT_COUNT).slice(0, -1)}]`;
+	const responseAggregationsPreamble =
+		renderResponseAggregationsPreamble(aggregations);
+	const responseAggregations = renderResponseAggregations(aggregations);
+
+	return `import { util } from "@aws-appsync/utils";
+
+const FILTER_SPEC = ${filterSpecLiteral};
+
+export function request(ctx) {
+	const args = ctx.args;
+	const size = Math.min(args.first || ${options.defaultPageSize}, ${options.maxPageSize});
+	const searchAfter = args.after ? JSON.parse(util.base64Decode(args.after)) : undefined;
+
+	const query = buildQuery(args.query, args.filter, args.searchFilter);
+	const sort = buildSort(args.sortBy);
+
+	const body = {
+		size: size + 1,
+		track_total_hits: ${options.trackTotalHitsUpTo},
+		sort,
+		query,${aggsBlock}
+	};
+
+	if (searchAfter) {
+		body.search_after = searchAfter;
+	}
+
+	return {
+		operation: "GET",
+		path: "/${indexName}/_search",
+		params: { body },
+	};
+}
+
+export function response(ctx) {
+	if (ctx.error) {
+		return util.error(ctx.error.message, ctx.error.type);
+	}
+
+	const parsedBody = ctx.result;
+	const hits = parsedBody.hits.hits;
+	const totalHits = parsedBody.hits.total.value;
+	const args = ctx.args;
+	const size = Math.min(args.first || ${options.defaultPageSize}, ${options.maxPageSize});
+
+	const hasNextPage = hits.length > size;
+	const edges = hits.slice(0, size).map((hit) => ({
+		node: hit._source,
+		cursor: util.base64Encode(JSON.stringify(hit.sort)),
+	}));
+${responseAggregationsPreamble}
+	return {
+		edges,
+		totalCount: totalHits,${responseAggregations}
+		pageInfo: {
+			hasNextPage,
+			endCursor: edges.length > 0 ? edges[edges.length - 1].cursor : null,
+		},
+	};
+}
+
+function buildQuery(queryText, filter, searchFilter) {
+	const musts = [];
+	const filters = [];
+	const mustNots = [];
+
+	if (queryText) {
+		musts.push({
+			multi_match: {
+				query: queryText,
+				fields: ${textFieldsLiteral},
+				type: "best_fields",
+			},
+		});
+	}
+
+	const keywordFields = ${keywordFieldsLiteral};
+	if (filter) {
+		for (const field of keywordFields) {
+			if (filter[field] != null) {
+				filters.push({ term: { [field]: filter[field] } });
+			}
+		}
+	}
+
+	if (searchFilter) {
+		applyFilterSpec(FILTER_SPEC, searchFilter, filters, mustNots);
+	}
+
+	if (musts.length === 0 && filters.length === 0 && mustNots.length === 0) {
+		return { match_all: {} };
+	}
+
+	return {
+		bool: {
+			...(musts.length > 0 ? { must: musts } : {}),
+			...(filters.length > 0 ? { filter: filters } : {}),
+			...(mustNots.length > 0 ? { must_not: mustNots } : {}),
+		},
+	};
+}
+
+function buildSort(sortBy) {
+	const fallback = [{ _score: "desc" }, { _id: "asc" }];
+	if (!sortBy || sortBy.length === 0) {
+		return fallback;
+	}
+	const out = [];
+	for (const entry of sortBy) {
+		if (entry && entry.field) {
+			const direction = entry.direction === "ASC" ? "asc" : "desc";
+			out.push({ [entry.field]: direction });
+		}
+	}
+	out.push({ _id: "asc" });
+	return out;
+}
+
+function applyFilterSpec(rootSpec, rootInput, rootOutFilters, rootOutMustNots) {
+	if (!rootSpec || !rootInput) return;
+
+	const procSlots = ${slotsLiteral};
+	const finSlots = ${slotsLiteral};
+	procSlots[0] = {
+		spec: rootSpec,
+		input: rootInput,
+		outFilters: rootOutFilters,
+		outMustNots: rootOutMustNots,
+	};
+	let procHead = 0;
+	let procTail = 1;
+	let finTail = 0;
+
+	for (const _slot of procSlots) {
+		if (procHead < procTail) {
+			const item = procSlots[procHead];
+			procHead = procHead + 1;
+			const spec = item.spec;
+			const input = item.input;
+			const outFilters = item.outFilters;
+			const outMustNots = item.outMustNots;
+
+			for (const node of spec) {
+				const value = input[node.i];
+				if (node.k === "nested") {
+					if (value != null) {
+						const childFilters = [];
+						const childMustNots = [];
+						if (procTail + 1 > procSlots.length) {
+							util.error(
+								"applyFilterSpec exceeded fixed work-slot capacity; SearchFilter shape too deep for APPSYNC_JS function",
+							);
+						}
+						if (finTail + 1 > finSlots.length) {
+							util.error(
+								"applyFilterSpec exceeded fixed finalize-slot capacity; SearchFilter shape too deep for APPSYNC_JS function",
+							);
+						}
+						procSlots[procTail] = {
+							spec: node.c,
+							input: value,
+							outFilters: childFilters,
+							outMustNots: childMustNots,
+						};
+						procTail = procTail + 1;
+						finSlots[finTail] = {
+							path: node.p,
+							childFilters,
+							childMustNots,
+							parentFilters: outFilters,
+							parentMustNots: outMustNots,
+						};
+						finTail = finTail + 1;
+					}
+				} else if (node.k === "object") {
+					if (value != null) {
+						if (procTail + 1 > procSlots.length) {
+							util.error(
+								"applyFilterSpec exceeded fixed work-slot capacity; SearchFilter shape too deep for APPSYNC_JS function",
+							);
+						}
+						procSlots[procTail] = {
+							spec: node.c,
+							input: value,
+							outFilters,
+							outMustNots,
+						};
+						procTail = procTail + 1;
+					}
+				} else if (node.k === "term") {
+					if (value != null) {
+						outFilters.push({ term: { [node.f]: value } });
+					}
+				} else if (node.k === "term_negate") {
+					if (value != null) {
+						outMustNots.push({ term: { [node.f]: value } });
+					}
+				} else if (node.k === "terms") {
+					if (value != null && value.length > 0) {
+						outFilters.push({ terms: { [node.f]: value } });
+					}
+				} else if (node.k === "exists") {
+					if (value != null) {
+						if (value === true) {
+							outFilters.push({ exists: { field: node.f } });
+						} else {
+							outMustNots.push({ exists: { field: node.f } });
+						}
+					}
+				} else if (node.k === "nested_exists") {
+					if (value != null) {
+						const nestedClause = {
+							nested: { path: node.p, query: { match_all: {} } },
+						};
+						if (value === true) {
+							outFilters.push(nestedClause);
+						} else {
+							outMustNots.push(nestedClause);
+						}
+					}
+				} else if (node.k === "range") {
+					const base = node.i;
+					const bounds = {};
+					let any = false;
+					if (input[base + "Gte"] != null) {
+						bounds.gte = input[base + "Gte"];
+						any = true;
+					}
+					if (input[base + "Lte"] != null) {
+						bounds.lte = input[base + "Lte"];
+						any = true;
+					}
+					if (input[base + "Gt"] != null) {
+						bounds.gt = input[base + "Gt"];
+						any = true;
+					}
+					if (input[base + "Lt"] != null) {
+						bounds.lt = input[base + "Lt"];
+						any = true;
+					}
+					if (any) {
+						outFilters.push({ range: { [node.f]: bounds } });
+					}
+				}
+			}
+		}
+	}
+
+	for (const _slot of finSlots) {
+		if (finTail > 0) {
+			finTail = finTail - 1;
+			const item = finSlots[finTail];
+			for (const clause of item.childFilters) {
+				item.parentFilters.push({
+					nested: {
+						path: item.path,
+						query: { bool: { filter: [clause] } },
+					},
+				});
+			}
+			for (const clause of item.childMustNots) {
+				item.parentMustNots.push({
+					nested: {
+						path: item.path,
+						query: { bool: { filter: [clause] } },
+					},
+				});
+			}
+		}
+	}
+}
+`;
 }
 
 /**
@@ -735,6 +1110,9 @@ export const __test = {
 	renderResolver,
 	renderPrepareFunction,
 	renderSearchFunction,
+	renderMonolithicResolver,
 	renderAggsBlock,
 	renderResponseAggregations,
+	DEFAULT_MINIFY,
+	DEFAULT_MONOLITHIC_THRESHOLD_BYTES,
 };

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -84,6 +84,7 @@ export async function $onEmit(
 	const packageName = context.options["package-name"];
 	const packageVersion = context.options["package-version"];
 	const graphqlOptions = context.options.graphql;
+	const resolverFiles: EmittedResolverFile[] = [];
 	if (graphqlOptions?.emit) {
 		const pageOptions = {
 			defaultPageSize: graphqlOptions["default-page-size"] ?? 20,
@@ -92,9 +93,13 @@ export async function $onEmit(
 		const resolverOptions = {
 			...pageOptions,
 			trackTotalHitsUpTo: graphqlOptions["track-total-hits-up-to"] ?? 10000,
+			// Default `minify: false` until terser-vs-APPSYNC_JS shape mismatch
+			// is root-caused (issue #112 in-situ probe). Verbose monolithic
+			// emission is stable and still fits the 32K cap with headroom.
+			minify: graphqlOptions.minify ?? false,
+			monolithicThresholdBytes:
+				graphqlOptions["monolithic-threshold-bytes"] ?? 32000,
 		};
-
-		const resolverFiles: EmittedResolverFile[] = [];
 
 		for (const projection of resolved) {
 			const sdlFile = emitGraphQLSdl(context.program, projection, pageOptions);
@@ -103,7 +108,10 @@ export async function $onEmit(
 				content: sdlFile.content,
 			});
 
-			const resolverFile = emitGraphQLResolver(projection, resolverOptions);
+			const resolverFile = await emitGraphQLResolver(
+				projection,
+				resolverOptions,
+			);
 			resolverFiles.push(resolverFile);
 			await emitFile(context.program, {
 				path: resolvePath(context.emitterOutputDir, resolverFile.fileName),
@@ -137,6 +145,7 @@ export async function $onEmit(
 			packageVersion,
 			resolved,
 			graphqlArtifacts,
+			graphqlOptions?.emit ? resolverFiles : undefined,
 		);
 		await emitFile(context.program, {
 			path: resolvePath(context.emitterOutputDir, "package.json"),
@@ -233,10 +242,15 @@ function generateGraphQLManifest(
 ): string {
 	const resolvers = projections.map((projection, i) => {
 		const resolver = resolverFiles[i];
+		// `mode` (issue #112) tells the consumer which AppSync resolver kind
+		// to wire — UNIT for `monolithic`, PIPELINE for `pipeline`. The
+		// `functions` array is empty under `monolithic` and ignored by the
+		// consumer in that case.
 		return {
 			projection: projection.projectionModel.name,
 			indexName: projection.indexName,
 			queryFieldName: resolver.queryFieldName,
+			mode: resolver.mode,
 			resolverFile: resolver.fileName,
 			sdlFile: `${toKebabCase(projection.projectionModel.name)}.graphql`,
 			functions: resolver.functions.map((fn) => ({
@@ -312,6 +326,7 @@ function generatePackageJson(
 	packageVersion: string,
 	projections: ResolvedProjection[],
 	graphqlProjections?: ResolvedProjection[],
+	resolverFiles?: EmittedResolverFile[],
 ): string {
 	const artifactExports: Record<string, string> = {};
 
@@ -323,12 +338,29 @@ function generatePackageJson(
 	if (graphqlProjections) {
 		artifactExports["./graphql-resolvers.json"] = "./graphql-resolvers.json";
 		artifactExports["./graphql-resolvers.js"] = "./graphql-resolvers.js";
+		const filesByName = new Map<string, EmittedResolverFile>();
+		if (resolverFiles) {
+			for (let i = 0; i < graphqlProjections.length; i++) {
+				filesByName.set(
+					graphqlProjections[i].projectionModel.name,
+					resolverFiles[i],
+				);
+			}
+		}
 		for (const projection of graphqlProjections) {
 			const kebab = toKebabCase(projection.projectionModel.name);
 			artifactExports[`./${kebab}.graphql`] = `./${kebab}.graphql`;
 			artifactExports[`./${kebab}-resolver.js`] = `./${kebab}-resolver.js`;
-			artifactExports[`./${kebab}-fn-prepare.js`] = `./${kebab}-fn-prepare.js`;
-			artifactExports[`./${kebab}-fn-search.js`] = `./${kebab}-fn-search.js`;
+			// Pipeline functions (prepare/search) only exist on the disk for
+			// projections emitted in pipeline mode (issue #112). Monolithic
+			// projections collapse those into the resolver file. Only export
+			// what's actually present.
+			const file = filesByName.get(projection.projectionModel.name);
+			if (file && file.mode === "pipeline") {
+				artifactExports[`./${kebab}-fn-prepare.js`] =
+					`./${kebab}-fn-prepare.js`;
+				artifactExports[`./${kebab}-fn-search.js`] = `./${kebab}-fn-search.js`;
+			}
 		}
 	}
 

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -5,6 +5,20 @@ export interface GraphQLEmitterOptions {
 	"default-page-size"?: number;
 	"max-page-size"?: number;
 	"track-total-hits-up-to"?: number;
+	/**
+	 * Apply post-emit minification (terser, APPSYNC_JS-safe config) before the
+	 * monolithic-vs-pipeline byte check. Default: true. Disable for verbose
+	 * source emission (easier CloudWatch trace inspection at the cost of more
+	 * projections falling into pipeline mode). Issue #112.
+	 */
+	minify?: boolean;
+	/**
+	 * Byte threshold for the monolithic-vs-pipeline switch. Above the
+	 * threshold a projection emits as a 3-function pipeline; at or below it
+	 * emits as a single UNIT resolver. Default: 28000 (32K AppSync per-file
+	 * cap minus headroom). Issue #112.
+	 */
+	"monolithic-threshold-bytes"?: number;
 }
 
 export interface OpenSearchEmitterOptions {
@@ -169,6 +183,16 @@ export const $lib = createTypeSpecLibrary({
 							type: "number",
 							nullable: true,
 							default: 10000,
+						},
+						minify: {
+							type: "boolean",
+							nullable: true,
+							default: false,
+						},
+						"monolithic-threshold-bytes": {
+							type: "number",
+							nullable: true,
+							default: 32000,
 						},
 					},
 					additionalProperties: false,

--- a/src/minify.ts
+++ b/src/minify.ts
@@ -1,0 +1,91 @@
+import { type MinifyOptions, minify } from "terser";
+
+/**
+ * APPSYNC_JS-safe terser config. The runtime forbids a long list of normally
+ * benign JS — `while`, `continue`, C-style `for(;;)`, `++`/`--` (unary increment),
+ * regex literals, `try/catch`, recursion, `String()/Number()/Boolean()` global
+ * coercion calls. Terser's default optimizations generate several of those
+ * (notably `++`/`--`, regex helpers via inlined polyfills, and ternaries that
+ * use `void 0`). The config below disables everything that is known to emit
+ * a forbidden form, plus the dangerous escape hatches (`unsafe`,
+ * `unsafe_arrows`, `unsafe_methods`).
+ *
+ * The aim is byte shrinkage from string-literal interning + dead-code removal
+ * + property mangling of locals. NOT execution speed — the AppSync function
+ * is parsed once per cold-start, and the FILTER_SPEC walker is microseconds
+ * regardless of variable names. The savings come from the FILTER_SPEC literal
+ * (repeated discriminators / path prefixes interned) and from collapsing the
+ * fixed renderer scaffolding.
+ */
+const APPSYNC_SAFE_TERSER_OPTIONS: MinifyOptions = {
+	ecma: 2020,
+	module: true,
+	compress: {
+		// Generic safety: disable any "unsafe" optimization family. These can
+		// rewrite calls and operators in ways that change observable behavior
+		// (or produce constructs APPSYNC_JS rejects).
+		unsafe: false,
+		unsafe_arrows: false,
+		unsafe_comps: false,
+		unsafe_Function: false,
+		unsafe_math: false,
+		unsafe_symbols: false,
+		unsafe_methods: false,
+		unsafe_proto: false,
+		unsafe_regexp: false,
+		unsafe_undefined: false,
+		// `loops: true` (default) rewrites `for...of` into `while` for some
+		// shapes — APPSYNC_JS bans `while`. Keep as-is.
+		loops: false,
+		// `sequences: true` joins statements with the comma operator, which
+		// the APPSYNC_JS deploy validator rejects (INVALID_BINARY_OPERATOR
+		// on the `,`). Disable to keep separate statements.
+		sequences: false,
+		// terser by default rewrites `x = x + 1` → `x++`. APPSYNC_JS bans `++`/`--`.
+		// Disable peephole optimizations that produce unary update operators.
+		reduce_vars: false,
+		evaluate: false,
+		// `comparisons` rewrites `!a == b` to `a != b`, which is fine; leave on.
+		// `arrows` rewrites function() into () =>; APPSYNC_JS supports arrows.
+		// `booleans_as_integers: true` would emit `0`/`1` for true/false in
+		// boolean contexts — fine but visually surprising. Leave off (default).
+		booleans_as_integers: false,
+		// String interning relies on the default `passes: 1` plus terser's
+		// internal literal sharing. Multiple passes can introduce `++` via
+		// reduce_vars; one pass is enough for the FILTER_SPEC use case.
+		passes: 1,
+		// Drop nothing — emitter doesn't emit console.* anyway, but be explicit.
+		drop_console: false,
+		drop_debugger: false,
+		// `pure_getters` could elide property access; keep conservative default.
+		pure_getters: false,
+		// Disable `expression: false` — keep statement-level structure intact
+		// so the emitted module exports are not collapsed into expressions
+		// (APPSYNC_JS expects top-level `export function ...`).
+	},
+	// Mangling produces tightly-shadowed identifiers (parameters re-used as
+	// const names in inner scopes) that APPSYNC_JS's runtime parser silently
+	// mis-resolves at request-evaluation time, even though the AST is valid.
+	// Skipping mangle costs ~30% of byte savings but keeps the resolver
+	// runnable. The dominant savings come from whitespace removal and
+	// FILTER_SPEC literal interning, which compress + literal-folding still
+	// achieve.
+	mangle: false,
+	format: {
+		comments: false,
+		// `ecma: 2020` permits arrow functions, optional chaining; those are
+		// fine in APPSYNC_JS.
+	},
+};
+
+export async function minifyAppsync(code: string): Promise<string> {
+	const result = await minify(code, APPSYNC_SAFE_TERSER_OPTIONS);
+	if (typeof result.code !== "string") {
+		throw new Error("terser returned no code");
+	}
+	return result.code;
+}
+
+export const __test = {
+	APPSYNC_SAFE_TERSER_OPTIONS,
+};

--- a/src/projection.test.ts
+++ b/src/projection.test.ts
@@ -1037,17 +1037,30 @@ describe("emitted resolver size budget", () => {
 		const resolved = resolveProjectionModel(runner.program, projection);
 		assert.ok(resolved);
 
-		const result = emitGraphQLResolver(resolved, {
+		const result = await emitGraphQLResolver(resolved, {
 			defaultPageSize: 20,
 			maxPageSize: 100,
 			trackTotalHitsUpTo: 10000,
 		});
 
-		// AppSync APPSYNC_JS hard cap on resolver source code.
+		// AppSync APPSYNC_JS hard cap on resolver source code. With the
+		// two-stage emit (issue #112), monolithic mode keeps everything in
+		// `content`; pipeline mode splits across `content` + functions. Either
+		// way every emitted file must fit under the per-file cap.
 		const APPSYNC_CODE_CAP = 32 * 1024;
-		assert.ok(
-			result.content.length < APPSYNC_CODE_CAP,
-			`emitted resolver is ${result.content.length} bytes — exceeds AppSync's ${APPSYNC_CODE_CAP}-byte cap. Wide projections need further shrink work.`,
-		);
+		const files = [
+			{ name: result.fileName, content: result.content },
+			...result.functions.map((fn) => ({
+				name: fn.fileName,
+				content: fn.content,
+			})),
+		];
+		for (const file of files) {
+			const bytes = Buffer.byteLength(file.content, "utf-8");
+			assert.ok(
+				bytes < APPSYNC_CODE_CAP,
+				`emitted file ${file.name} is ${bytes} bytes — exceeds AppSync's ${APPSYNC_CODE_CAP}-byte per-file cap.`,
+			);
+		}
 	});
 });

--- a/test/tspconfig.yaml
+++ b/test/tspconfig.yaml
@@ -6,3 +6,8 @@ options:
     emitter-output-dir: "{cwd}/build/opensearch-emit"
     graphql:
       emit: true
+      # Force pipeline mode + verbose source for the legacy test assertions
+      # (which substring-match the readable pipeline shape). New test
+      # tspconfig.monolithic.yaml exercises monolithic mode separately.
+      minify: false
+      monolithic-threshold-bytes: 0


### PR DESCRIPTION
Adds a configurable post-emit minify step (terser, APPSYNC_JS-safe) followed by a deterministic byte-length check that picks monolithic for under-threshold projections and pipeline for over-threshold ones; closes #112.