### PR TITLE
fix: @sortable on text field emits .keyword subfield in sort (closes #126)

### DIFF
--- a/src/emit-graphql-resolver.test.ts
+++ b/src/emit-graphql-resolver.test.ts
@@ -388,6 +388,148 @@ describe("emitGraphQLResolver", () => {
 		]);
 	});
 
+	it("buildSort suffixes .keyword on @sortable text fields, leaves keyword/numeric/date/boolean fields untouched (closes #126)", async () => {
+		// Matrix of sortable fields:
+		//   name           — text (string, no @keyword) → must sort on name.keyword
+		//   counterpartyId — keyword string             → sort on bare path
+		//   notional       — numeric                    → sort on bare path
+		//   validFrom      — date                       → sort on bare path
+		//   active         — boolean                    → sort on bare path
+		// OpenSearch rejects sort against a `text` field with
+		// UserIllegalArgumentException, so the resolver must target the
+		// `.keyword` subfield that emit-mapping always attaches to text fields.
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "name",
+					searchable: true,
+					type: { kind: "Scalar", name: "string" } as unknown as Type,
+				}),
+				makeField({
+					name: "counterpartyId",
+					keyword: true,
+					searchable: true,
+					type: { kind: "Scalar", name: "string" } as unknown as Type,
+				}),
+				makeField({
+					name: "notional",
+					searchable: true,
+					type: { kind: "Scalar", name: "float64" } as unknown as Type,
+				}),
+				makeField({
+					name: "validFrom",
+					searchable: true,
+					type: { kind: "Scalar", name: "utcDateTime" } as unknown as Type,
+				}),
+				makeField({
+					name: "active",
+					searchable: true,
+					type: { kind: "Scalar", name: "boolean" } as unknown as Type,
+				}),
+			],
+		});
+		// Mark all five sortable. makeField does not expose `sortable`, so set it
+		// directly on the field shape.
+		for (const f of projection.fields) {
+			(f as unknown as { sortable: boolean }).sortable = true;
+		}
+
+		const source = prepareFunctionContent(
+			await emitGraphQLResolver(projection, defaultOptions),
+		);
+		const stripped = source
+			.replace(/^import \{ util \} from "@aws-appsync\/utils";?\n?/m, "")
+			.replace(/^export function /gm, "function ");
+		const buildSort = new Function(`${stripped}\nreturn buildSort;`)() as (
+			sortBy: unknown,
+		) => unknown;
+
+		// text field → .keyword suffix
+		assert.deepEqual(buildSort([{ field: "name", direction: "ASC" }]), [
+			{ "name.keyword": "asc" },
+			{ _id: "asc" },
+		]);
+		// @keyword string → bare path
+		assert.deepEqual(
+			buildSort([{ field: "counterpartyId", direction: "DESC" }]),
+			[{ counterpartyId: "desc" }, { _id: "asc" }],
+		);
+		// numeric / date / boolean → bare path
+		assert.deepEqual(buildSort([{ field: "notional", direction: "DESC" }]), [
+			{ notional: "desc" },
+			{ _id: "asc" },
+		]);
+		assert.deepEqual(buildSort([{ field: "validFrom", direction: "ASC" }]), [
+			{ validFrom: "asc" },
+			{ _id: "asc" },
+		]);
+		assert.deepEqual(buildSort([{ field: "active", direction: "ASC" }]), [
+			{ active: "asc" },
+			{ _id: "asc" },
+		]);
+
+		// Multi-field sortBy: each entry routes independently.
+		assert.deepEqual(
+			buildSort([
+				{ field: "name", direction: "ASC" },
+				{ field: "notional", direction: "DESC" },
+				{ field: "counterpartyId", direction: "ASC" },
+			]),
+			[
+				{ "name.keyword": "asc" },
+				{ notional: "desc" },
+				{ counterpartyId: "asc" },
+				{ _id: "asc" },
+			],
+		);
+	});
+
+	it("buildSort emits monolithic mode also suffixes .keyword on text sort fields", async () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "name",
+					searchable: true,
+					type: { kind: "Scalar", name: "string" } as unknown as Type,
+				}),
+			],
+		});
+		(projection.fields[0] as unknown as { sortable: boolean }).sortable = true;
+
+		// Default options (no monolithicThresholdBytes override) → monolithic mode.
+		const result = await emitGraphQLResolver(projection, {
+			defaultPageSize: 20,
+			maxPageSize: 100,
+			trackTotalHitsUpTo: 10000,
+		});
+		assert.equal(result.mode, "monolithic");
+		// The TEXT_SORT_FIELDS literal must include "name", and the buildSort
+		// body must consult it.
+		assert.ok(result.content.includes('TEXT_SORT_FIELDS = ["name"]'));
+		assert.ok(result.content.includes('".keyword"'));
+	});
+
+	it("buildSort leaves text fields that aren't @sortable out of TEXT_SORT_FIELDS", async () => {
+		// A text field that's only @searchable (not @sortable) is still mapped
+		// as text+.keyword by emit-mapping, but it should NOT appear in
+		// TEXT_SORT_FIELDS — the GraphQL schema won't expose it as a sort
+		// option, and we don't want the resolver to silently rewrite a sort
+		// path the caller crafted by hand.
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "notes",
+					searchable: true,
+					type: { kind: "Scalar", name: "string" } as unknown as Type,
+				}),
+			],
+		});
+		// sortable left as false (default).
+
+		const result = await emitGraphQLResolver(projection, defaultOptions);
+		assert.ok(combinedContent(result).includes("TEXT_SORT_FIELDS = []"));
+	});
+
 	it("uses search_after for cursor pagination", async () => {
 		const projection = makeProjection({ fields: [] });
 		const result = await emitGraphQLResolver(projection, defaultOptions);

--- a/src/emit-graphql-resolver.ts
+++ b/src/emit-graphql-resolver.ts
@@ -88,6 +88,24 @@ export async function emitGraphQLResolver(
 		.filter((f) => f.searchable && f.keyword)
 		.map((f) => f.projectedName ?? f.name);
 
+	// Sortable fields that map to OpenSearch `text` (string, no @keyword,
+	// no nested, no sub-projection). OpenSearch refuses to sort on `text`
+	// — the request fails with `UserIllegalArgumentException: Text fields
+	// are not optimised for operations that require per-document field
+	// data ...`. The emit-mapping layer always adds a `.keyword` subfield
+	// for these (see emit-mapping.ts mapString), so the resolver suffixes
+	// `.keyword` on the sort target at runtime. Closes #126.
+	const textSortFields = projection.fields
+		.filter(
+			(f) =>
+				f.sortable &&
+				!f.keyword &&
+				!f.nested &&
+				!f.subProjection &&
+				hasTextType(f),
+		)
+		.map((f) => f.projectedName ?? f.name);
+
 	const aggregations = collectAggregations(projection);
 	const searchFilterShape = buildSearchFilterShape(projection);
 
@@ -101,6 +119,7 @@ export async function emitGraphQLResolver(
 	const monolithicContent = renderMonolithicResolver(
 		textFields,
 		keywordFields,
+		textSortFields,
 		aggregations,
 		searchFilterShape,
 		projection.indexName,
@@ -123,6 +142,7 @@ export async function emitGraphQLResolver(
 	const prepareContent = renderPrepareFunction(
 		textFields,
 		keywordFields,
+		textSortFields,
 		aggregations,
 		searchFilterShape,
 		options,
@@ -175,6 +195,7 @@ function hasTextType(field: ResolvedProjectionField): boolean {
 function renderMonolithicResolver(
 	textFields: string[],
 	keywordFields: string[],
+	textSortFields: string[],
 	aggregations: AggregationEntry[],
 	searchFilterShape: SearchFilterShape | undefined,
 	indexName: string,
@@ -182,6 +203,7 @@ function renderMonolithicResolver(
 ): string {
 	const textFieldsLiteral = JSON.stringify(textFields);
 	const keywordFieldsLiteral = JSON.stringify(keywordFields);
+	const textSortFieldsLiteral = JSON.stringify(textSortFields);
 	const aggsAssignment = renderAggsAssignment(aggregations, "\t");
 	const filterSpecLiteral = renderFilterSpecLiteral(searchFilterShape);
 	const slotsLiteral = `[${"null,".repeat(FILTER_WORK_SLOT_COUNT).slice(0, -1)}]`;
@@ -287,6 +309,8 @@ function buildQuery(queryText, filter, searchFilter) {
 	};
 }
 
+const TEXT_SORT_FIELDS = ${textSortFieldsLiteral};
+
 function buildSort(sortBy) {
 	const fallback = [{ _score: "desc" }, { _id: "asc" }];
 	if (!sortBy || sortBy.length === 0) {
@@ -296,7 +320,13 @@ function buildSort(sortBy) {
 	for (const entry of sortBy) {
 		if (entry && entry.field) {
 			const direction = entry.direction === "ASC" ? "asc" : "desc";
-			out.push({ [entry.field]: direction });
+			// OpenSearch refuses to sort on \`text\` fields. The emit-mapping
+			// layer always adds a \`.keyword\` subfield for sortable text
+			// fields, so target that subfield at runtime.
+			const target = TEXT_SORT_FIELDS.indexOf(entry.field) >= 0
+				? entry.field + ".keyword"
+				: entry.field;
+			out.push({ [target]: direction });
 		}
 	}
 	out.push({ _id: "asc" });
@@ -518,12 +548,14 @@ ${responseAggregationsPreamble}
 function renderPrepareFunction(
 	textFields: string[],
 	keywordFields: string[],
+	textSortFields: string[],
 	aggregations: AggregationEntry[],
 	searchFilterShape: SearchFilterShape | undefined,
 	options: ResolverOptions,
 ): string {
 	const textFieldsLiteral = JSON.stringify(textFields);
 	const keywordFieldsLiteral = JSON.stringify(keywordFields);
+	const textSortFieldsLiteral = JSON.stringify(textSortFields);
 	const aggsAssignment = renderAggsAssignment(aggregations, "\t");
 	const filterSpecLiteral = renderFilterSpecLiteral(searchFilterShape);
 	// `null` (4 chars) instead of `undefined` (9 chars) keeps the literal small
@@ -604,6 +636,8 @@ function buildQuery(queryText, filter, searchFilter) {
 	};
 }
 
+const TEXT_SORT_FIELDS = ${textSortFieldsLiteral};
+
 function buildSort(sortBy) {
 	const fallback = [{ _score: "desc" }, { _id: "asc" }];
 	if (!sortBy || sortBy.length === 0) {
@@ -613,7 +647,13 @@ function buildSort(sortBy) {
 	for (const entry of sortBy) {
 		if (entry && entry.field) {
 			const direction = entry.direction === "ASC" ? "asc" : "desc";
-			out.push({ [entry.field]: direction });
+			// OpenSearch refuses to sort on \`text\` fields. The emit-mapping
+			// layer always adds a \`.keyword\` subfield for sortable text
+			// fields, so target that subfield at runtime.
+			const target = TEXT_SORT_FIELDS.indexOf(entry.field) >= 0
+				? entry.field + ".keyword"
+				: entry.field;
+			out.push({ [target]: direction });
 		}
 	}
 	// Always tie-break on _id for stable cursor pagination.


### PR DESCRIPTION
## Symptom

OpenSearch rejects the search request with:

```
UserIllegalArgumentException: Text fields are not optimised for operations that require per-document field data like aggregations and sorting, so these operations are disabled by default. Please use a keyword field instead.
```

…whenever a `@sortable` TypeSpec field maps to OS `text` (string, no `@keyword`). The generated resolver emits `{ [field]: direction }` straight from the GraphQL arg.

## Root cause

`emit-mapping` always attaches a `.keyword` subfield to text strings, but `buildSort` in the emitted resolver wasn't aware of which sortable fields are text-mapped.

## Fix

Emit a per-projection `TEXT_SORT_FIELDS` literal (sortable && string && !keyword && !nested && !subProjection) and have `buildSort` suffix `.keyword` for entries that hit it. `@keyword` strings, numerics, dates, and booleans keep their bare paths. Applies to both monolithic and pipeline resolver shapes.

## Test coverage

- text field `name` -> `name.keyword`
- `@keyword` string, numeric, date, boolean -> bare path
- multi-field `sortBy` routes each entry independently
- monolithic mode also renders `TEXT_SORT_FIELDS`
- non-sortable text field stays out of `TEXT_SORT_FIELDS`

## Downstream

- stxcommodities/core-services#1392 — surfaced this from a CP360 / TLS search backend.
- stxcommodities/core-services#1393 — closed; that one tried to fix it at the TypeSpec layer, but the right cut is here in the emitter.