### PR TITLE
fix(emitter): drop trailing "s" only on array fields, preserve singular field names in agg buckets

### DIFF
--- a/src/aggregations.test.ts
+++ b/src/aggregations.test.ts
@@ -9,7 +9,25 @@ import {
 } from "./aggregations.js";
 import type { ResolvedProjection } from "./projection.js";
 
-const { aggregationFieldName, singularize, capitalize, isTextField } = __test;
+const {
+	aggregationFieldName,
+	singularize,
+	capitalize,
+	isTextField,
+	isArrayType,
+} = __test;
+
+const stringScalar = { kind: "Scalar", name: "string" } as unknown as Type;
+const arrayOfString = {
+	kind: "Model",
+	name: "Array",
+	indexer: { value: { kind: "Scalar", name: "string" } },
+} as unknown as Type;
+const arrayOfModel = {
+	kind: "Model",
+	name: "Array",
+	indexer: { value: { kind: "Model" } },
+} as unknown as Type;
 
 function makeProjection(
 	overrides: Partial<{
@@ -61,18 +79,37 @@ function liftAggregations(
 }
 
 describe("aggregationFieldName", () => {
-	it("emits byField for terms with plural drop", () => {
-		assert.equal(aggregationFieldName("tags", "terms"), "byTag");
-		assert.equal(aggregationFieldName("groups", "terms"), "byGroup");
-		assert.equal(aggregationFieldName("locations", "terms"), "byLocation");
+	it("emits byField for terms with plural drop on array fields", () => {
+		assert.equal(
+			aggregationFieldName("tags", "terms", undefined, true),
+			"byTag",
+		);
+		assert.equal(
+			aggregationFieldName("groups", "terms", undefined, true),
+			"byGroup",
+		);
+		assert.equal(
+			aggregationFieldName("locations", "terms", undefined, true),
+			"byLocation",
+		);
 	});
 
-	it("emits uniqueFieldCount for cardinality", () => {
+	it("preserves singular field names ending in 's' on scalar fields", () => {
+		assert.equal(aggregationFieldName("status", "terms"), "byStatus");
+		assert.equal(aggregationFieldName("address", "terms"), "byAddress");
+		assert.equal(aggregationFieldName("process", "terms"), "byProcess");
+		assert.equal(aggregationFieldName("class", "terms"), "byClass");
+	});
+
+	it("emits uniqueFieldCount for cardinality on array fields", () => {
 		assert.equal(
-			aggregationFieldName("locations", "cardinality"),
+			aggregationFieldName("locations", "cardinality", undefined, true),
 			"uniqueLocationCount",
 		);
-		assert.equal(aggregationFieldName("tags", "cardinality"), "uniqueTagCount");
+		assert.equal(
+			aggregationFieldName("tags", "cardinality", undefined, true),
+			"uniqueTagCount",
+		);
 	});
 
 	it("emits missingFieldCount for missing", () => {
@@ -86,8 +123,11 @@ describe("aggregationFieldName", () => {
 		assert.equal(aggregationFieldName("description", "terms"), "byDescription");
 	});
 
-	it("handles -ies plural", () => {
-		assert.equal(aggregationFieldName("categories", "terms"), "byCategory");
+	it("handles -ies plural on array fields", () => {
+		assert.equal(
+			aggregationFieldName("categories", "terms", undefined, true),
+			"byCategory",
+		);
 	});
 
 	it("emits <field><Sum|Avg|Min|Max> for numeric metric aggs", () => {
@@ -209,6 +249,7 @@ describe("collectAggregations", () => {
 					name: "locations",
 					keyword: true,
 					aggregations: ["terms", "cardinality"],
+					type: arrayOfString,
 				}),
 			],
 		});
@@ -292,6 +333,7 @@ describe("collectAggregations", () => {
 					name: "tags",
 					projectedName: "labels",
 					aggregations: ["terms"],
+					type: arrayOfString,
 				}),
 			],
 		});
@@ -299,6 +341,53 @@ describe("collectAggregations", () => {
 		const entries = collectAggregations(projection);
 		assert.equal(entries[0].openSearchField, "labels.keyword");
 		assert.equal(entries[0].aggName, "byLabel");
+	});
+
+	it("preserves trailing 's' on singular scalar fields (status, address)", () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "status",
+					keyword: true,
+					aggregations: ["terms"],
+					type: stringScalar,
+				}),
+				makeField({
+					name: "address",
+					keyword: true,
+					aggregations: ["terms"],
+					type: stringScalar,
+				}),
+				makeField({
+					name: "process",
+					keyword: true,
+					aggregations: ["terms"],
+					type: stringScalar,
+				}),
+			],
+		});
+
+		const entries = collectAggregations(projection);
+		assert.equal(entries.length, 3);
+		assert.equal(entries[0].aggName, "byStatus");
+		assert.equal(entries[1].aggName, "byAddress");
+		assert.equal(entries[2].aggName, "byProcess");
+	});
+
+	it("drops trailing 's' on array (collection) fields", () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "tags",
+					keyword: true,
+					aggregations: ["terms"],
+					type: arrayOfString,
+				}),
+			],
+		});
+
+		const entries = collectAggregations(projection);
+		assert.equal(entries[0].aggName, "byTag");
 	});
 });
 
@@ -438,6 +527,33 @@ describe("collectAggregations with nested sub-projections", () => {
 		assert.ok(byTagName, "expected nestedPath prefix from projectedName");
 		assert.equal(byTagName.nestedPath, "labels");
 		assert.equal(byTagName.openSearchField, "labels.name");
+	});
+});
+
+describe("isArrayType", () => {
+	it("returns true for Model Array types", () => {
+		assert.equal(isArrayType(arrayOfString), true);
+		assert.equal(isArrayType(arrayOfModel), true);
+	});
+
+	it("returns false for scalar types", () => {
+		assert.equal(isArrayType(stringScalar), false);
+		assert.equal(
+			isArrayType({ kind: "Scalar", name: "int32" } as unknown as Type),
+			false,
+		);
+	});
+
+	it("returns false for non-Array Model types", () => {
+		assert.equal(
+			isArrayType({ kind: "Model", name: "Address" } as unknown as Type),
+			false,
+		);
+	});
+
+	it("returns false for non-Model kinds", () => {
+		assert.equal(isArrayType({ kind: "Enum" } as unknown as Type), false);
+		assert.equal(isArrayType({ kind: "Boolean" } as unknown as Type), false);
 	});
 });
 

--- a/src/aggregations.ts
+++ b/src/aggregations.ts
@@ -1,3 +1,4 @@
+import type { Type } from "@typespec/compiler";
 import type { AggregationKind, AggregationOptions } from "./decorators.js";
 import type {
 	ResolvedProjection,
@@ -55,6 +56,7 @@ function collectAggregationsRecursive(
 						projectedName,
 						directive.kind,
 						nestedPath,
+						isArrayType(field.type),
 					),
 					openSearchField,
 					useTextType,
@@ -94,8 +96,15 @@ export function aggregationFieldName(
 	fieldName: string,
 	kind: AggregationKind,
 	nestedPath?: string,
+	fieldIsArray = false,
 ): string {
-	const fieldPart = capitalize(singularize(fieldName));
+	// Only collapse a trailing "s" when the source field is itself an array
+	// (tags: Tag[] -> byTag). Singular fields whose name ends in "s"
+	// (status, process, address) keep their name verbatim (byStatus,
+	// byProcess, byAddress).
+	const fieldPart = capitalize(
+		fieldIsArray ? singularize(fieldName) : fieldName,
+	);
 	const prefix = nestedPath ? nestedPathPrefix(nestedPath) : "";
 	const capital = `${prefix}${fieldPart}`;
 	const camel = lowerFirst(capital);
@@ -203,9 +212,18 @@ function isStringLikeType(type: ResolvedProjectionField["type"]): boolean {
 	return false;
 }
 
+function isArrayType(type: Type): boolean {
+	return (
+		type.kind === "Model" &&
+		type.name === "Array" &&
+		type.indexer?.value !== undefined
+	);
+}
+
 export const __test = {
 	aggregationFieldName,
 	singularize,
 	capitalize,
 	isTextField,
+	isArrayType,
 };

--- a/src/emit-graphql-resolver.test.ts
+++ b/src/emit-graphql-resolver.test.ts
@@ -438,7 +438,7 @@ describe("emitGraphQLResolver", () => {
 		);
 		assert.ok(
 			combinedContent(result).includes(
-				'bySpecy: { terms: { field: "species" } }',
+				'bySpecies: { terms: { field: "species" } }',
 			),
 		);
 	});
@@ -514,8 +514,8 @@ describe("emitGraphQLResolver", () => {
 				"edges",
 				"totalCount",
 				"aggregations",
-				"aggregations/bySpecy",
-				"aggregations/bySpecy/key",
+				"aggregations/bySpecies",
+				"aggregations/bySpecies/key",
 			],
 		});
 		assert.ok(
@@ -524,8 +524,8 @@ describe("emitGraphQLResolver", () => {
 		);
 		const aggs = body.aggs as Record<string, unknown>;
 		assert.ok(
-			"bySpecy" in aggs,
-			`body.aggs.bySpecy must be present; got aggs=${JSON.stringify(aggs)}`,
+			"bySpecies" in aggs,
+			`body.aggs.bySpecies must be present; got aggs=${JSON.stringify(aggs)}`,
 		);
 	});
 
@@ -536,6 +536,11 @@ describe("emitGraphQLResolver", () => {
 					name: "locations",
 					keyword: true,
 					aggregations: ["cardinality"],
+					type: {
+						kind: "Model",
+						name: "Array",
+						indexer: { value: { kind: "Scalar", name: "string" } },
+					} as unknown as Type,
 				}),
 				makeField({
 					name: "description",
@@ -843,11 +848,21 @@ describe("emitGraphQLResolver", () => {
 					name: "tags",
 					keyword: true,
 					aggregations: ["terms"],
+					type: {
+						kind: "Model",
+						name: "Array",
+						indexer: { value: { kind: "Scalar", name: "string" } },
+					} as unknown as Type,
 				}),
 				makeField({
 					name: "locations",
 					keyword: true,
 					aggregations: ["cardinality"],
+					type: {
+						kind: "Model",
+						name: "Array",
+						indexer: { value: { kind: "Scalar", name: "string" } },
+					} as unknown as Type,
 				}),
 				makeField({
 					name: "description",

--- a/src/emit-graphql-sdl.test.ts
+++ b/src/emit-graphql-sdl.test.ts
@@ -610,6 +610,11 @@ describe("emitGraphQLSdl aggregations", () => {
 					name: "locations",
 					keyword: true,
 					aggregations: ["terms", "cardinality"],
+					type: {
+						kind: "Model",
+						name: "Array",
+						indexer: { value: { kind: "Scalar", name: "string" } },
+					} as unknown as Type,
 				}),
 			],
 		});
@@ -617,6 +622,32 @@ describe("emitGraphQLSdl aggregations", () => {
 		const result = emitGraphQLSdl(dummyProgram, projection, defaultOptions);
 		assert.ok(result.content.includes("byLocation: [TermBucket!]!"));
 		assert.ok(result.content.includes("uniqueLocationCount: Int!"));
+	});
+
+	it("preserves singular field names ending in 's' (status, address)", () => {
+		const projection = makeProjection({
+			name: "TradeSearchDoc",
+			fields: [
+				makeField({
+					name: "status",
+					keyword: true,
+					aggregations: ["terms"],
+					type: { kind: "Scalar", name: "string" } as unknown as Type,
+				}),
+				makeField({
+					name: "address",
+					keyword: true,
+					aggregations: ["terms"],
+					type: { kind: "Scalar", name: "string" } as unknown as Type,
+				}),
+			],
+		});
+
+		const result = emitGraphQLSdl(dummyProgram, projection, defaultOptions);
+		assert.ok(result.content.includes("byStatus: [TermBucket!]!"));
+		assert.ok(result.content.includes("byAddress: [TermBucket!]!"));
+		assert.ok(!result.content.includes("byStatu:"));
+		assert.ok(!result.content.includes("byAddres:"));
 	});
 });
 

--- a/test/example.js
+++ b/test/example.js
@@ -123,6 +123,16 @@ test("emits graphql aggregation types and resolver block", async () => {
 	assert.ok(sdl.includes("uniqueAliasCount: Int!"));
 	assert.ok(sdl.includes("missingNicknameCount: Int!"));
 	assert.ok(sdl.includes("aggregations: PetSearchAggregations!"));
+	// Singular scalar field whose name ends in 's' must keep the name verbatim
+	// (issue #119). Pet.species is a scalar string, not Pet.species: string[].
+	assert.ok(
+		sdl.includes("bySpecies: [TermBucket!]!"),
+		`expected bySpecies (preserved) in SDL; got:\n${sdl}`,
+	);
+	assert.ok(
+		!sdl.includes("bySpecy:"),
+		"emitter must not strip trailing 's' from singular fields",
+	);
 
 	// Aggs request shape lives in the prepare function; response mapping
 	// lives in the resolver after-mapping (pipeline split — issue #105).


### PR DESCRIPTION
Aggregation bucket names like \`byStatu\` were over-stripping the trailing \`s\` from singular fields; gates the strip on the source field being an array (preserves \`byTag\`/\`byApproval\`, fixes \`byStatus\`/\`byAddress\`/\`byProcess\`/\`bySpecies\`); closes #119.

**BREAKING.** Aggregation field names previously emitted as \`byStatu\`, \`byAddres\`, \`bySpecy\`, \`byProces\`, etc. are now \`byStatus\`, \`byAddress\`, \`bySpecies\`, \`byProcess\`. Consumers querying those fields must update GraphQL queries.