### PR TITLE
fix(rest): int64 fields must not map to GraphQL Int (closes #138)

### DIFF
--- a/src/emit-rest-sdl.test.ts
+++ b/src/emit-rest-sdl.test.ts
@@ -132,6 +132,66 @@ describe("emitRestSdl", () => {
 		assert.ok(!content.includes("ID"));
 	});
 
+	it("maps int64 to Float in object, input, and arg positions to avoid 32-bit Int overflow (issue #138)", async () => {
+		const { runner, resolved } = await resolveFixture(`
+      model Pet {
+        petId: string;
+        createdAt: int64;
+      }
+
+      model CreatePetInput {
+        createdAt: int64;
+      }
+
+      @route("/pets")
+      namespace Pets {
+        @restResolver @get op getPet(@path petId: string): Pet;
+        @restResolver @post op createPet(@body input: CreatePetInput): Pet;
+        @restResolver @get op listPets(@query since?: int64): Pet[];
+      }
+    `);
+		const [{ content }] = emitRestSdl(runner.program, resolved);
+
+		assert.ok(
+			content.includes("type Pet {\n  petId: String!\n  createdAt: Float!\n}"),
+		);
+		assert.ok(
+			content.includes("input CreatePetInput {\n  createdAt: Float!\n}"),
+		);
+		assert.ok(content.includes("listPets(since: Float): [Pet!]"));
+	});
+
+	it("maps safeint to Float like int64 (issue #138)", async () => {
+		const { runner, resolved } = await resolveFixture(`
+      model Pet { count: safeint; }
+
+      @route("/pets")
+      namespace Pets {
+        @restResolver @get op getPet(@path petId: string): Pet;
+      }
+    `);
+		const [{ content }] = emitRestSdl(runner.program, resolved);
+
+		assert.ok(content.includes("type Pet {\n  count: Float!\n}"));
+	});
+
+	it("keeps int32 and integer as Int — only 64-bit-capable scalars are remapped (issue #138)", async () => {
+		const { runner, resolved } = await resolveFixture(`
+      model Pet {
+        age: int32;
+        weight: integer;
+      }
+
+      @route("/pets")
+      namespace Pets {
+        @restResolver @get op getPet(@path petId: string): Pet;
+      }
+    `);
+		const [{ content }] = emitRestSdl(runner.program, resolved);
+
+		assert.ok(content.includes("type Pet {\n  age: Int!\n  weight: Int!\n}"));
+	});
+
 	it("renders required @query params with a bang", async () => {
 		const { runner, resolved } = await resolveFixture(`
       model Pet { petId: string; }

--- a/src/emit-rest-sdl.ts
+++ b/src/emit-rest-sdl.ts
@@ -182,7 +182,7 @@ function restTypeRef(
 		registerModel(program, type, registry, position);
 		return type.name;
 	}
-	return toGraphQLType(program, type);
+	return toGraphQLType(program, type, undefined, "rest");
 }
 
 function registerModel(

--- a/src/graphql-types.ts
+++ b/src/graphql-types.ts
@@ -7,7 +7,7 @@ import type { ResolvedProjectionField } from "./projection.js";
  * same scalar/model mapping without touching the OpenSearch search path.
  */
 
-export type GraphQLEmitContext = "response" | "filter";
+export type GraphQLEmitContext = "response" | "filter" | "rest";
 
 export function toGraphQLType(
 	program: Program,
@@ -58,10 +58,18 @@ function scalarToGraphQL(scalar: Scalar, context: GraphQLEmitContext): string {
 				// can serialize the 64-bit value as a numeric string. Response types
 				// keep Int for backward compatibility (a separate concern, since the
 				// resolver-side serialization path is already constrained by AppSync).
+				// The REST target maps to Float (issue #138): AppSync rejects values
+				// > 2^31-1 during response coercion, and Float (IEEE double) is exact
+				// for integers up to 2^53 — fine for epoch-ms timestamps.
+				if (context === "rest") return "Float";
 				return context === "filter" ? "String" : "Int";
+			case "safeint":
+				// safeint spans up to 2^53, which also overflows GraphQL's 32-bit Int.
+				// The REST target maps it to Float (issue #138); the OpenSearch paths
+				// keep Int unchanged.
+				return context === "rest" ? "Float" : "Int";
 			case "int32":
 			case "integer":
-			case "safeint":
 			case "uint8":
 			case "uint16":
 			case "uint32":

--- a/test/petstore/main.tsp
+++ b/test/petstore/main.tsp
@@ -8,6 +8,7 @@ model Pet {
 	petId: string;
 	name: string;
 	status: PetStatus;
+	createdAt: int64;
 }
 
 enum PetStatus {
@@ -19,6 +20,7 @@ enum PetStatus {
 model CreatePetInput {
 	name: string;
 	status: PetStatus;
+	createdAt: int64;
 }
 
 @route("/pets")

--- a/test/snapshots/petstore/pet.graphql
+++ b/test/snapshots/petstore/pet.graphql
@@ -2,6 +2,7 @@ type Pet {
   petId: String!
   name: String!
   status: PetStatus!
+  createdAt: Float!
 }
 
 enum PetStatus {
@@ -13,6 +14,7 @@ enum PetStatus {
 input CreatePetInput {
   name: String!
   status: PetStatus!
+  createdAt: Float!
 }
 
 type Query {


### PR DESCRIPTION
GraphQL Int is 32-bit, so int64 fields like epoch-ms timestamps overflow at runtime — AppSync rejects values above 2^31-1 during response coercion.

The REST target now maps `int64` and `safeint` to `Float` (IEEE double, exact for integers up to 2^53) in object, input, and argument positions. `int32`/`integer` stay `Int`. The OpenSearch SDL path is untouched; its output is byte-identical.

`uint64` is also remapped: the issue names int64/safeint, but uint64 shares the same mapping case and the same overflow, so leaving it on Int would be inconsistent. Flagging in case that should stay out of scope.

Closes #138