### PR TITLE
fix(rest): rest-only package emits artifact-only package.json, no tsconfig

### DIFF
--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -257,6 +257,10 @@ export async function $onEmit(
 		// don't merit a separate exports entry. The fragment is still needed,
 		// though — track it via `nestedOnly` so the .graphql file gets exported.
 		const graphqlArtifacts = graphqlOptions?.emit ? topLevel : undefined;
+		// Rest-only emit (issue #143): no projections means no doc types and no
+		// index.ts barrel, so the package must not point at an entrypoint or
+		// run tsc on publish — and there is nothing for a tsconfig to compile.
+		const restOnly = projectionModels.length === 0;
 		const packageJsonContent = generatePackageJson(
 			packageName,
 			packageVersion,
@@ -270,17 +274,20 @@ export async function $onEmit(
 						...restResolverFiles.map((file) => file.fileName),
 					]
 				: undefined,
+			restOnly,
 		);
 		await emitFile(context.program, {
 			path: resolvePath(context.emitterOutputDir, "package.json"),
 			content: packageJsonContent,
 		});
 
-		const tsConfigContent = generateTsConfig(resolved);
-		await emitFile(context.program, {
-			path: resolvePath(context.emitterOutputDir, "tsconfig.json"),
-			content: tsConfigContent,
-		});
+		if (!restOnly) {
+			const tsConfigContent = generateTsConfig(resolved);
+			await emitFile(context.program, {
+				path: resolvePath(context.emitterOutputDir, "tsconfig.json"),
+				content: tsConfigContent,
+			});
+		}
 	}
 }
 
@@ -501,6 +508,7 @@ function generatePackageJson(
 	resolverFiles?: EmittedResolverFile[],
 	nestedOnlyGraphqlProjections?: ResolvedProjection[],
 	restArtifactFileNames?: string[],
+	restOnly = false,
 ): string {
 	const artifactExports: Record<string, string> = {};
 
@@ -557,6 +565,19 @@ function generatePackageJson(
 	const sorted = Object.fromEntries(
 		Object.entries(artifactExports).sort(([a], [b]) => a.localeCompare(b)),
 	);
+
+	// Rest-only package (issue #143): SDL / resolver / manifest artifacts only —
+	// no index.ts entrypoint exists, so no main/types/"." export and no tsc run.
+	if (restOnly) {
+		const restPackageJson = {
+			name: packageName,
+			version: packageVersion,
+			type: "module" as const,
+			exports: sorted,
+		};
+
+		return `${JSON.stringify(restPackageJson, null, 2)}\n`;
+	}
 
 	const packageJson = {
 		name: packageName,

--- a/test/petstore/tspconfig.yaml
+++ b/test/petstore/tspconfig.yaml
@@ -3,6 +3,8 @@ emit:
 options:
   "@kattebak/typespec-opensearch-emitter":
     emitter-output-dir: "{cwd}/build/petstore-emit"
+    package-name: "@kattebak/petstore-rest"
+    package-version: "0.0.1"
     graphql:
       emit: true
     rest:

--- a/test/rest-example.js
+++ b/test/rest-example.js
@@ -117,3 +117,20 @@ test("generated resolvers contain no async or disallowed globals (APPSYNC_JS)", 
 		);
 	}
 });
+
+test("rest-only package.json carries artifacts only — no entrypoint, no tsc (issue #143)", async () => {
+	const packageJson = JSON.parse(
+		await readFile(`${EMIT_DIR}/package.json`, "utf8"),
+	);
+
+	assert.equal(packageJson.name, "@kattebak/petstore-rest");
+	assert.ok(!("main" in packageJson));
+	assert.ok(!("types" in packageJson));
+	assert.ok(!("scripts" in packageJson));
+	assert.ok(!("devDependencies" in packageJson));
+	assert.ok(!("." in packageJson.exports));
+
+	const emittedFiles = await readdir(EMIT_DIR);
+	assert.ok(!emittedFiles.includes("tsconfig.json"));
+	assert.ok(!emittedFiles.includes("index.ts"));
+});

--- a/test/snapshots/petstore/package.json
+++ b/test/snapshots/petstore/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@kattebak/petstore-rest",
+  "version": "0.0.1",
+  "type": "module",
+  "exports": {
+    "./graphql-resolvers.js": "./graphql-resolvers.js",
+    "./graphql-resolvers.json": "./graphql-resolvers.json",
+    "./Mutation.createPet.js": "./Mutation.createPet.js",
+    "./pet.graphql": "./pet.graphql",
+    "./Query.getPet.js": "./Query.getPet.js",
+    "./Query.listPets.js": "./Query.listPets.js"
+  }
+}


### PR DESCRIPTION
Closes #143.

A rest-only spec (only `@restResolver` operations, no `SearchProjection` models) has no doc types and no `index.ts` barrel, but the generated `package.json` still pointed `main`/`types`/the `"."` export at `index.js` and ran `tsc` on `prepare`, and a `tsconfig.json` with `include: ["index.ts"]` was emitted. `npm publish` of such a package fails (TS18003: no inputs).

Rest-only packages now emit:

```json
{
  "name": "@kattebak/petstore-rest",
  "version": "0.0.1",
  "type": "module",
  "exports": {
    "./pet.graphql": "./pet.graphql",
    "./Query.getPet.js": "./Query.getPet.js",
    ...
  }
}
```

and no `tsconfig.json`. Mixed specs (projections + rest ops) are unchanged.

- Petstore fixture now sets `package-name`/`package-version`, so the snapshot covers the rest-only `package.json`.
- New test asserts no entrypoint/scripts/devDependencies and no `tsconfig.json`/`index.ts` in the emit dir.
- Full suite: 341 unit + snapshot/example tests pass.