### PR TITLE
fix(rest): disambiguate generic model instantiations in REST SDL

### DIFF
--- a/src/emit-rest-sdl.test.ts
+++ b/src/emit-rest-sdl.test.ts
@@ -291,4 +291,66 @@ describe("emitRestSdl", () => {
 		assert.equal(files.length, 1);
 		assert.equal(files[0].fileName, "pet.graphql");
 	});
+
+	it("disambiguates distinct instantiations of a shared generic wrapper (issue #148)", async () => {
+		const { runner, resolved } = await resolveFixture(`
+      model ResultList<T> {
+        continuationToken?: string;
+        items: T[];
+      }
+
+      model Pet { petId: string; }
+      model Order { orderId: string; }
+
+      @route("/pets")
+      namespace Pets {
+        @restResolver @get op listPets(): ResultList<Pet>;
+      }
+
+      @route("/orders")
+      namespace Orders {
+        @restResolver @get op listOrders(): ResultList<Order>;
+      }
+    `);
+		const [{ content }] = emitRestSdl(runner.program, resolved, {
+			sdlFileName: "all.graphql",
+		});
+
+		assert.ok(
+			content.includes(
+				"type PetResultList {\n  continuationToken: String\n  items: [Pet!]!\n}",
+			),
+		);
+		assert.ok(
+			content.includes(
+				"type OrderResultList {\n  continuationToken: String\n  items: [Order!]!\n}",
+			),
+		);
+		assert.ok(content.includes("listPets: PetResultList"));
+		assert.ok(content.includes("listOrders: OrderResultList"));
+		// The bare template name must not appear as its own emitted type.
+		assert.ok(!content.includes("type ResultList "));
+	});
+
+	it("still dedupes the same generic instantiation reused across operations", async () => {
+		const { runner, resolved } = await resolveFixture(`
+      model ResultList<T> {
+        continuationToken?: string;
+        items: T[];
+      }
+
+      model Pet { petId: string; }
+
+      @route("/pets")
+      namespace Pets {
+        @restResolver @get op listPets(): ResultList<Pet>;
+        @restResolver @get op searchPets(@query q?: string): ResultList<Pet>;
+      }
+    `);
+		const [{ content }] = emitRestSdl(runner.program, resolved, {
+			sdlFileName: "all.graphql",
+		});
+
+		assert.equal((content.match(/type PetResultList \{/g) ?? []).length, 1);
+	});
 });

--- a/src/emit-rest-sdl.ts
+++ b/src/emit-rest-sdl.ts
@@ -72,7 +72,7 @@ export function emitRestSdl(
 /** Group key: the (unwrapped) return model name, falling back to the field name. */
 function groupName(op: ResolvedRestOperation): string {
 	const model = unwrapModel(op.returnType);
-	return model?.name ?? op.fieldName;
+	return model ? restModelName(model) : op.fieldName;
 }
 
 function unwrapModel(type: Type): Model | undefined {
@@ -81,6 +81,31 @@ function unwrapModel(type: Type): Model | undefined {
 		return unwrapModel(type.indexer.value);
 	}
 	return type.name ? type : undefined;
+}
+
+/**
+ * Distinct GraphQL type name for a model. Plain (non-template) models keep
+ * their bare name, unchanged from before — this is what keeps default output
+ * byte-identical. A template instantiation (e.g. `ResultList<TaskDefinition>`)
+ * shares its template's `.name` ("ResultList") across every instantiation, so
+ * without this every `ResultList<T>` collapsed onto one GraphQL type and
+ * silently kept whichever `T` registered first (issue #148). When every
+ * template argument is itself a named model, the instantiation is
+ * disambiguated as `<Arg1><Arg2>...<TemplateName>` (`TaskDefinitionResultList`);
+ * anything else (unresolvable/unnamed args) falls back to the bare name.
+ */
+function restModelName(model: Model): string {
+	const args = model.templateMapper?.args;
+	if (!args || args.length === 0) return model.name;
+
+	const argNames = args.map((arg) =>
+		typeof arg === "object" && "kind" in arg && arg.kind === "Model" && arg.name
+			? arg.name
+			: undefined,
+	);
+	if (argNames.some((name) => !name)) return model.name;
+
+	return `${argNames.join("")}${model.name}`;
 }
 
 interface TypeRegistry {
@@ -206,7 +231,7 @@ function restTypeRef(
 	}
 	if (type.kind === "Model" && type.name) {
 		registerModel(program, type, registry, position);
-		return type.name;
+		return restModelName(type);
 	}
 	return toGraphQLType(program, type, undefined, "rest");
 }
@@ -218,8 +243,9 @@ function registerModel(
 	position: "object" | "input",
 ): void {
 	const target = position === "input" ? registry.inputs : registry.objects;
-	if (target.has(model.name)) return;
-	target.set(model.name, model);
+	const name = restModelName(model);
+	if (target.has(name)) return;
+	target.set(name, model);
 	// Walk properties so referenced models/enums are registered too.
 	for (const property of model.properties.values()) {
 		restTypeRef(program, property.type, registry, position);
@@ -238,7 +264,7 @@ function renderModelBlock(
 		const nullable = property.optional ? "" : "!";
 		return `  ${property.name}: ${gqlType}${nullable}`;
 	});
-	return `${keyword} ${model.name} {\n${fieldLines.join("\n")}\n}`;
+	return `${keyword} ${restModelName(model)} {\n${fieldLines.join("\n")}\n}`;
 }
 
 function renderEnumBlock(enumType: Enum): string {
@@ -254,4 +280,5 @@ export const __test = {
 	renderField,
 	restPropertyRef,
 	restTypeRef,
+	restModelName,
 };


### PR DESCRIPTION
## Summary

- `emit-rest-sdl.ts` keyed its type registry by bare `Model.name`, so every instantiation of a generic template shared one GraphQL type. Two `@restResolver` ops returning `ResultList<TaskDefinition>` and `ResultList<Activity>` (found while wiring EDD-043 leg 2 in a consumer project) silently collapsed onto a single `type ResultList`, keeping whichever `T` registered first — the second op's SDL field type was simply wrong, no error surfaced.
- Adds `restModelName()`: non-generic models are unaffected (byte-identical default output, verified by the existing snapshot/byte-identical tests); a template instantiation whose type arguments are all named models is disambiguated as `<Arg1><Arg2>...<TemplateName>` (`PetResultList`, `OrderResultList`).

Closes #148.

## Test plan

- [x] `npm test` — full suite (358 tests) green, including the byte-identical/snapshot regression tests
- [x] New regression tests: distinct instantiations emit distinct correctly-typed GraphQL types; the same instantiation reused across ops still dedupes to one type