### PR TITLE
feat(rest): add resourcePathPrefix option

### DIFF
--- a/src/emit-rest-resolver.test.ts
+++ b/src/emit-rest-resolver.test.ts
@@ -89,6 +89,29 @@ describe("emitRestResolver request rendering", () => {
 		assert.ok(!content.includes("query: {"));
 		assert.ok(!content.includes("JSON.stringify"));
 	});
+
+	it("prepends resourcePathPrefix to path params template literal (issue #140)", () => {
+		const { content } = emitRestResolver(getPet, {
+			resourcePathPrefix: "/api/v1",
+		});
+		assert.ok(
+			content.includes(
+				"resourcePath: `/api/v1/pets/${util.urlEncode(ctx.args.petId)}`",
+			),
+		);
+	});
+
+	it("prepends resourcePathPrefix to plain string resourcePath (issue #140)", () => {
+		const { content } = emitRestResolver(createPet, {
+			resourcePathPrefix: "/api/v1",
+		});
+		assert.ok(content.includes('resourcePath: "/api/v1/pets"'));
+	});
+
+	it("leaves resourcePath unchanged when no prefix given (issue #140)", () => {
+		const { content } = emitRestResolver(createPet);
+		assert.ok(content.includes('resourcePath: "/pets"'));
+	});
 });
 
 describe("emitRestResolver header injection", () => {

--- a/src/emit-rest-resolver.ts
+++ b/src/emit-rest-resolver.ts
@@ -20,6 +20,11 @@ export interface RestResolverOptions {
 	 * through to `Http<status>`.
 	 */
 	errorMap?: Record<string, string>;
+	/**
+	 * Literal path segment prepended to every generated `resourcePath`.
+	 * Must start with `/` and must not end with `/`. Issue #140.
+	 */
+	resourcePathPrefix?: string;
 }
 
 export interface EmittedRestResolverFile {
@@ -49,7 +54,7 @@ export function emitRestResolver(
 		"",
 		renderBaseHeaders(options.injectHeaders),
 		"",
-		renderRequest(op),
+		renderRequest(op, options.resourcePathPrefix),
 		"",
 		"export function response(ctx) {",
 		"\treturn mapResponse(ctx);",
@@ -85,7 +90,10 @@ function renderBaseHeaders(injectHeaders?: Record<string, string>): string {
 	return ["const BASE_HEADERS = (ctx) => ({", ...lines, "});"].join("\n");
 }
 
-function renderRequest(op: RestOperationShape): string {
+function renderRequest(
+	op: RestOperationShape,
+	resourcePathPrefix?: string,
+): string {
 	const paramsLines: string[] = ["\t\t\theaders: BASE_HEADERS(ctx),"];
 	if (op.queryParams.length > 0) {
 		paramsLines.push("\t\t\tquery: {");
@@ -109,7 +117,7 @@ function renderRequest(op: RestOperationShape): string {
 		"export function request(ctx) {",
 		"\treturn {",
 		`\t\tmethod: "${op.httpMethod}",`,
-		`\t\tresourcePath: ${renderResourcePath(op)},`,
+		`\t\tresourcePath: ${renderResourcePath(op, resourcePathPrefix)},`,
 		params,
 		"\t};",
 		"}",
@@ -119,17 +127,22 @@ function renderRequest(op: RestOperationShape): string {
 /**
  * Route template → JS expression. Each `{param}` placeholder becomes
  * `${util.urlEncode(ctx.args.<param>)}` inside a template literal; routes
- * without path params render as a plain string literal.
+ * without path params render as a plain string literal. An optional
+ * `resourcePathPrefix` is prepended verbatim. Issue #140.
  */
-function renderResourcePath(op: RestOperationShape): string {
+function renderResourcePath(
+	op: RestOperationShape,
+	resourcePathPrefix?: string,
+): string {
+	const prefix = resourcePathPrefix ?? "";
 	if (op.pathParams.length === 0) {
-		return `"${op.path}"`;
+		return `"${prefix}${op.path}"`;
 	}
 	const interpolated = op.path.replace(
 		/\{([^}]+)\}/g,
 		(_match, name: string) => `\${util.urlEncode(ctx.args.${name})}`,
 	);
-	return `\`${interpolated}\``;
+	return `\`${prefix}${interpolated}\``;
 }
 
 /**

--- a/src/emitter.test.ts
+++ b/src/emitter.test.ts
@@ -527,6 +527,48 @@ describe("generateRestManifestEntries (issue #134)", () => {
 		);
 		assert.equal(withUndefined, withEmpty);
 	});
+
+	it("prepends resourcePathPrefix to resourcePath in manifest entries (issue #140)", () => {
+		const entries = __test.generateRestManifestEntries(
+			[getPet],
+			undefined,
+			"/api/v1",
+		);
+		assert.equal(entries[0].resourcePath, "/api/v1/pets/{petId}");
+	});
+
+	it("leaves resourcePath unchanged when no prefix given (default behavior)", () => {
+		const entries = __test.generateRestManifestEntries([getPet]);
+		assert.equal(entries[0].resourcePath, "/pets/{petId}");
+	});
+});
+
+describe("validateResourcePathPrefix (issue #140)", () => {
+	it("returns undefined when prefix is undefined", () => {
+		assert.equal(__test.validateResourcePathPrefix(undefined), undefined);
+	});
+
+	it("returns undefined when prefix is empty string", () => {
+		assert.equal(__test.validateResourcePathPrefix(""), undefined);
+	});
+
+	it("returns the prefix when valid", () => {
+		assert.equal(__test.validateResourcePathPrefix("/api/v1"), "/api/v1");
+	});
+
+	it("throws when prefix does not start with /", () => {
+		assert.throws(
+			() => __test.validateResourcePathPrefix("api/v1"),
+			/must start with "\/"/,
+		);
+	});
+
+	it("throws when prefix ends with /", () => {
+		assert.throws(
+			() => __test.validateResourcePathPrefix("/api/v1/"),
+			/must not end with "\/"/,
+		);
+	});
 });
 
 describe("isTemplateDeclaration", () => {

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -211,6 +211,9 @@ export async function $onEmit(
 		// only; with no @restResolver operations these loops are no-ops and the
 		// manifest stays byte-identical to the OpenSearch-only emit.
 		const restOptions = context.options.rest;
+		const resourcePathPrefix = validateResourcePathPrefix(
+			restOptions?.resourcePathPrefix,
+		);
 		const restResolved = restOperations.map((operation) =>
 			resolveRestOperation(context.program, operation),
 		);
@@ -225,6 +228,7 @@ export async function $onEmit(
 			const restResolverFile = emitRestResolver(restOperation, {
 				injectHeaders: restOptions?.injectHeaders,
 				errorMap: restOptions?.errorMap,
+				resourcePathPrefix,
 			});
 			restResolverFiles.push(restResolverFile);
 			await emitFile(context.program, {
@@ -237,7 +241,11 @@ export async function $onEmit(
 			topLevel,
 			resolverFiles,
 			queryFieldDirectivesByProjection,
-			generateRestManifestEntries(restResolved, restOptions?.dataSourceName),
+			generateRestManifestEntries(
+				restResolved,
+				restOptions?.dataSourceName,
+				resourcePathPrefix,
+			),
 		);
 		await emitFile(context.program, {
 			path: resolvePath(context.emitterOutputDir, "graphql-resolvers.json"),
@@ -377,17 +385,37 @@ function serializeProjections(resolved: ResolvedProjection[]) {
 function generateRestManifestEntries(
 	restOperations: ResolvedRestOperation[],
 	dataSourceName?: string,
+	resourcePathPrefix?: string,
 ): RestManifestEntry[] {
+	const prefix = resourcePathPrefix ?? "";
 	return restOperations.map((op) => ({
 		typeName: op.typeName,
 		fieldName: op.fieldName,
 		dataSource: dataSourceName ?? "HTTP",
 		httpMethod: op.httpMethod,
-		resourcePath: op.path,
+		resourcePath: `${prefix}${op.path}`,
 		mode: "monolithic",
 		resolverFile: restResolverFileName(op),
 		sdlFile: restSdlFileName(op),
 	}));
+}
+
+/**
+ * Validates `rest.resourcePathPrefix` (issue #140). Must start with `/` and
+ * must not end with `/`. Returns the validated string, or `undefined` when
+ * no prefix is configured (preserves current behavior).
+ */
+function validateResourcePathPrefix(prefix?: string): string | undefined {
+	if (prefix === undefined || prefix === "") return undefined;
+	if (!prefix.startsWith("/")) {
+		throw new Error(`rest.resourcePathPrefix "${prefix}" must start with "/"`);
+	}
+	if (prefix.endsWith("/")) {
+		throw new Error(
+			`rest.resourcePathPrefix "${prefix}" must not end with "/"`,
+		);
+	}
+	return prefix;
 }
 
 interface RestManifestEntry {
@@ -452,6 +480,7 @@ export const __test = {
 	generateGraphQLManifest,
 	generateRestManifestEntries,
 	generateGraphQLEntryPoint,
+	validateResourcePathPrefix,
 };
 
 function generateTsConfig(projections: ResolvedProjection[]): string {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -45,6 +45,12 @@ export interface RestEmitterOptions {
 	 * to `Http<status>`). Issue #134.
 	 */
 	errorMap?: Record<string, string>;
+	/**
+	 * Path segment prepended to every `resourcePath` in the generated resolver
+	 * and manifest entry. Must start with `/` and must not end with `/`.
+	 * Example: `/api/v1`. Default: `""` (current behavior). Issue #140.
+	 */
+	resourcePathPrefix?: string;
 }
 
 export interface OpenSearchEmitterOptions {
@@ -269,6 +275,7 @@ export const $lib = createTypeSpecLibrary({
 							nullable: true,
 							additionalProperties: { type: "string" },
 						},
+						resourcePathPrefix: { type: "string", nullable: true },
 					},
 					additionalProperties: false,
 				},


### PR DESCRIPTION
Adds `rest.resourcePathPrefix` to `RestEmitterOptions` so every generated `resourcePath` can be prefixed with a shared path segment (e.g. `/api/v1`).

- `resourcePathPrefix` is prepended to `resourcePath` in both the AppSync JS resolver and the manifest entry
- Validation at emit time: must start with `/`, must not end with `/`
- Default is `""` — existing behaviour unchanged

closes #140