### PR TITLE
fix(emitter): fail loud on SearchFilter name collisions, not silent drop (closes #132)

### DIFF
--- a/src/emit-graphql-sdl.test.ts
+++ b/src/emit-graphql-sdl.test.ts
@@ -99,6 +99,27 @@ const dummyProgram = {
 } as never;
 const defaultOptions = { defaultPageSize: 20, maxPageSize: 100 };
 
+// reportDiagnostic(program, ...) ultimately calls program.reportDiagnostic(diag)
+// (see @typespec/compiler diagnostic-creator). The stub program above never
+// supplies that method because the non-collision paths never report — so for
+// the collision tests use a program that captures diagnostics into an array.
+function makeCapturingProgram(): {
+	program: never;
+	diagnostics: { code: string }[];
+} {
+	const diagnostics: { code: string }[] = [];
+	const program = {
+		stateMap: () => ({
+			get: () => undefined,
+			has: () => false,
+		}),
+		reportDiagnostic: (diag: { code: string }) => {
+			diagnostics.push(diag);
+		},
+	} as never;
+	return { program, diagnostics };
+}
+
 describe("emitGraphQLSdl", () => {
 	it("generates object type from projection fields", () => {
 		const projection = makeProjection({
@@ -710,6 +731,83 @@ describe("emitGraphQLSdl SearchFilter input", () => {
 			addressInputCount,
 			1,
 			"AddressSearchFilter must be declared exactly once in the SDL",
+		);
+	});
+
+	it("reports no diagnostic for the identical-shape-via-two-paths case (#103)", () => {
+		// Same shape as the #103 test, but assert the content-aware dedup does
+		// not mistake the legitimate same-block case for a collision.
+		const addressSub = {
+			projectionModel: { name: "AddressSearchDoc" },
+			sourceModel: { name: "Address" },
+			indexName: "addresses",
+			fields: [
+				makeField({ name: "country", keyword: true, filterables: ["term"] }),
+			],
+		} as unknown as ResolvedProjection;
+
+		const projection = makeProjection({
+			name: "CounterpartySearchDoc",
+			fields: [
+				makeField({
+					name: "homeAddress",
+					subProjection: addressSub,
+					type: { kind: "Model" } as unknown as Type,
+				}),
+				makeField({
+					name: "billingAddress",
+					subProjection: addressSub,
+					type: { kind: "Model" } as unknown as Type,
+				}),
+			],
+		});
+
+		const { program, diagnostics } = makeCapturingProgram();
+		emitGraphQLSdl(program, projection, defaultOptions);
+		assert.equal(
+			diagnostics.length,
+			0,
+			"identical shape via two paths must dedup silently, not report a collision",
+		);
+	});
+
+	it("fails loud when two different shapes collide on one SearchFilter input name", () => {
+		// Mirrors the real COS failure: a document `CounterpartySearchDoc` with a
+		// non-@nested struct field `counterparty: Counterparty`. The document
+		// projection yields `CounterpartySearchFilter`, and the nested
+		// `Counterparty` struct's filter name is also `CounterpartySearchFilter`
+		// — but with a different shape. Name-only dedup would silently drop one;
+		// content-aware dedup must report a collision instead.
+		const counterpartyStruct = {
+			projectionModel: { name: "Counterparty" },
+			sourceModel: { name: "Counterparty" },
+			indexName: "",
+			// Distinct field set from the document root below.
+			fields: [
+				makeField({ name: "legalName", keyword: true, filterables: ["term"] }),
+			],
+		} as unknown as ResolvedProjection;
+
+		const projection = makeProjection({
+			name: "CounterpartySearchDoc",
+			fields: [
+				// Root-level filterable → document filter name CounterpartySearchFilter.
+				makeField({ name: "status", keyword: true, filterables: ["term"] }),
+				// Non-@nested struct field whose model is `Counterparty` →
+				// CounterpartySearchFilter, with a different shape.
+				makeField({
+					name: "counterparty",
+					subProjection: counterpartyStruct,
+					type: { kind: "Model" } as unknown as Type,
+				}),
+			],
+		});
+
+		const { program, diagnostics } = makeCapturingProgram();
+		emitGraphQLSdl(program, projection, defaultOptions);
+		assert.ok(
+			diagnostics.some((d) => d.code.endsWith("searchfilter-name-collision")),
+			"a genuine SearchFilter name collision must report searchfilter-name-collision",
 		);
 	});
 

--- a/src/emit-graphql-sdl.ts
+++ b/src/emit-graphql-sdl.ts
@@ -1,4 +1,11 @@
-import type { Model, Program, Scalar, Type, Union } from "@typespec/compiler";
+import {
+	type Model,
+	NoTarget,
+	type Program,
+	type Scalar,
+	type Type,
+	type Union,
+} from "@typespec/compiler";
 import {
 	type AggregationEntry,
 	aggregationsTypeName,
@@ -15,6 +22,7 @@ import {
 	type FilterSpecNode,
 	type SearchFilterShape,
 } from "./filters.js";
+import { reportDiagnostic } from "./lib.js";
 import type {
 	ResolvedProjection,
 	ResolvedProjectionField,
@@ -274,12 +282,17 @@ function renderSearchFilterInputs(
 	shape: SearchFilterShape,
 ): string {
 	const blocks: string[] = [];
-	// Dedup `<Type>SearchFilter` declarations by typeName (issue #103). The
-	// same nested shape can be reachable via multiple paths in the recursion
-	// graph; without dedup the SDL ends up with two `input X { ... }` blocks
-	// for the same X, which is ill-formed.
-	const seen = new Set<string>();
-	renderSearchFilterShapeRecursive(program, shape, blocks, seen);
+	// Dedup `<Type>SearchFilter` declarations by their *rendered content*, not
+	// just by typeName (issue #103, #132). The same nested shape reached via
+	// multiple paths (e.g. `homeAddress` and `billingAddress` both →
+	// `AddressSearchFilter`) renders an identical block — emit it once. But
+	// `searchFilterTypeName` is not injective: a document `XSearchDoc` and a
+	// nested struct `X` both map to `XSearchFilter` while having *different*
+	// shapes. Deduping by name alone silently drops the second shape and leaves
+	// the parent field self-referencing; comparing rendered blocks lets the
+	// legitimate same-shape case dedup while a genuine collision fails loud.
+	const emitted = new Map<string, string>();
+	renderSearchFilterShapeRecursive(program, shape, blocks, emitted);
 	return blocks.join("\n\n");
 }
 
@@ -287,13 +300,27 @@ function renderSearchFilterShapeRecursive(
 	program: Program,
 	shape: SearchFilterShape,
 	out: string[],
-	seen: Set<string>,
+	emitted: Map<string, string>,
 ): void {
-	if (seen.has(shape.typeName)) return;
-	seen.add(shape.typeName);
-	out.push(renderSearchFilterInputBlock(program, shape));
+	const block = renderSearchFilterInputBlock(program, shape);
+	const prior = emitted.get(shape.typeName);
+	if (prior !== undefined) {
+		// Same rendered block ⇒ same shape via two paths (#103): dedup silently
+		// and don't recurse again. A different block ⇒ two distinct shapes claim
+		// one input name — ill-formed SDL, so fail loud and stop this branch.
+		if (prior !== block) {
+			reportDiagnostic(program, {
+				code: "searchfilter-name-collision",
+				format: { typeName: shape.typeName },
+				target: shape.target ?? NoTarget,
+			});
+		}
+		return;
+	}
+	emitted.set(shape.typeName, block);
+	out.push(block);
 	for (const sub of shape.nestedShapes) {
-		renderSearchFilterShapeRecursive(program, sub, out, seen);
+		renderSearchFilterShapeRecursive(program, sub, out, emitted);
 	}
 }
 

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -1,3 +1,4 @@
+import type { Model } from "@typespec/compiler";
 import type { FilterableKind } from "./decorators.js";
 import type {
 	ResolvedProjection,
@@ -238,6 +239,13 @@ export interface SearchFilterShape {
 	nodes: FilterSpecNode[];
 	/** Sub-projection filter shapes that should also be emitted as input types. */
 	nestedShapes: SearchFilterShape[];
+	/**
+	 * Source model this shape was built from — the diagnostic target when two
+	 * structurally-different shapes collide on the same `typeName`
+	 * (searchfilter-name-collision). Optional because hand-built test shapes and
+	 * stubbed projections may not carry a real Model.
+	 */
+	target?: Model;
 }
 
 export function buildSearchFilterShape(
@@ -300,6 +308,7 @@ function buildShapeRecursive(
 							typeName: nestedTypeName,
 							nodes: subShape.nodes,
 							nestedShapes: subShape.nestedShapes,
+							target: field.subProjection.projectionModel,
 						});
 					}
 				} else {
@@ -326,6 +335,7 @@ function buildShapeRecursive(
 							typeName: subTypeName,
 							nodes: subShape.nodes,
 							nestedShapes: subShape.nestedShapes,
+							target: field.subProjection.projectionModel,
 						});
 					}
 				}
@@ -337,6 +347,7 @@ function buildShapeRecursive(
 		typeName: searchFilterTypeName(projection.projectionModel.name),
 		nodes,
 		nestedShapes,
+		target: projection.projectionModel,
 	};
 }
 

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -118,6 +118,12 @@ export const $lib = createTypeSpecLibrary({
 					"Decorator @filterable requires at least one filter kind argument.",
 			},
 		},
+		"searchfilter-name-collision": {
+			severity: "error",
+			messages: {
+				default: paramMessage`Two different SearchFilter shapes both resolve to the GraphQL input name "${"typeName"}". This happens when a projection and one of its nested struct models share a base name (e.g. a document "XSearchDoc" with a nested "x: X" field both map to "XSearchFilter"). Rename the nested model (e.g. "XSummary", emitting "XSummarySearchFilter") so each shape gets a distinct input name.`,
+			},
+		},
 	},
 	state: {
 		searchable: { description: "Marks a property as searchable" },


### PR DESCRIPTION
## What

The `#103` dedup collapsed `<Type>SearchFilter` input declarations by **name only**. `searchFilterTypeName` is not injective — a document `XSearchDoc` and a nested struct model `X` both map to `XSearchFilter`. When their shapes differ, the second was **silently dropped** and the parent field left self-referencing: ill-formed SDL, no error.

Real trigger (COS): `CounterpartySearchDoc is SearchProjection<DescribeCounterparty>` with a non-`@nested` `counterparty: Counterparty` field. The nested scalar filters (`counterpartyId`/`createdAt`/`updatedAt`) never emitted and `counterparty` pointed at the document input itself.

## Fix

Make the dedup **content-aware** (`Map<typeName, renderedBlock>`):
- identical rendered block on recurrence → legitimate same-shape-via-two-paths (`AddressSearchFilter` from `homeAddress`+`billingAddress`, the original #103 case) → dedup silently.
- differing block → genuine collision → report new `searchfilter-name-collision` **error** naming the offending model, telling the author to give the nested model a distinct name (the `TradeSummary` pattern).

Converts silent SDL corruption into a build failure.

## Tests

- collision case (COS `Counterparty`) reports `searchfilter-name-collision`
- identical-shape-via-two-paths (#103) reports **zero** diagnostics — regression guard for the legit dedup

Full suite green: build + lint + 294 unit + emit + 11 example.

Closes #132.