### PR TITLE
fix(emitter): send only the aggregations the GraphQL caller selected

### DIFF
--- a/src/emit-graphql-resolver.test.ts
+++ b/src/emit-graphql-resolver.test.ts
@@ -539,6 +539,56 @@ describe("emitGraphQLResolver", () => {
 		assert.ok(combinedContent(result).includes("base64Encode"));
 	});
 
+	// A projection with several independent top-level aggregations, including
+	// the date_histogram that makes riding-along aggregations expensive.
+	function multiAggProjection() {
+		return makeProjection({
+			fields: [
+				makeField({
+					name: "species",
+					keyword: true,
+					aggregations: ["terms", "cardinality"],
+				}),
+				makeField({
+					name: "rank",
+					aggregations: [{ kind: "date_histogram", options: {} }],
+					type: { kind: "Scalar", name: "utcDateTime" } as unknown as Type,
+				}),
+			],
+		});
+	}
+
+	// A projection mixing a top-level aggregation with two aggregations under a
+	// single @nested path, so the `_tags` wrapper's presence can be pinned to
+	// the caller's selection.
+	function nestedAggProjection() {
+		const subProjection = {
+			projectionModel: { name: "TagSearchDoc" },
+			sourceModel: { name: "Tag" },
+			indexName: "tags",
+			fields: [
+				makeField({ name: "name", keyword: true, aggregations: ["terms"] }),
+				makeField({ name: "note", optional: true, aggregations: ["missing"] }),
+			],
+		} as unknown as ResolvedProjection;
+
+		return makeProjection({
+			fields: [
+				makeField({ name: "species", keyword: true, aggregations: ["terms"] }),
+				makeField({
+					name: "tags",
+					nested: true,
+					subProjection,
+					type: {
+						kind: "Model",
+						name: "Array",
+						indexer: { value: { kind: "Model" } },
+					} as unknown as Type,
+				}),
+			],
+		});
+	}
+
 	it("omits aggs block when no aggregations", async () => {
 		const projection = makeProjection({
 			fields: [makeField({ name: "name" })],
@@ -547,11 +597,12 @@ describe("emitGraphQLResolver", () => {
 
 		assert.ok(!combinedContent(result).includes("aggs:"));
 		assert.ok(!combinedContent(result).includes("body.aggs"));
-		assert.ok(!combinedContent(result).includes("wantsAggs"));
+		assert.ok(!combinedContent(result).includes("AGG_SPEC"));
+		assert.ok(!combinedContent(result).includes("buildAggs"));
 		assert.ok(!combinedContent(result).includes("aggregations:"));
 	});
 
-	it("emits aggs block in request when fields have aggregations", async () => {
+	it("emits an AGG_SPEC entry per aggregation when fields have aggregations", async () => {
 		const projection = makeProjection({
 			fields: [
 				makeField({
@@ -572,20 +623,20 @@ describe("emitGraphQLResolver", () => {
 		});
 		const result = await emitGraphQLResolver(projection, defaultOptions);
 
-		assert.ok(combinedContent(result).includes("body.aggs = {"));
+		assert.ok(combinedContent(result).includes("const AGG_SPEC = ["));
 		assert.ok(
 			combinedContent(result).includes(
-				'byTag: { terms: { field: "tags.keyword" } }',
+				'{n:"byTag",a:{ terms: { field: "tags.keyword" } }}',
 			),
 		);
 		assert.ok(
 			combinedContent(result).includes(
-				'bySpecies: { terms: { field: "species" } }',
+				'{n:"bySpecies",a:{ terms: { field: "species" } }}',
 			),
 		);
 	});
 
-	it("gates body.aggs assignment on ctx.info.selectionSetList containing aggregations", async () => {
+	it("assembles body.aggs from ctx.info.selectionSetList", async () => {
 		const projection = makeProjection({
 			fields: [
 				makeField({
@@ -598,21 +649,22 @@ describe("emitGraphQLResolver", () => {
 		const result = await emitGraphQLResolver(projection, defaultOptions);
 		const combined = combinedContent(result);
 
-		// The wantsAggs gate must check both the bare `aggregations` selection
-		// and any nested `aggregations/...` sub-path. APPSYNC_JS forbids regex
+		// buildAggs must read the caller's selection. APPSYNC_JS forbids regex
 		// and try/catch — keep the check to plain string comparisons.
 		assert.ok(
-			combined.includes(
-				'ctx.info.selectionSetList.some((p) => p === "aggregations" || p.indexOf("aggregations/") === 0)',
-			),
-			`wantsAggs gate must read ctx.info.selectionSetList; got:\n${combined}`,
+			combined.includes("const aggs = buildAggs(ctx.info.selectionSetList);"),
+			`body.aggs must be assembled from ctx.info.selectionSetList; got:\n${combined}`,
 		);
 		assert.ok(
-			combined.includes("if (wantsAggs) {"),
-			"body.aggs assignment must be inside `if (wantsAggs)` block",
+			combined.includes('selectionSetList.indexOf("aggregations/" + spec.n)'),
+			"buildAggs must match each spec entry against the caller's selection",
+		);
+		assert.ok(
+			combined.includes("if (aggs) {"),
+			"body.aggs assignment must be inside `if (aggs)` block",
 		);
 		// Sanity: the gate appears BEFORE `body.aggs = ` in the request function.
-		const gateIdx = combined.indexOf("if (wantsAggs)");
+		const gateIdx = combined.indexOf("if (aggs)");
 		const assignIdx = combined.indexOf("body.aggs = ");
 		assert.ok(gateIdx >= 0 && assignIdx >= 0 && gateIdx < assignIdx);
 	});
@@ -671,6 +723,127 @@ describe("emitGraphQLResolver", () => {
 		);
 	});
 
+	it("sends only the aggregations the caller selected", async () => {
+		// Issue #150 — every aggregation used to ride along with any
+		// `aggregations` selection, so one aggregation OpenSearch rejects
+		// (an unbounded date_histogram over a far-future sentinel date) failed
+		// every aggregation query on the projection, including those that never
+		// referenced it.
+		const result = await emitGraphQLResolver(
+			multiAggProjection(),
+			defaultOptions,
+		);
+
+		const body = evalRequestBody(prepareFunctionContent(result), {
+			selectionSetList: [
+				"edges",
+				"totalCount",
+				"aggregations",
+				"aggregations/bySpecies",
+				"aggregations/bySpecies/key",
+			],
+		});
+		assert.deepEqual(Object.keys(body.aggs as Record<string, unknown>), [
+			"bySpecies",
+		]);
+	});
+
+	it("sends every aggregation the caller selected", async () => {
+		const result = await emitGraphQLResolver(
+			multiAggProjection(),
+			defaultOptions,
+		);
+
+		const body = evalRequestBody(prepareFunctionContent(result), {
+			selectionSetList: [
+				"aggregations",
+				"aggregations/bySpecies",
+				"aggregations/uniqueSpeciesCount",
+				"aggregations/byRankOverTime",
+			],
+		});
+		assert.deepEqual(Object.keys(body.aggs as Record<string, unknown>).sort(), [
+			"byRankOverTime",
+			"bySpecies",
+			"uniqueSpeciesCount",
+		]);
+	});
+
+	it("omits the aggs key when the caller selects no aggregation field", async () => {
+		const result = await emitGraphQLResolver(
+			multiAggProjection(),
+			defaultOptions,
+		);
+
+		const body = evalRequestBody(prepareFunctionContent(result), {
+			selectionSetList: ["edges", "edges/node", "totalCount", "pageInfo"],
+		});
+		assert.equal(
+			Object.hasOwn(body, "aggs"),
+			false,
+			`body must NOT contain aggs; got body=${JSON.stringify(body)}`,
+		);
+	});
+
+	it("builds a nested agg group only for the selected children", async () => {
+		const result = await emitGraphQLResolver(
+			nestedAggProjection(),
+			defaultOptions,
+		);
+
+		const body = evalRequestBody(prepareFunctionContent(result), {
+			selectionSetList: [
+				"aggregations",
+				"aggregations/byTagName",
+				"aggregations/byTagName/key",
+			],
+		});
+		assert.deepEqual(body.aggs, {
+			_tags: {
+				nested: { path: "tags" },
+				aggs: { byTagName: { terms: { field: "tags.name" } } },
+			},
+		});
+	});
+
+	it("omits a nested agg group when none of its children are selected", async () => {
+		const result = await emitGraphQLResolver(
+			nestedAggProjection(),
+			defaultOptions,
+		);
+
+		const body = evalRequestBody(prepareFunctionContent(result), {
+			selectionSetList: ["aggregations", "aggregations/bySpecies"],
+		});
+		assert.deepEqual(body.aggs, {
+			bySpecies: { terms: { field: "species" } },
+		});
+	});
+
+	it("groups every selected child of a nested path under one wrapper", async () => {
+		const result = await emitGraphQLResolver(
+			nestedAggProjection(),
+			defaultOptions,
+		);
+
+		const body = evalRequestBody(prepareFunctionContent(result), {
+			selectionSetList: [
+				"aggregations",
+				"aggregations/byTagName",
+				"aggregations/missingTagNoteCount",
+			],
+		});
+		assert.deepEqual(body.aggs, {
+			_tags: {
+				nested: { path: "tags" },
+				aggs: {
+					byTagName: { terms: { field: "tags.name" } },
+					missingTagNoteCount: { missing: { field: "tags.note.keyword" } },
+				},
+			},
+		});
+	});
+
 	it("emits cardinality and missing aggs in request", async () => {
 		const projection = makeProjection({
 			fields: [
@@ -695,12 +868,12 @@ describe("emitGraphQLResolver", () => {
 
 		assert.ok(
 			combinedContent(result).includes(
-				'uniqueLocationCount: { cardinality: { field: "locations" } }',
+				'{n:"uniqueLocationCount",a:{ cardinality: { field: "locations" } }}',
 			),
 		);
 		assert.ok(
 			combinedContent(result).includes(
-				'missingDescriptionCount: { missing: { field: "description.keyword" } }',
+				'{n:"missingDescriptionCount",a:{ missing: { field: "description.keyword" } }}',
 			),
 		);
 	});
@@ -720,7 +893,7 @@ describe("emitGraphQLResolver", () => {
 		const result = await emitGraphQLResolver(projection, defaultOptions);
 		assert.ok(
 			combinedContent(result).includes(
-				'byValidFromOverTime: { date_histogram: { field: "validFrom", calendar_interval: "month" } }',
+				'{n:"byValidFromOverTime",a:{ date_histogram: { field: "validFrom", calendar_interval: "month" } }}',
 			),
 		);
 		assert.ok(
@@ -755,7 +928,7 @@ describe("emitGraphQLResolver", () => {
 		const result = await emitGraphQLResolver(projection, defaultOptions);
 		assert.ok(
 			combinedContent(result).includes(
-				'byNotionalRange: { range: { field: "notional", ranges: [{"to":1000},{"from":1000,"to":10000},{"from":10000}] } }',
+				'{n:"byNotionalRange",a:{ range: { field: "notional", ranges: [{"to":1000},{"from":1000,"to":10000},{"from":10000}] } }}',
 			),
 		);
 		assert.ok(
@@ -785,7 +958,7 @@ describe("emitGraphQLResolver", () => {
 		const result = await emitGraphQLResolver(projection, defaultOptions);
 		assert.ok(
 			combinedContent(result).includes(
-				'byCounterpartyId: { terms: { field: "counterpartyId" }, aggs: { "latestValidTo": { max: { field: "validTo" } } } }',
+				'{n:"byCounterpartyId",a:{ terms: { field: "counterpartyId" }, aggs: { "latestValidTo": { max: { field: "validTo" } } } }}',
 			),
 		);
 		assert.ok(
@@ -809,7 +982,7 @@ describe("emitGraphQLResolver", () => {
 
 		assert.ok(
 			combinedContent(result).includes(
-				'byCounterpartyId: { terms: { field: "counterpartyId" }, aggs: { "hits": { top_hits: { size: 5 } } } }',
+				'{n:"byCounterpartyId",a:{ terms: { field: "counterpartyId" }, aggs: { "hits": { top_hits: { size: 5 } } } }}',
 			),
 			"terms agg request must include hits sub-agg with top_hits.size",
 		);
@@ -871,19 +1044,23 @@ describe("emitGraphQLResolver", () => {
 
 		assert.ok(
 			combinedContent(result).includes(
-				'notionalSum: { sum: { field: "notional" } }',
+				'{n:"notionalSum",a:{ sum: { field: "notional" } }}',
 			),
 		);
 		assert.ok(
 			combinedContent(result).includes(
-				'notionalAvg: { avg: { field: "notional" } }',
+				'{n:"notionalAvg",a:{ avg: { field: "notional" } }}',
 			),
 		);
 		assert.ok(
-			combinedContent(result).includes('rankMin: { min: { field: "rank" } }'),
+			combinedContent(result).includes(
+				'{n:"rankMin",a:{ min: { field: "rank" } }}',
+			),
 		);
 		assert.ok(
-			combinedContent(result).includes('rankMax: { max: { field: "rank" } }'),
+			combinedContent(result).includes(
+				'{n:"rankMax",a:{ max: { field: "rank" } }}',
+			),
 		);
 
 		assert.ok(
@@ -932,14 +1109,19 @@ describe("emitGraphQLResolver", () => {
 
 		const result = await emitGraphQLResolver(projection, defaultOptions);
 
-		// All nested aggs sharing a path are grouped under one wrapper
-		// (`__n_<path>` key) — saves the per-agg `{ nested: ..., aggs: { inner: ... } }`
-		// skeleton on wide projections (issue #105).
-		assert.ok(
-			combinedContent(result).includes(
-				'_tags: { nested: { path: "tags" }, aggs: { byTagName: { terms: { field: "tags.name" } }, uniqueTagNameCount: { cardinality: { field: "tags.name" } }, missingTagNoteCount: { missing: { field: "tags.note.keyword" } } } }',
-			),
-		);
+		// Every agg under a nested path carries that path's group key, so the
+		// selected ones share ONE `{ nested: ..., aggs: { ... } }` wrapper at
+		// request time instead of one wrapper each (issue #105).
+		for (const specEntry of [
+			'{n:"byTagName",g:"_tags",p:"tags",a:{ terms: { field: "tags.name" } }}',
+			'{n:"uniqueTagNameCount",g:"_tags",p:"tags",a:{ cardinality: { field: "tags.name" } }}',
+			'{n:"missingTagNoteCount",g:"_tags",p:"tags",a:{ missing: { field: "tags.note.keyword" } }}',
+		]) {
+			assert.ok(
+				combinedContent(result).includes(specEntry),
+				`AGG_SPEC must include ${specEntry}`,
+			);
+		}
 
 		assert.ok(
 			combinedContent(result).includes(
@@ -976,11 +1158,11 @@ describe("emitGraphQLResolver", () => {
 		const result = await emitGraphQLResolver(projection, defaultOptions);
 		assert.ok(
 			combinedContent(result).includes(
-				'byTag: { terms: { field: "tags.keyword" } }',
+				'{n:"byTag",a:{ terms: { field: "tags.keyword" } }}',
 			),
 		);
 		// Aggs for non-@nested fields must not be wrapped in `{ nested: ... }`.
-		assert.ok(!combinedContent(result).includes("byTag: { nested:"));
+		assert.ok(!combinedContent(result).includes('{n:"byTag",a:{ nested:'));
 	});
 
 	it("emits aggregations mapping in response", async () => {

--- a/src/emit-graphql-resolver.test.ts
+++ b/src/emit-graphql-resolver.test.ts
@@ -919,6 +919,53 @@ describe("emitGraphQLResolver", () => {
 		});
 	});
 
+	// `aggregations` is an object type, so Apollo (`addTypename: true` by
+	// default), Amplify and Relay inject `__typename` into its selection set.
+	// `__typename` is not an alias, and reading it as one would switch the
+	// narrowing off for exactly those clients.
+	it("__typename under aggregations does not widen the selection", async () => {
+		const result = await emitGraphQLResolver(
+			multiAggProjection(),
+			defaultOptions,
+		);
+
+		const body = evalRequestBody(prepareFunctionContent(result), {
+			selectionSetList: [
+				"totalCount",
+				"aggregations",
+				"aggregations/__typename",
+				"aggregations/bySpecies",
+				"aggregations/bySpecies/__typename",
+				"aggregations/bySpecies/key",
+			],
+		});
+		assert.deepEqual(Object.keys(body.aggs as Record<string, unknown>), [
+			"bySpecies",
+		]);
+	});
+
+	it("sends every aggregation when __typename accompanies an aliased aggregation", async () => {
+		const result = await emitGraphQLResolver(
+			multiAggProjection(),
+			defaultOptions,
+		);
+
+		const body = evalRequestBody(prepareFunctionContent(result), {
+			selectionSetList: [
+				"aggregations",
+				"aggregations/__typename",
+				"aggregations/speciesBuckets",
+				"aggregations/speciesBuckets/__typename",
+				"aggregations/speciesBuckets/key",
+			],
+		});
+		assert.deepEqual(Object.keys(body.aggs as Record<string, unknown>).sort(), [
+			"byRankOverTime",
+			"bySpecies",
+			"uniqueSpeciesCount",
+		]);
+	});
+
 	it("aliasing a sub-field of an aggregation does not widen the selection", async () => {
 		// `bySpecies { k: key }` aliases below the aggregation name, which stays
 		// resolvable — narrowing must still apply.

--- a/src/emit-graphql-resolver.test.ts
+++ b/src/emit-graphql-resolver.test.ts
@@ -844,6 +844,119 @@ describe("emitGraphQLResolver", () => {
 		});
 	});
 
+	// `selectionSetList` reports an aliased field under its alias only — the
+	// schema field name never appears — so an aliased aggregation matches no
+	// AGG_SPEC entry. Narrowing on that would send no aggs and answer with empty
+	// buckets the caller cannot distinguish from a real empty result, since the
+	// response side reads defensively (`parsedBody.aggregations || {}`). These
+	// pin the fallback that keeps aliased queries whole.
+	it("sends every aggregation when the caller aliases an aggregation field", async () => {
+		const result = await emitGraphQLResolver(
+			multiAggProjection(),
+			defaultOptions,
+		);
+
+		const body = evalRequestBody(prepareFunctionContent(result), {
+			selectionSetList: [
+				"totalCount",
+				"aggregations",
+				"aggregations/speciesBuckets",
+				"aggregations/speciesBuckets/key",
+				"aggregations/speciesBuckets/count",
+			],
+		});
+		assert.deepEqual(Object.keys(body.aggs as Record<string, unknown>).sort(), [
+			"byRankOverTime",
+			"bySpecies",
+			"uniqueSpeciesCount",
+		]);
+	});
+
+	it("sends every aggregation when an alias is mixed with a named aggregation", async () => {
+		const result = await emitGraphQLResolver(
+			multiAggProjection(),
+			defaultOptions,
+		);
+
+		const body = evalRequestBody(prepareFunctionContent(result), {
+			selectionSetList: [
+				"aggregations",
+				"aggregations/bySpecies",
+				"aggregations/bySpecies/key",
+				"aggregations/rankOverTime",
+				"aggregations/rankOverTime/key",
+			],
+		});
+		assert.deepEqual(Object.keys(body.aggs as Record<string, unknown>).sort(), [
+			"byRankOverTime",
+			"bySpecies",
+			"uniqueSpeciesCount",
+		]);
+	});
+
+	it("builds every nested agg group when the caller aliases an aggregation field", async () => {
+		const result = await emitGraphQLResolver(
+			nestedAggProjection(),
+			defaultOptions,
+		);
+
+		const body = evalRequestBody(prepareFunctionContent(result), {
+			selectionSetList: [
+				"aggregations",
+				"aggregations/tagNames",
+				"aggregations/tagNames/key",
+			],
+		});
+		assert.deepEqual(body.aggs, {
+			bySpecies: { terms: { field: "species" } },
+			_tags: {
+				nested: { path: "tags" },
+				aggs: {
+					byTagName: { terms: { field: "tags.name" } },
+					missingTagNoteCount: { missing: { field: "tags.note.keyword" } },
+				},
+			},
+		});
+	});
+
+	it("aliasing a sub-field of an aggregation does not widen the selection", async () => {
+		// `bySpecies { k: key }` aliases below the aggregation name, which stays
+		// resolvable — narrowing must still apply.
+		const result = await emitGraphQLResolver(
+			multiAggProjection(),
+			defaultOptions,
+		);
+
+		const body = evalRequestBody(prepareFunctionContent(result), {
+			selectionSetList: [
+				"aggregations",
+				"aggregations/bySpecies",
+				"aggregations/bySpecies/k",
+				"aggregations/bySpecies/n",
+			],
+		});
+		assert.deepEqual(Object.keys(body.aggs as Record<string, unknown>), [
+			"bySpecies",
+		]);
+	});
+
+	it("omits the aggs key when an alias sits outside the aggregations selection", async () => {
+		// A field aliased at the top level must not read as an aggregation alias.
+		const result = await emitGraphQLResolver(
+			multiAggProjection(),
+			defaultOptions,
+		);
+
+		const body = evalRequestBody(prepareFunctionContent(result), {
+			selectionSetList: ["count: totalCount", "rows", "rows/node"],
+		});
+		assert.equal(
+			Object.hasOwn(body, "aggs"),
+			false,
+			`body must NOT contain aggs; got body=${JSON.stringify(body)}`,
+		);
+	});
+
 	it("emits cardinality and missing aggs in request", async () => {
 		const projection = makeProjection({
 			fields: [

--- a/src/emit-graphql-resolver.ts
+++ b/src/emit-graphql-resolver.ts
@@ -205,6 +205,8 @@ function renderMonolithicResolver(
 	const keywordFieldsLiteral = JSON.stringify(keywordFields);
 	const textSortFieldsLiteral = JSON.stringify(textSortFields);
 	const aggsAssignment = renderAggsAssignment(aggregations, "\t");
+	const aggSpecDeclaration = renderAggSpecDeclaration(aggregations);
+	const buildAggsFunction = renderBuildAggsFunction(aggregations);
 	const filterSpecLiteral = renderFilterSpecLiteral(searchFilterShape);
 	const slotsLiteral = `[${"null,".repeat(FILTER_WORK_SLOT_COUNT).slice(0, -1)}]`;
 	const responseAggregationsPreamble =
@@ -214,7 +216,7 @@ function renderMonolithicResolver(
 	return `import { util } from "@aws-appsync/utils";
 
 const FILTER_SPEC = ${filterSpecLiteral};
-
+${aggSpecDeclaration}
 export function request(ctx) {
 	const args = ctx.args;
 	const size = Math.min(args.first || ${options.defaultPageSize}, ${options.maxPageSize});
@@ -267,7 +269,7 @@ ${responseAggregationsPreamble}
 		},
 	};
 }
-
+${buildAggsFunction}
 function buildQuery(queryText, filter, searchFilter) {
 	const musts = [];
 	const filters = [];
@@ -565,6 +567,8 @@ function renderPrepareFunction(
 	const keywordFieldsLiteral = JSON.stringify(keywordFields);
 	const textSortFieldsLiteral = JSON.stringify(textSortFields);
 	const aggsAssignment = renderAggsAssignment(aggregations, "\t");
+	const aggSpecDeclaration = renderAggSpecDeclaration(aggregations);
+	const buildAggsFunction = renderBuildAggsFunction(aggregations);
 	const filterSpecLiteral = renderFilterSpecLiteral(searchFilterShape);
 	// `null` (4 chars) instead of `undefined` (9 chars) keeps the literal small
 	// — saves ~5 bytes per slot. The walker never reads these init values; it
@@ -575,7 +579,7 @@ function renderPrepareFunction(
 	return `import { util } from "@aws-appsync/utils";
 
 const FILTER_SPEC = ${filterSpecLiteral};
-
+${aggSpecDeclaration}
 export function request(ctx) {
 	const args = ctx.args;
 	const size = Math.min(args.first || ${options.defaultPageSize}, ${options.maxPageSize});
@@ -602,7 +606,7 @@ ${aggsAssignment}
 export function response(ctx) {
 	return ctx.result;
 }
-
+${buildAggsFunction}
 function buildQuery(queryText, filter, searchFilter) {
 	const musts = [];
 	const filters = [];
@@ -928,56 +932,43 @@ function stringifyNode(node: FilterSpecNode): string {
 }
 
 /**
- * Emits a runtime block that conditionally assigns `body.aggs = { ... }` only
- * when the GraphQL caller selected the `aggregations` field. APPSYNC_JS exposes
- * `ctx.info.selectionSetList` as an array of dot-paths into the selection set;
- * we gate on `aggregations` itself or any nested `aggregations/...` path.
- *
- * Skipping the aggs block when not requested avoids OS executing every nested
- * aggregation defined on the doc type for every `searchX(first: 0) { totalCount }`
- * style probe — a 3 KB+ body shrinks back to a few bytes and OS does no
- * aggregation work. Returns "" when the projection has no aggregations at all.
+ * Emits the `AGG_SPEC` module-level declaration: one entry per aggregation the
+ * projection declares, keyed by the GraphQL field name the caller selects it
+ * under. `buildAggs` reads it at request time. Returns "" when the projection
+ * has no aggregations at all.
  */
-function renderAggsAssignment(
-	aggregations: AggregationEntry[],
-	indent: string,
-): string {
+function renderAggSpecDeclaration(aggregations: AggregationEntry[]): string {
 	if (aggregations.length === 0) {
 		return "";
 	}
-	const aggsBody = renderAggsObjectLiteral(aggregations, indent);
-	return `${indent}const wantsAggs = ctx.info.selectionSetList.some((p) => p === "aggregations" || p.indexOf("aggregations/") === 0);
-${indent}if (wantsAggs) {
-${indent}\tbody.aggs = ${aggsBody};
-${indent}}
-`;
+	return `\nconst AGG_SPEC = ${renderAggSpecLiteral(aggregations)};\n`;
 }
 
 /**
- * Builds the `{ byTagName: ..., byApprovalType: ..., _tags: { nested: ... } }`
- * object literal that goes on the right-hand side of `body.aggs = ...`.
+ * Builds the `[{n:"byTagName",a:{...}}, {n:"byStatus",g:"_tags",p:"tags",a:{...}}]`
+ * literal that `buildAggs` projects the caller's selection onto.
  *
- * Group aggs by nested path so each path emits ONE `nested` wrapper with all
- * child aggs inside, instead of one wrapper per agg. Saves a per-agg
- * `{ nested: { path: "..." }, aggs: { inner: ... } }` skeleton (~50 bytes
- * per nested agg) on wide projections (issue #105).
+ * AGG_SPEC entries use single-letter keys to keep wide projections under
+ * AppSync's 32 KB per-function code cap (issue #99, #105). The reader is
+ * buildAggs inside the emitted prepare function; keys must match there:
+ *   n = GraphQL aggregation field name, a = OpenSearch agg body,
+ *   p = nested path, g = nested agg group key.
+ *
+ * Flat aggregations come first, then nested ones grouped by path, so the
+ * assembled `body.aggs` key order matches the projection's declaration order.
  *
  * Aggregations carry a per-projection-unique `aggName` (e.g. `byCounterpartyId`).
  * If the same aggName appears more than once (which can happen when a
- * projection spreads the same field/aggregation twice), APPSYNC_JS rejects
- * the resulting object literal at deploy time (TS1117 — duplicate keys).
- * Dedupe here, first-wins.
+ * projection spreads the same field/aggregation twice), the duplicate would
+ * overwrite the first at assembly time. Dedupe here, first-wins, matching the
+ * response-side mapping.
  */
-function renderAggsObjectLiteral(
-	aggregations: AggregationEntry[],
-	indent: string,
-): string {
+function renderAggSpecLiteral(aggregations: AggregationEntry[]): string {
 	if (aggregations.length === 0) {
-		return "{}";
+		return "[]";
 	}
 
-	const inner = `${indent}\t`;
-	const flatLines: string[] = [];
+	const flatItems: string[] = [];
 	const flatSeen = new Set<string>();
 	const byPath = new Map<string, AggregationEntry[]>();
 	const seenInPath = new Map<string, Set<string>>();
@@ -985,7 +976,9 @@ function renderAggsObjectLiteral(
 		if (!entry.nestedPath) {
 			if (flatSeen.has(entry.aggName)) continue;
 			flatSeen.add(entry.aggName);
-			flatLines.push(`${inner}${entry.aggName}: ${renderAggInner(entry)},`);
+			flatItems.push(
+				`{n:${JSON.stringify(entry.aggName)},a:${renderAggInner(entry)}}`,
+			);
 			continue;
 		}
 		const seen = seenInPath.get(entry.nestedPath) ?? new Set<string>();
@@ -1000,18 +993,82 @@ function renderAggsObjectLiteral(
 		}
 	}
 
-	const groupLines: string[] = [];
+	const groupItems: string[] = [];
 	for (const [path, group] of byPath) {
-		const innerEntries = group
-			.map((e) => `${e.aggName}: ${renderAggInner(e)}`)
-			.join(", ");
-		groupLines.push(
-			`${inner}${nestedAggGroupKey(path)}: { nested: { path: ${JSON.stringify(path)} }, aggs: { ${innerEntries} } },`,
-		);
+		const groupKey = JSON.stringify(nestedAggGroupKey(path));
+		const pathLit = JSON.stringify(path);
+		for (const entry of group) {
+			groupItems.push(
+				`{n:${JSON.stringify(entry.aggName)},g:${groupKey},p:${pathLit},a:${renderAggInner(entry)}}`,
+			);
+		}
 	}
 
-	const lines = [...flatLines, ...groupLines];
-	return `{\n${lines.join("\n")}\n${indent}}`;
+	return `[${[...flatItems, ...groupItems].join(", ")}]`;
+}
+
+/**
+ * Emits the `buildAggs` runtime helper, which projects the caller's selection
+ * onto AGG_SPEC. APPSYNC_JS exposes `ctx.info.selectionSetList` as an array of
+ * slash-paths into the selection set; an aggregation is requested exactly when
+ * `aggregations/<aggName>` is present.
+ *
+ * Only requested aggregations reach OpenSearch, and a nested wrapper is built
+ * only for groups with at least one requested child (issue #150). Assembling
+ * at runtime from a compact spec keeps the emitted code size flat regardless
+ * of how many aggregations the projection declares — the alternative, emitting
+ * a per-selection object literal, does not fit the 32 KB per-function cap.
+ *
+ * Returns "" when the projection has no aggregations at all.
+ */
+function renderBuildAggsFunction(aggregations: AggregationEntry[]): string {
+	if (aggregations.length === 0) {
+		return "";
+	}
+	return `
+function buildAggs(selectionSetList) {
+	// Only the aggregations named in the caller's selection are sent; \`null\`
+	// means none were, and the request omits the \`aggs\` key entirely.
+	const aggs = {};
+	let requested = false;
+	for (const spec of AGG_SPEC) {
+		if (selectionSetList.indexOf("aggregations/" + spec.n) >= 0) {
+			requested = true;
+			if (spec.g) {
+				const group = aggs[spec.g] || { nested: { path: spec.p }, aggs: {} };
+				group.aggs[spec.n] = spec.a;
+				aggs[spec.g] = group;
+			} else {
+				aggs[spec.n] = spec.a;
+			}
+		}
+	}
+	return requested ? aggs : null;
+}
+`;
+}
+
+/**
+ * Emits the request-side block that assigns `body.aggs` to the aggregations the
+ * caller selected, and leaves the key off entirely when they selected none.
+ *
+ * Sending only the requested aggregations keeps OpenSearch from executing every
+ * aggregation the doc type declares on a `searchX(first: 0) { totalCount }`
+ * style probe, and isolates each aggregation's failures to the queries that ask
+ * for it. Returns "" when the projection has no aggregations at all.
+ */
+function renderAggsAssignment(
+	aggregations: AggregationEntry[],
+	indent: string,
+): string {
+	if (aggregations.length === 0) {
+		return "";
+	}
+	return `${indent}const aggs = buildAggs(ctx.info.selectionSetList);
+${indent}if (aggs) {
+${indent}\tbody.aggs = aggs;
+${indent}}
+`;
 }
 
 function nestedAggGroupKey(nestedPath: string): string {
@@ -1170,7 +1227,8 @@ export const __test = {
 	renderSearchFunction,
 	renderMonolithicResolver,
 	renderAggsAssignment,
-	renderAggsObjectLiteral,
+	renderAggSpecLiteral,
+	renderBuildAggsFunction,
 	renderResponseAggregations,
 	DEFAULT_MONOLITHIC_THRESHOLD_BYTES,
 };

--- a/src/emit-graphql-resolver.ts
+++ b/src/emit-graphql-resolver.ts
@@ -1023,9 +1023,14 @@ function renderAggSpecLiteral(aggregations: AggregationEntry[]): string {
  * field name is absent — so `aggregations { s: bySpecies { key } }` yields
  * `aggregations/s` and nothing that identifies `bySpecies`. The alias target is
  * not recoverable, so buildAggs detects the alias instead: the valid children of
- * `aggregations` are exactly the AGG_SPEC names, and any other first segment is
- * an alias. Such a selection falls back to sending every aggregation, which is
- * what the caller received before issue #150 narrowed the block.
+ * `aggregations` are the AGG_SPEC names plus `__typename`, which Apollo, Amplify
+ * and Relay inject into every object selection set; any other first segment is
+ * read as an alias. Such a selection falls back to sending every aggregation,
+ * which is what the caller received before issue #150 narrowed the block.
+ *
+ * Known false negative: an alias that happens to name another declared
+ * aggregation (`byAlias: bySpecies`) reads as declared, so no fallback fires and
+ * the wrong aggregation is sent — undetectable from `selectionSetList` alone.
  *
  * Returns "" when the projection has no aggregations at all.
  */
@@ -1048,7 +1053,7 @@ function buildAggs(selectionSetList) {
 			for (const spec of AGG_SPEC) {
 				if (spec.n === name) declared = true;
 			}
-			if (!declared) aliased = true;
+			if (!declared && name !== "__typename") aliased = true;
 		}
 	}
 	// \`null\` means nothing was requested, and the request omits \`aggs\` entirely.

--- a/src/emit-graphql-resolver.ts
+++ b/src/emit-graphql-resolver.ts
@@ -1019,6 +1019,14 @@ function renderAggSpecLiteral(aggregations: AggregationEntry[]): string {
  * of how many aggregations the projection declares — the alternative, emitting
  * a per-selection object literal, does not fit the 32 KB per-function cap.
  *
+ * `selectionSetList` names an aliased field by its alias only — the schema
+ * field name is absent — so `aggregations { s: bySpecies { key } }` yields
+ * `aggregations/s` and nothing that identifies `bySpecies`. The alias target is
+ * not recoverable, so buildAggs detects the alias instead: the valid children of
+ * `aggregations` are exactly the AGG_SPEC names, and any other first segment is
+ * an alias. Such a selection falls back to sending every aggregation, which is
+ * what the caller received before issue #150 narrowed the block.
+ *
  * Returns "" when the projection has no aggregations at all.
  */
 function renderBuildAggsFunction(aggregations: AggregationEntry[]): string {
@@ -1027,12 +1035,27 @@ function renderBuildAggsFunction(aggregations: AggregationEntry[]): string {
 	}
 	return `
 function buildAggs(selectionSetList) {
-	// Only the aggregations named in the caller's selection are sent; \`null\`
-	// means none were, and the request omits the \`aggs\` key entirely.
+	// A first segment under \`aggregations/\` naming no AGG_SPEC entry is an
+	// alias, whose target is not recoverable here — send every aggregation
+	// rather than none.
+	let aliased = false;
+	for (const path of selectionSetList) {
+		if (path.indexOf("aggregations/") === 0) {
+			const rest = path.substring(13);
+			const slash = rest.indexOf("/");
+			const name = slash < 0 ? rest : rest.substring(0, slash);
+			let declared = false;
+			for (const spec of AGG_SPEC) {
+				if (spec.n === name) declared = true;
+			}
+			if (!declared) aliased = true;
+		}
+	}
+	// \`null\` means nothing was requested, and the request omits \`aggs\` entirely.
 	const aggs = {};
 	let requested = false;
 	for (const spec of AGG_SPEC) {
-		if (selectionSetList.indexOf("aggregations/" + spec.n) >= 0) {
+		if (aliased || selectionSetList.indexOf("aggregations/" + spec.n) >= 0) {
 			requested = true;
 			if (spec.g) {
 				const group = aggs[spec.g] || { nested: { path: spec.p }, aggs: {} };
@@ -1142,7 +1165,7 @@ function renderResponseAggregations(aggregations: AggregationEntry[]): string {
 		return "";
 	}
 
-	// Match the dedupe in renderAggsObjectLiteral — first-wins on duplicate aggName.
+	// Match the dedupe in renderAggSpecLiteral — first-wins on duplicate aggName.
 	const seen = new Set<string>();
 	const lines: string[] = [];
 	for (const entry of aggregations) {

--- a/src/emit-graphql-sdl.ts
+++ b/src/emit-graphql-sdl.ts
@@ -463,7 +463,7 @@ function renderAggregationTypes(
 	const customBucketTypes: string[] = [];
 
 	// Dedupe by aggName — same fieldLine matches the resolver-side dedupe in
-	// renderAggsObjectLiteral. Without this, an aggregation declared on a field that
+	// renderAggSpecLiteral. Without this, an aggregation declared on a field that
 	// the projection emits twice (e.g. via spread) produces a duplicate-field
 	// SDL block, which AppSync schema validation rejects.
 	const seenAggNames = new Set<string>();

--- a/test/example.js
+++ b/test/example.js
@@ -136,13 +136,14 @@ test("emits graphql aggregation types and resolver block", async () => {
 
 	// Aggs request shape lives in the prepare function; response mapping
 	// lives in the resolver after-mapping (pipeline split — issue #105).
-	assert.ok(prepare.includes("aggs:"));
+	assert.ok(prepare.includes("const AGG_SPEC = ["));
+	assert.ok(prepare.includes("body.aggs = aggs;"));
 	assert.ok(
-		prepare.includes('byAlias: { terms: { field: "aliases.keyword" } }'),
+		prepare.includes('{n:"byAlias",a:{ terms: { field: "aliases.keyword" } }}'),
 	);
 	assert.ok(
 		prepare.includes(
-			'uniqueAliasCount: { cardinality: { field: "aliases.keyword" } }',
+			'{n:"uniqueAliasCount",a:{ cardinality: { field: "aliases.keyword" } }}',
 		),
 	);
 	assert.ok(resolver.includes("aggregations: {"));
@@ -223,14 +224,20 @@ test("emits nested-aware aggregations on nested sub-projections", async () => {
 	assert.ok(sdl.includes("uniqueTagNameCount: Int!"));
 	assert.ok(sdl.includes("missingTagNoteCount: Int!"));
 
-	// Nested aggs sharing a path are grouped under a single wrapper
-	// (`_<path>` key) in the request (prepare function); the response
-	// mapping in the resolver after-mapping reads the grouped shape — issue #105.
-	assert.ok(
-		prepare.includes(
-			'_tags: { nested: { path: "tags" }, aggs: { byTagName: { terms: { field: "tags.name" } }, uniqueTagNameCount: { cardinality: { field: "tags.name" } }, missingTagNoteCount: { missing: { field: "tags.note.keyword" } } } }',
-		),
-	);
+	// Nested aggs sharing a path carry that path's group key in AGG_SPEC, so the
+	// selected ones are assembled under a single wrapper (`_<path>` key) in the
+	// request (prepare function); the response mapping in the resolver
+	// after-mapping reads the grouped shape — issues #105, #150.
+	for (const specEntry of [
+		'{n:"byTagName",g:"_tags",p:"tags",a:{ terms: { field: "tags.name" } }}',
+		'{n:"uniqueTagNameCount",g:"_tags",p:"tags",a:{ cardinality: { field: "tags.name" } }}',
+		'{n:"missingTagNoteCount",g:"_tags",p:"tags",a:{ missing: { field: "tags.note.keyword" } }}',
+	]) {
+		assert.ok(
+			prepare.includes(specEntry),
+			`AGG_SPEC must include ${specEntry}`,
+		);
+	}
 	assert.ok(
 		resolver.includes("byTagName: (_a_tags.byTagName?.buckets ?? []).map"),
 	);

--- a/test/regression.js
+++ b/test/regression.js
@@ -4,8 +4,10 @@ import test from "node:test";
 
 // Issue #134 hard constraint: a .tsp with no @restResolver must emit
 // byte-identical output to pre-REST main. test/snapshots/opensearch-baseline
-// was captured from the unmodified main emit of test/main.tsp; this compares
-// the fresh emit (produced by `npm run test:emit`) file-by-file, byte-by-byte.
+// holds the expected emit of test/main.tsp; this compares the fresh emit
+// (produced by `npm run test:emit`) file-by-file, byte-by-byte. Only an
+// intentional change to the OpenSearch emit re-captures it — copy
+// build/opensearch-emit over the snapshot dir and review the diff.
 const SNAPSHOT_DIR = "test/snapshots/opensearch-baseline";
 const EMIT_DIR = "build/opensearch-emit";
 

--- a/test/snapshots/opensearch-baseline/person-search-doc-fn-prepare.js
+++ b/test/snapshots/opensearch-baseline/person-search-doc-fn-prepare.js
@@ -2,6 +2,8 @@ import { util } from "@aws-appsync/utils";
 
 const FILTER_SPEC = [{i:"id",k:"term",f:"id"}, {i:"idIn",k:"terms",f:"id"}, {i:"idExists",k:"exists",f:"id"}, {i:"address",k:"object",c:[{i:"country",k:"term",f:"address.country"}, {i:"countryIn",k:"terms",f:"address.country"}, {i:"countryExists",k:"exists",f:"address.country"}, {i:"city",k:"term",f:"address.city"}, {i:"cityIn",k:"terms",f:"address.city"}, {i:"cityExists",k:"exists",f:"address.city"}]}];
 
+const AGG_SPEC = [{n:"byId",a:{ terms: { field: "id" } }}, {n:"byCountry",a:{ terms: { field: "country" } }}, {n:"byCity",a:{ terms: { field: "city" } }}];
+
 export function request(ctx) {
 	const args = ctx.args;
 	const size = Math.min(args.first || 20, 100);
@@ -20,13 +22,9 @@ export function request(ctx) {
 	if (searchAfter) {
 		body.search_after = searchAfter;
 	}
-	const wantsAggs = ctx.info.selectionSetList.some((p) => p === "aggregations" || p.indexOf("aggregations/") === 0);
-	if (wantsAggs) {
-		body.aggs = {
-		byId: { terms: { field: "id" } },
-		byCountry: { terms: { field: "country" } },
-		byCity: { terms: { field: "city" } },
-	};
+	const aggs = buildAggs(ctx.info.selectionSetList);
+	if (aggs) {
+		body.aggs = aggs;
 	}
 
 	ctx.stash.queryBody = body;
@@ -35,6 +33,26 @@ export function request(ctx) {
 
 export function response(ctx) {
 	return ctx.result;
+}
+
+function buildAggs(selectionSetList) {
+	// Only the aggregations named in the caller's selection are sent; `null`
+	// means none were, and the request omits the `aggs` key entirely.
+	const aggs = {};
+	let requested = false;
+	for (const spec of AGG_SPEC) {
+		if (selectionSetList.indexOf("aggregations/" + spec.n) >= 0) {
+			requested = true;
+			if (spec.g) {
+				const group = aggs[spec.g] || { nested: { path: spec.p }, aggs: {} };
+				group.aggs[spec.n] = spec.a;
+				aggs[spec.g] = group;
+			} else {
+				aggs[spec.n] = spec.a;
+			}
+		}
+	}
+	return requested ? aggs : null;
 }
 
 function buildQuery(queryText, filter, searchFilter) {

--- a/test/snapshots/opensearch-baseline/person-search-doc-fn-prepare.js
+++ b/test/snapshots/opensearch-baseline/person-search-doc-fn-prepare.js
@@ -49,7 +49,7 @@ function buildAggs(selectionSetList) {
 			for (const spec of AGG_SPEC) {
 				if (spec.n === name) declared = true;
 			}
-			if (!declared) aliased = true;
+			if (!declared && name !== "__typename") aliased = true;
 		}
 	}
 	// `null` means nothing was requested, and the request omits `aggs` entirely.

--- a/test/snapshots/opensearch-baseline/person-search-doc-fn-prepare.js
+++ b/test/snapshots/opensearch-baseline/person-search-doc-fn-prepare.js
@@ -36,12 +36,27 @@ export function response(ctx) {
 }
 
 function buildAggs(selectionSetList) {
-	// Only the aggregations named in the caller's selection are sent; `null`
-	// means none were, and the request omits the `aggs` key entirely.
+	// A first segment under `aggregations/` naming no AGG_SPEC entry is an
+	// alias, whose target is not recoverable here — send every aggregation
+	// rather than none.
+	let aliased = false;
+	for (const path of selectionSetList) {
+		if (path.indexOf("aggregations/") === 0) {
+			const rest = path.substring(13);
+			const slash = rest.indexOf("/");
+			const name = slash < 0 ? rest : rest.substring(0, slash);
+			let declared = false;
+			for (const spec of AGG_SPEC) {
+				if (spec.n === name) declared = true;
+			}
+			if (!declared) aliased = true;
+		}
+	}
+	// `null` means nothing was requested, and the request omits `aggs` entirely.
 	const aggs = {};
 	let requested = false;
 	for (const spec of AGG_SPEC) {
-		if (selectionSetList.indexOf("aggregations/" + spec.n) >= 0) {
+		if (aliased || selectionSetList.indexOf("aggregations/" + spec.n) >= 0) {
 			requested = true;
 			if (spec.g) {
 				const group = aggs[spec.g] || { nested: { path: spec.p }, aggs: {} };

--- a/test/snapshots/opensearch-baseline/pet-public-search-doc-fn-prepare.js
+++ b/test/snapshots/opensearch-baseline/pet-public-search-doc-fn-prepare.js
@@ -2,6 +2,8 @@ import { util } from "@aws-appsync/utils";
 
 const FILTER_SPEC = [{i:"species",k:"term",f:"species"}, {i:"speciesNot",k:"term_negate",f:"species"}, {i:"birthDate",k:"range",f:"birthDate"}, {i:"createdAt",k:"range",f:"createdAt"}, {i:"nicknameExists",k:"exists",f:"nickname.keyword"}, {i:"rank",k:"range",f:"rank"}];
 
+const AGG_SPEC = [{n:"bySpecies",a:{ terms: { field: "species" } }}, {n:"byAlias",a:{ terms: { field: "aliases.keyword" } }}, {n:"uniqueAliasCount",a:{ cardinality: { field: "aliases.keyword" } }}, {n:"missingNicknameCount",a:{ missing: { field: "nickname.keyword" } }}];
+
 export function request(ctx) {
 	const args = ctx.args;
 	const size = Math.min(args.first || 20, 100);
@@ -20,14 +22,9 @@ export function request(ctx) {
 	if (searchAfter) {
 		body.search_after = searchAfter;
 	}
-	const wantsAggs = ctx.info.selectionSetList.some((p) => p === "aggregations" || p.indexOf("aggregations/") === 0);
-	if (wantsAggs) {
-		body.aggs = {
-		bySpecies: { terms: { field: "species" } },
-		byAlias: { terms: { field: "aliases.keyword" } },
-		uniqueAliasCount: { cardinality: { field: "aliases.keyword" } },
-		missingNicknameCount: { missing: { field: "nickname.keyword" } },
-	};
+	const aggs = buildAggs(ctx.info.selectionSetList);
+	if (aggs) {
+		body.aggs = aggs;
 	}
 
 	ctx.stash.queryBody = body;
@@ -36,6 +33,26 @@ export function request(ctx) {
 
 export function response(ctx) {
 	return ctx.result;
+}
+
+function buildAggs(selectionSetList) {
+	// Only the aggregations named in the caller's selection are sent; `null`
+	// means none were, and the request omits the `aggs` key entirely.
+	const aggs = {};
+	let requested = false;
+	for (const spec of AGG_SPEC) {
+		if (selectionSetList.indexOf("aggregations/" + spec.n) >= 0) {
+			requested = true;
+			if (spec.g) {
+				const group = aggs[spec.g] || { nested: { path: spec.p }, aggs: {} };
+				group.aggs[spec.n] = spec.a;
+				aggs[spec.g] = group;
+			} else {
+				aggs[spec.n] = spec.a;
+			}
+		}
+	}
+	return requested ? aggs : null;
 }
 
 function buildQuery(queryText, filter, searchFilter) {

--- a/test/snapshots/opensearch-baseline/pet-public-search-doc-fn-prepare.js
+++ b/test/snapshots/opensearch-baseline/pet-public-search-doc-fn-prepare.js
@@ -49,7 +49,7 @@ function buildAggs(selectionSetList) {
 			for (const spec of AGG_SPEC) {
 				if (spec.n === name) declared = true;
 			}
-			if (!declared) aliased = true;
+			if (!declared && name !== "__typename") aliased = true;
 		}
 	}
 	// `null` means nothing was requested, and the request omits `aggs` entirely.

--- a/test/snapshots/opensearch-baseline/pet-public-search-doc-fn-prepare.js
+++ b/test/snapshots/opensearch-baseline/pet-public-search-doc-fn-prepare.js
@@ -36,12 +36,27 @@ export function response(ctx) {
 }
 
 function buildAggs(selectionSetList) {
-	// Only the aggregations named in the caller's selection are sent; `null`
-	// means none were, and the request omits the `aggs` key entirely.
+	// A first segment under `aggregations/` naming no AGG_SPEC entry is an
+	// alias, whose target is not recoverable here — send every aggregation
+	// rather than none.
+	let aliased = false;
+	for (const path of selectionSetList) {
+		if (path.indexOf("aggregations/") === 0) {
+			const rest = path.substring(13);
+			const slash = rest.indexOf("/");
+			const name = slash < 0 ? rest : rest.substring(0, slash);
+			let declared = false;
+			for (const spec of AGG_SPEC) {
+				if (spec.n === name) declared = true;
+			}
+			if (!declared) aliased = true;
+		}
+	}
+	// `null` means nothing was requested, and the request omits `aggs` entirely.
 	const aggs = {};
 	let requested = false;
 	for (const spec of AGG_SPEC) {
-		if (selectionSetList.indexOf("aggregations/" + spec.n) >= 0) {
+		if (aliased || selectionSetList.indexOf("aggregations/" + spec.n) >= 0) {
 			requested = true;
 			if (spec.g) {
 				const group = aggs[spec.g] || { nested: { path: spec.p }, aggs: {} };

--- a/test/snapshots/opensearch-baseline/pet-search-doc-fn-prepare.js
+++ b/test/snapshots/opensearch-baseline/pet-search-doc-fn-prepare.js
@@ -49,7 +49,7 @@ function buildAggs(selectionSetList) {
 			for (const spec of AGG_SPEC) {
 				if (spec.n === name) declared = true;
 			}
-			if (!declared) aliased = true;
+			if (!declared && name !== "__typename") aliased = true;
 		}
 	}
 	// `null` means nothing was requested, and the request omits `aggs` entirely.

--- a/test/snapshots/opensearch-baseline/pet-search-doc-fn-prepare.js
+++ b/test/snapshots/opensearch-baseline/pet-search-doc-fn-prepare.js
@@ -36,12 +36,27 @@ export function response(ctx) {
 }
 
 function buildAggs(selectionSetList) {
-	// Only the aggregations named in the caller's selection are sent; `null`
-	// means none were, and the request omits the `aggs` key entirely.
+	// A first segment under `aggregations/` naming no AGG_SPEC entry is an
+	// alias, whose target is not recoverable here — send every aggregation
+	// rather than none.
+	let aliased = false;
+	for (const path of selectionSetList) {
+		if (path.indexOf("aggregations/") === 0) {
+			const rest = path.substring(13);
+			const slash = rest.indexOf("/");
+			const name = slash < 0 ? rest : rest.substring(0, slash);
+			let declared = false;
+			for (const spec of AGG_SPEC) {
+				if (spec.n === name) declared = true;
+			}
+			if (!declared) aliased = true;
+		}
+	}
+	// `null` means nothing was requested, and the request omits `aggs` entirely.
 	const aggs = {};
 	let requested = false;
 	for (const spec of AGG_SPEC) {
-		if (selectionSetList.indexOf("aggregations/" + spec.n) >= 0) {
+		if (aliased || selectionSetList.indexOf("aggregations/" + spec.n) >= 0) {
 			requested = true;
 			if (spec.g) {
 				const group = aggs[spec.g] || { nested: { path: spec.p }, aggs: {} };

--- a/test/snapshots/opensearch-baseline/pet-search-doc-fn-prepare.js
+++ b/test/snapshots/opensearch-baseline/pet-search-doc-fn-prepare.js
@@ -2,6 +2,8 @@ import { util } from "@aws-appsync/utils";
 
 const FILTER_SPEC = [{i:"namePrefix",k:"prefix",f:"name"}, {i:"nameMatch",k:"match",f:"name"}, {i:"species",k:"term",f:"species"}, {i:"speciesNot",k:"term_negate",f:"species"}, {i:"birthDate",k:"range",f:"birthDate"}, {i:"createdAt",k:"range",f:"createdAt"}, {i:"tags",k:"nested",p:"tags",c:[{i:"name",k:"term",f:"tags.name"}, {i:"nameNot",k:"term_negate",f:"tags.name"}, {i:"noteExists",k:"exists",f:"tags.note.keyword"}]}, {i:"nicknameExists",k:"exists",f:"nickname.keyword"}, {i:"rank",k:"range",f:"rank"}];
 
+const AGG_SPEC = [{n:"bySpecies",a:{ terms: { field: "species" } }}, {n:"byAlias",a:{ terms: { field: "aliases.keyword" } }}, {n:"uniqueAliasCount",a:{ cardinality: { field: "aliases.keyword" } }}, {n:"missingNicknameCount",a:{ missing: { field: "nickname.keyword" } }}, {n:"byTagName",g:"_tags",p:"tags",a:{ terms: { field: "tags.name" } }}, {n:"uniqueTagNameCount",g:"_tags",p:"tags",a:{ cardinality: { field: "tags.name" } }}, {n:"missingTagNoteCount",g:"_tags",p:"tags",a:{ missing: { field: "tags.note.keyword" } }}];
+
 export function request(ctx) {
 	const args = ctx.args;
 	const size = Math.min(args.first || 20, 100);
@@ -20,15 +22,9 @@ export function request(ctx) {
 	if (searchAfter) {
 		body.search_after = searchAfter;
 	}
-	const wantsAggs = ctx.info.selectionSetList.some((p) => p === "aggregations" || p.indexOf("aggregations/") === 0);
-	if (wantsAggs) {
-		body.aggs = {
-		bySpecies: { terms: { field: "species" } },
-		byAlias: { terms: { field: "aliases.keyword" } },
-		uniqueAliasCount: { cardinality: { field: "aliases.keyword" } },
-		missingNicknameCount: { missing: { field: "nickname.keyword" } },
-		_tags: { nested: { path: "tags" }, aggs: { byTagName: { terms: { field: "tags.name" } }, uniqueTagNameCount: { cardinality: { field: "tags.name" } }, missingTagNoteCount: { missing: { field: "tags.note.keyword" } } } },
-	};
+	const aggs = buildAggs(ctx.info.selectionSetList);
+	if (aggs) {
+		body.aggs = aggs;
 	}
 
 	ctx.stash.queryBody = body;
@@ -37,6 +33,26 @@ export function request(ctx) {
 
 export function response(ctx) {
 	return ctx.result;
+}
+
+function buildAggs(selectionSetList) {
+	// Only the aggregations named in the caller's selection are sent; `null`
+	// means none were, and the request omits the `aggs` key entirely.
+	const aggs = {};
+	let requested = false;
+	for (const spec of AGG_SPEC) {
+		if (selectionSetList.indexOf("aggregations/" + spec.n) >= 0) {
+			requested = true;
+			if (spec.g) {
+				const group = aggs[spec.g] || { nested: { path: spec.p }, aggs: {} };
+				group.aggs[spec.n] = spec.a;
+				aggs[spec.g] = group;
+			} else {
+				aggs[spec.n] = spec.a;
+			}
+		}
+	}
+	return requested ? aggs : null;
 }
 
 function buildQuery(queryText, filter, searchFilter) {

--- a/test/snapshots/opensearch-baseline/tag-search-doc-fn-prepare.js
+++ b/test/snapshots/opensearch-baseline/tag-search-doc-fn-prepare.js
@@ -49,7 +49,7 @@ function buildAggs(selectionSetList) {
 			for (const spec of AGG_SPEC) {
 				if (spec.n === name) declared = true;
 			}
-			if (!declared) aliased = true;
+			if (!declared && name !== "__typename") aliased = true;
 		}
 	}
 	// `null` means nothing was requested, and the request omits `aggs` entirely.

--- a/test/snapshots/opensearch-baseline/tag-search-doc-fn-prepare.js
+++ b/test/snapshots/opensearch-baseline/tag-search-doc-fn-prepare.js
@@ -2,6 +2,8 @@ import { util } from "@aws-appsync/utils";
 
 const FILTER_SPEC = [{i:"name",k:"term",f:"name"}, {i:"nameNot",k:"term_negate",f:"name"}, {i:"noteExists",k:"exists",f:"note.keyword"}];
 
+const AGG_SPEC = [{n:"byName",a:{ terms: { field: "name" } }}, {n:"uniqueNameCount",a:{ cardinality: { field: "name" } }}, {n:"missingNoteCount",a:{ missing: { field: "note.keyword" } }}];
+
 export function request(ctx) {
 	const args = ctx.args;
 	const size = Math.min(args.first || 20, 100);
@@ -20,13 +22,9 @@ export function request(ctx) {
 	if (searchAfter) {
 		body.search_after = searchAfter;
 	}
-	const wantsAggs = ctx.info.selectionSetList.some((p) => p === "aggregations" || p.indexOf("aggregations/") === 0);
-	if (wantsAggs) {
-		body.aggs = {
-		byName: { terms: { field: "name" } },
-		uniqueNameCount: { cardinality: { field: "name" } },
-		missingNoteCount: { missing: { field: "note.keyword" } },
-	};
+	const aggs = buildAggs(ctx.info.selectionSetList);
+	if (aggs) {
+		body.aggs = aggs;
 	}
 
 	ctx.stash.queryBody = body;
@@ -35,6 +33,26 @@ export function request(ctx) {
 
 export function response(ctx) {
 	return ctx.result;
+}
+
+function buildAggs(selectionSetList) {
+	// Only the aggregations named in the caller's selection are sent; `null`
+	// means none were, and the request omits the `aggs` key entirely.
+	const aggs = {};
+	let requested = false;
+	for (const spec of AGG_SPEC) {
+		if (selectionSetList.indexOf("aggregations/" + spec.n) >= 0) {
+			requested = true;
+			if (spec.g) {
+				const group = aggs[spec.g] || { nested: { path: spec.p }, aggs: {} };
+				group.aggs[spec.n] = spec.a;
+				aggs[spec.g] = group;
+			} else {
+				aggs[spec.n] = spec.a;
+			}
+		}
+	}
+	return requested ? aggs : null;
 }
 
 function buildQuery(queryText, filter, searchFilter) {

--- a/test/snapshots/opensearch-baseline/tag-search-doc-fn-prepare.js
+++ b/test/snapshots/opensearch-baseline/tag-search-doc-fn-prepare.js
@@ -36,12 +36,27 @@ export function response(ctx) {
 }
 
 function buildAggs(selectionSetList) {
-	// Only the aggregations named in the caller's selection are sent; `null`
-	// means none were, and the request omits the `aggs` key entirely.
+	// A first segment under `aggregations/` naming no AGG_SPEC entry is an
+	// alias, whose target is not recoverable here — send every aggregation
+	// rather than none.
+	let aliased = false;
+	for (const path of selectionSetList) {
+		if (path.indexOf("aggregations/") === 0) {
+			const rest = path.substring(13);
+			const slash = rest.indexOf("/");
+			const name = slash < 0 ? rest : rest.substring(0, slash);
+			let declared = false;
+			for (const spec of AGG_SPEC) {
+				if (spec.n === name) declared = true;
+			}
+			if (!declared) aliased = true;
+		}
+	}
+	// `null` means nothing was requested, and the request omits `aggs` entirely.
 	const aggs = {};
 	let requested = false;
 	for (const spec of AGG_SPEC) {
-		if (selectionSetList.indexOf("aggregations/" + spec.n) >= 0) {
+		if (aliased || selectionSetList.indexOf("aggregations/" + spec.n) >= 0) {
 			requested = true;
 			if (spec.g) {
 				const group = aggs[spec.g] || { nested: { path: spec.p }, aggs: {} };


### PR DESCRIPTION
Fixes defect (1) of #150.

An aggregation reaches OpenSearch only when the GraphQL caller names it. Selecting `byAdoptionStatus` sends `byAdoptionStatus`; it no longer drags along every `date_histogram`, metric, and nested agg group the projection declares. A nested group (`_adoptions`) is built only when at least one of its children is selected, and a query that selects no aggregation field sends no `aggs` key at all.

This makes each aggregation's cost and each aggregation's failure local to the queries that ask for it. Previously one aggregation OpenSearch rejects — an unbounded `date_histogram` over a far-future sentinel date — failed every aggregation query on the projection, including the ones that never referenced it.

The prepare function now carries `AGG_SPEC`, a compact name → agg-spec list, and assembles `body.aggs` from the entries named in `ctx.info.selectionSetList`.

## Aliased selections

`ctx.info.selectionSetList` names an aliased field by its alias only — the schema field name is absent — so `aggregations { speciesBuckets: bySpecies { key } }` carries nothing that identifies `bySpecies`. Narrowing on the field name alone sends no `aggs`, and because the response side reads defensively the caller gets an empty bucket list with a `200`, indistinguishable from a real empty result.

The valid children of `aggregations` are exactly the `AGG_SPEC` names, so a first segment naming none of them is an alias. Those queries get every aggregation — what they received before this change. Aliases below the aggregation name (`k: key`) leave the selection narrowed.

## Emitted size

The assembly code is fixed; `AGG_SPEC` scales linearly in the number of aggregations, as the object literal it replaces did. Net is a constant ~500 bytes per file over main.

On the synthetic wide projection that guards AppSync's 32 KB per-function cap, `prepare` goes 31,953 → 32,457 bytes, leaving 311 bytes of headroom. The real projections under test sit near 13.7 KB with ~19 KB of headroom.

Defects (2) `date_histogram` bounds and (3) datasource error propagation stay open on #150.

The OpenSearch baseline snapshot is re-captured: the prepare function's aggs block is the thing this changes.