### PR TITLE
fix(emitter): map int64 to String in GraphQL filter inputs (was Int, overflowed)

### DIFF
--- a/src/emit-graphql-sdl.test.ts
+++ b/src/emit-graphql-sdl.test.ts
@@ -706,6 +706,53 @@ describe("emitGraphQLSdl SearchFilter input", () => {
 		assert.ok(result.content.includes("rankLt: Int"));
 	});
 
+	it("emits int64 range filter inputs as String to avoid Int32 overflow on 64-bit values (e.g. epoch-ms timestamps ~1.7T)", () => {
+		const projection = makeProjection({
+			name: "PetSearchDoc",
+			fields: [
+				makeField({
+					name: "createdAt",
+					filterables: ["range"],
+					type: { kind: "Scalar", name: "int64" } as unknown as Type,
+				}),
+				makeField({
+					name: "updatedAt",
+					filterables: ["range"],
+					type: { kind: "Scalar", name: "int64" } as unknown as Type,
+				}),
+			],
+		});
+
+		const result = emitGraphQLSdl(dummyProgram, projection, defaultOptions);
+		assert.ok(result.content.includes("createdAtGte: String"));
+		assert.ok(result.content.includes("createdAtLte: String"));
+		assert.ok(result.content.includes("createdAtGt: String"));
+		assert.ok(result.content.includes("createdAtLt: String"));
+		assert.ok(result.content.includes("updatedAtGte: String"));
+		assert.ok(!result.content.includes("createdAtGte: Int"));
+		assert.ok(!result.content.includes("updatedAtGte: Int"));
+		// Response type for int64 fields is unchanged (still Int) — out of scope
+		// for this fix; only filter inputs overflow at GraphQL parse time.
+		assert.ok(result.content.match(/createdAt: Int(?!\w)/));
+	});
+
+	it("preserves Int for int32 range filter inputs (only int64 / uint64 are remapped)", () => {
+		const projection = makeProjection({
+			name: "PetSearchDoc",
+			fields: [
+				makeField({
+					name: "score",
+					filterables: ["range"],
+					type: { kind: "Scalar", name: "int32" } as unknown as Type,
+				}),
+			],
+		});
+
+		const result = emitGraphQLSdl(dummyProgram, projection, defaultOptions);
+		assert.ok(result.content.includes("scoreGte: Int"));
+		assert.ok(result.content.includes("scoreLte: Int"));
+	});
+
 	it("emits SortDirection, <Type>SortField enum, and <Type>SortInput when fields are sortable", () => {
 		const projection = makeProjection({
 			name: "PetSearchDoc",

--- a/src/emit-graphql-sdl.ts
+++ b/src/emit-graphql-sdl.ts
@@ -224,7 +224,7 @@ function renderSearchFilterField(
 		return `  ${node.inputName}: Boolean`;
 	}
 	const gqlType = node.sourceField
-		? toGraphQLType(program, node.sourceField.type, node.sourceField)
+		? toGraphQLType(program, node.sourceField.type, node.sourceField, "filter")
 		: "String";
 	const baseScalar = stripListWrap(gqlType);
 	if (node.kind === "terms") {
@@ -342,7 +342,7 @@ function renderAggregationTypes(
 	const customBucketTypes: string[] = [];
 
 	// Dedupe by aggName — same fieldLine matches the resolver-side dedupe in
-	// renderAggsBlock. Without this, an aggregation declared on a field that
+	// renderAggsObjectLiteral. Without this, an aggregation declared on a field that
 	// the projection emits twice (e.g. via spread) produces a duplicate-field
 	// SDL block, which AppSync schema validation rejects.
 	const seenAggNames = new Set<string>();
@@ -452,10 +452,13 @@ function capitalizeFirst(name: string): string {
 	return name[0].toUpperCase() + name.slice(1);
 }
 
+type EmitContext = "response" | "filter";
+
 function toGraphQLType(
 	program: Program,
 	type: Type,
 	field?: ResolvedProjectionField,
+	context: EmitContext = "response",
 ): string {
 	if (field?.subProjection) {
 		const subName = field.subProjection.projectionModel.name;
@@ -466,9 +469,9 @@ function toGraphQLType(
 
 	switch (type.kind) {
 		case "Scalar":
-			return scalarToGraphQL(type);
+			return scalarToGraphQL(type, context);
 		case "Model":
-			return modelToGraphQL(program, type);
+			return modelToGraphQL(program, type, context);
 		case "String":
 			return "String";
 		case "Number":
@@ -476,7 +479,7 @@ function toGraphQLType(
 		case "Boolean":
 			return "Boolean";
 		case "Union":
-			return unionToGraphQL(program, type);
+			return unionToGraphQL(program, type, context);
 		case "Enum":
 			return "String";
 		default:
@@ -484,7 +487,7 @@ function toGraphQLType(
 	}
 }
 
-function scalarToGraphQL(scalar: Scalar): string {
+function scalarToGraphQL(scalar: Scalar, context: EmitContext): string {
 	let current: Scalar | undefined = scalar;
 	while (current) {
 		switch (current.name) {
@@ -492,14 +495,21 @@ function scalarToGraphQL(scalar: Scalar): string {
 			case "plainDate":
 			case "utcDateTime":
 				return "String";
-			case "int32":
 			case "int64":
+			case "uint64":
+				// AppSync GraphQL has no Long scalar; Int is 32-bit (max ~2.1B) so
+				// realistic int64 values (e.g. epoch-ms timestamps ~1.7T) overflow at
+				// parse time on filter inputs. Emit String for filter inputs so callers
+				// can serialize the 64-bit value as a numeric string. Response types
+				// keep Int for backward compatibility (a separate concern, since the
+				// resolver-side serialization path is already constrained by AppSync).
+				return context === "filter" ? "String" : "Int";
+			case "int32":
 			case "integer":
 			case "safeint":
 			case "uint8":
 			case "uint16":
 			case "uint32":
-			case "uint64":
 			case "int8":
 			case "int16":
 				return "Int";
@@ -519,19 +529,32 @@ function scalarToGraphQL(scalar: Scalar): string {
 	return "String";
 }
 
-function modelToGraphQL(program: Program, model: Model): string {
+function modelToGraphQL(
+	program: Program,
+	model: Model,
+	context: EmitContext,
+): string {
 	if (model.name === "Array" && model.indexer?.value) {
-		const elementType = toGraphQLType(program, model.indexer.value);
+		const elementType = toGraphQLType(
+			program,
+			model.indexer.value,
+			undefined,
+			context,
+		);
 		return `[${elementType}!]`;
 	}
 
 	return "String";
 }
 
-function unionToGraphQL(program: Program, union: Union): string {
+function unionToGraphQL(
+	program: Program,
+	union: Union,
+	context: EmitContext,
+): string {
 	for (const variant of union.variants.values()) {
 		if (variant.type.kind === "Scalar" || variant.type.kind === "String") {
-			return toGraphQLType(program, variant.type);
+			return toGraphQLType(program, variant.type, undefined, context);
 		}
 	}
 	return "String";


### PR DESCRIPTION
Filter inputs for int64 fields (e.g. createdAtGte for epoch-ms timestamps) were emitted as GraphQL Int (32-bit) and overflowed at parse time on real values; switches to String which holds 64-bit values as numeric strings (AWSTimestamp is also Int-on-the-wire and doesn't fix this — AppSync has no Long).