### PR TITLE
fix: declare repository in package.json for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
 	"description": "TypeSpec emitter for OpenSearch projections",
 	"type": "module",
 	"main": "dist/index.js",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/kattebak/typespec-opensearch-emitter.git"
+	},
 	"publishConfig": {
 		"access": "public"
 	},


### PR DESCRIPTION
The 1.26.1 publish from #128 was rejected by npm:

> Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: \`repository.url\` is "", expected to match `https://github.com/kattebak/typespec-opensearch-emitter`

With trusted publishing, npm verifies the package's declared repo matches the one in the provenance bundle from GitHub Actions. Adding the missing `repository` field unblocks the release.

This also re-runs the still-unreleased patch from #127.