### PR TITLE
fix(rest): map Record<T> to AWSJSON scalar

### DIFF
--- a/src/emit-rest-sdl.test.ts
+++ b/src/emit-rest-sdl.test.ts
@@ -192,6 +192,25 @@ describe("emitRestSdl", () => {
 		assert.ok(content.includes("type Pet {\n  age: Int!\n  weight: Int!\n}"));
 	});
 
+	it("maps Record<T> properties to AWSJSON scalar (issue #141)", async () => {
+		const { runner, resolved } = await resolveFixture(`
+      model Pet {
+        petId: string;
+        metadata: Record<unknown>;
+      }
+
+      @route("/pets")
+      namespace Pets {
+        @restResolver @get op getPet(@path petId: string): Pet;
+      }
+    `);
+		const [{ content }] = emitRestSdl(runner.program, resolved);
+
+		assert.ok(content.includes("  metadata: AWSJSON!"));
+		// Record should not be emitted as a named type
+		assert.ok(!content.includes("type Record"));
+	});
+
 	it("renders required @query params with a bang", async () => {
 		const { runner, resolved } = await resolveFixture(`
       model Pet { petId: string; }

--- a/src/emit-rest-sdl.ts
+++ b/src/emit-rest-sdl.ts
@@ -178,6 +178,14 @@ function restTypeRef(
 		);
 		return `[${element}!]`;
 	}
+	if (
+		type.kind === "Model" &&
+		type.name === "Record" &&
+		type.indexer?.value &&
+		type.properties.size === 0
+	) {
+		return "AWSJSON";
+	}
 	if (type.kind === "Model" && type.name) {
 		registerModel(program, type, registry, position);
 		return type.name;


### PR DESCRIPTION
Record<T> template instances have an indexer and no own properties. In
restTypeRef they were falling through to the named-model branch, which
registered them and emitted an empty `type Record {}` block — invalid GraphQL.

The fix detects Record the same way Array is already detected (name === "Record",
has indexer, no own properties) and returns the `AWSJSON` scalar instead.

closes #141