### PR TITLE
fix(emitter): propagate OpenSearch datasource errors instead of a phantom ReferenceError

### DIFF
--- a/src/emit-graphql-resolver.test.ts
+++ b/src/emit-graphql-resolver.test.ts
@@ -130,6 +130,43 @@ function evalRequestBody(
 	);
 }
 
+type UtilError = Error & { errorType?: string; data?: unknown };
+
+/**
+ * Evaluates an emitted `response(ctx)` against a stub `util`, mirroring the
+ * AppSync runtime closely enough for issue #150: `util.error` interrupts
+ * evaluation, so it throws here and carries the errorType/data through for
+ * assertions. Returns the handler's value on the success path.
+ */
+function evalResponse(source: string, ctx: unknown): unknown {
+	const stripped = source
+		.replace(/^import \{ util \} from "@aws-appsync\/utils";?\n?/m, "")
+		.replace(/^export function /gm, "function ");
+	const factory = new Function("util", `${stripped}\nreturn response;`) as (
+		util: unknown,
+	) => (ctx: unknown) => unknown;
+	const utilStub = {
+		base64Decode: (s: string) => Buffer.from(s, "base64").toString("utf8"),
+		base64Encode: (s: string) => Buffer.from(s, "utf8").toString("base64"),
+		error: (message: string, errorType?: string, data?: unknown) => {
+			const err: UtilError = new Error(message);
+			err.errorType = errorType;
+			err.data = data;
+			throw err;
+		},
+	};
+	return factory(utilStub)(ctx);
+}
+
+function captureResponseError(source: string, ctx: unknown): UtilError {
+	try {
+		evalResponse(source, ctx);
+	} catch (err) {
+		return err as UtilError;
+	}
+	throw new Error("response(ctx) returned without raising an error");
+}
+
 type EmitResult = Awaited<ReturnType<typeof emitGraphQLResolver>>;
 
 /**
@@ -2320,6 +2357,144 @@ describe("emitGraphQLResolver search filter DSL", () => {
 				],
 			},
 		});
+	});
+});
+
+describe("emitGraphQLResolver datasource error propagation (issue #150)", () => {
+	const okBody = {
+		hits: {
+			total: { value: 1 },
+			hits: [{ _source: { name: "Rex" }, sort: [1] }],
+		},
+	};
+
+	// The reported failure: OpenSearch rejects the search, and the emitted code
+	// must name `too_many_buckets_exception` rather than let an undefined body
+	// reach the after-mapping and resurface as a phantom ReferenceError.
+	const osErrorBody = {
+		error: {
+			type: "too_many_buckets_exception",
+			reason:
+				"Trying to create too many buckets. Must be less than or equal to: [65535] but was [95947].",
+		},
+		status: 400,
+	};
+
+	async function emitPipeline(): Promise<EmitResult> {
+		return await emitGraphQLResolver(
+			makeProjection({ fields: [makeField({ name: "name" })] }),
+			defaultOptions,
+		);
+	}
+
+	it("search function surfaces ctx.error with its message and type", async () => {
+		const result = await emitPipeline();
+		const err = captureResponseError(searchFunctionContent(result), {
+			error: { message: "Connection refused", type: "ServiceUnavailable" },
+			result: undefined,
+		});
+
+		assert.equal(err.message, "Connection refused");
+		assert.equal(err.errorType, "ServiceUnavailable");
+	});
+
+	it("search function surfaces an OpenSearch error envelope's type and reason", async () => {
+		const result = await emitPipeline();
+		const err = captureResponseError(searchFunctionContent(result), {
+			result: osErrorBody,
+		});
+
+		assert.equal(err.errorType, "too_many_buckets_exception");
+		assert.match(err.message, /too many buckets/);
+		assert.match(err.message, /95947/);
+	});
+
+	it("search function surfaces a non-2xx datasource response", async () => {
+		const result = await emitPipeline();
+		const err = captureResponseError(searchFunctionContent(result), {
+			result: { statusCode: 503, body: "service unavailable" },
+		});
+
+		assert.equal(err.errorType, "OpenSearchError");
+		assert.match(err.message, /503/);
+		assert.match(err.message, /service unavailable/);
+	});
+
+	it("search function surfaces a missing result rather than passing undefined on", async () => {
+		const result = await emitPipeline();
+		const err = captureResponseError(searchFunctionContent(result), {
+			result: undefined,
+		});
+
+		assert.equal(err.errorType, "OpenSearchError");
+		assert.match(err.message, /OpenSearch search failed/);
+	});
+
+	it("search function passes a successful response through unchanged", async () => {
+		const result = await emitPipeline();
+		const passed = evalResponse(searchFunctionContent(result), {
+			result: okBody,
+		});
+
+		assert.deepEqual(passed, okBody);
+	});
+
+	it("after-mapping reports a missing body instead of a ReferenceError on parsedBody", async () => {
+		const result = await emitPipeline();
+		const err = captureResponseError(result.content, {
+			args: {},
+			prev: { result: undefined },
+		});
+
+		assert.equal(err.errorType, "OpenSearchError");
+		assert.match(err.message, /OpenSearch search failed/);
+		assert.doesNotMatch(
+			err.message,
+			/is not defined/,
+			"the after-mapping must name the real failure, not a phantom ReferenceError",
+		);
+	});
+
+	it("after-mapping surfaces an OpenSearch error envelope reaching ctx.prev.result", async () => {
+		const result = await emitPipeline();
+		const err = captureResponseError(result.content, {
+			args: {},
+			prev: { result: osErrorBody },
+		});
+
+		assert.equal(err.errorType, "too_many_buckets_exception");
+		assert.match(err.message, /too many buckets/);
+	});
+
+	it("after-mapping shapes a successful response unchanged", async () => {
+		const result = await emitPipeline();
+		const shaped = evalResponse(result.content, {
+			args: {},
+			prev: { result: okBody },
+		}) as { totalCount: number; edges: { node: unknown }[] };
+
+		assert.equal(shaped.totalCount, 1);
+		assert.deepEqual(shaped.edges[0].node, { name: "Rex" });
+	});
+
+	it("monolithic after-mapping guards a missing body too", async () => {
+		const result = await emitGraphQLResolver(
+			makeProjection({ fields: [makeField({ name: "name" })] }),
+			{ ...defaultOptions, monolithicThresholdBytes: 28_000 },
+		);
+		assert.equal(result.mode, "monolithic");
+
+		const err = captureResponseError(result.content, {
+			args: {},
+			result: osErrorBody,
+		});
+		assert.equal(err.errorType, "too_many_buckets_exception");
+
+		const shaped = evalResponse(result.content, {
+			args: {},
+			result: okBody,
+		}) as { totalCount: number };
+		assert.equal(shaped.totalCount, 1);
 	});
 });
 

--- a/src/emit-graphql-resolver.test.ts
+++ b/src/emit-graphql-resolver.test.ts
@@ -130,13 +130,20 @@ function evalRequestBody(
 	);
 }
 
-type UtilError = Error & { errorType?: string; data?: unknown };
+type UtilError = Error & {
+	errorType?: string;
+	data?: unknown;
+	errorInfo?: unknown;
+};
 
 /**
  * Evaluates an emitted `response(ctx)` against a stub `util`, mirroring the
  * AppSync runtime closely enough for issue #150: `util.error` interrupts
- * evaluation, so it throws here and carries the errorType/data through for
- * assertions. Returns the handler's value on the success path.
+ * evaluation, so it throws here and carries the errorType/data/errorInfo
+ * through for assertions. The stub takes all four documented arguments
+ * (`message`, `errorType`, `data`, `errorInfo`) so a diagnostic parked in the
+ * wrong slot is visible to a test rather than silently dropped at runtime.
+ * Returns the handler's value on the success path.
  */
 function evalResponse(source: string, ctx: unknown): unknown {
 	const stripped = source
@@ -148,10 +155,16 @@ function evalResponse(source: string, ctx: unknown): unknown {
 	const utilStub = {
 		base64Decode: (s: string) => Buffer.from(s, "base64").toString("utf8"),
 		base64Encode: (s: string) => Buffer.from(s, "utf8").toString("base64"),
-		error: (message: string, errorType?: string, data?: unknown) => {
+		error: (
+			message: string,
+			errorType?: string,
+			data?: unknown,
+			errorInfo?: unknown,
+		) => {
 			const err: UtilError = new Error(message);
 			err.errorType = errorType;
 			err.data = data;
+			err.errorInfo = errorInfo;
 			throw err;
 		},
 	};
@@ -2409,6 +2422,31 @@ describe("emitGraphQLResolver datasource error propagation (issue #150)", () => 
 		assert.match(err.message, /95947/);
 	});
 
+	it("search function carries the response body as errorInfo, not data", async () => {
+		const result = await emitPipeline();
+		const err = captureResponseError(searchFunctionContent(result), {
+			result: osErrorBody,
+		});
+
+		assert.deepEqual(
+			err.errorInfo,
+			osErrorBody,
+			"the body must travel as errorInfo; AppSync filters `data` against the query selection set, which an OpenSearch body shares no field with",
+		);
+		assert.equal(err.data, null);
+	});
+
+	it("search function carries ctx.result as errorInfo when ctx.error is set", async () => {
+		const result = await emitPipeline();
+		const err = captureResponseError(searchFunctionContent(result), {
+			error: { message: "Connection refused", type: "ServiceUnavailable" },
+			result: osErrorBody,
+		});
+
+		assert.deepEqual(err.errorInfo, osErrorBody);
+		assert.equal(err.data, null);
+	});
+
 	it("search function surfaces a non-2xx datasource response", async () => {
 		const result = await emitPipeline();
 		const err = captureResponseError(searchFunctionContent(result), {
@@ -2464,6 +2502,8 @@ describe("emitGraphQLResolver datasource error propagation (issue #150)", () => 
 
 		assert.equal(err.errorType, "too_many_buckets_exception");
 		assert.match(err.message, /too many buckets/);
+		assert.deepEqual(err.errorInfo, osErrorBody);
+		assert.equal(err.data, null);
 	});
 
 	it("after-mapping shapes a successful response unchanged", async () => {

--- a/src/emit-graphql-resolver.ts
+++ b/src/emit-graphql-resolver.ts
@@ -249,7 +249,7 @@ export function response(ctx) {
 	}
 
 	const parsedBody = ctx.result;
-	const hits = parsedBody.hits.hits;
+${renderSearchBodyGuard("parsedBody", "\t")}	const hits = parsedBody.hits.hits;
 	const totalHits = parsedBody.hits.total.value;
 	const args = ctx.args;
 	const size = Math.min(args.first || ${options.defaultPageSize}, ${options.maxPageSize});
@@ -525,7 +525,7 @@ export function response(ctx) {
 	}
 
 	const parsedBody = ctx.prev.result;
-	const hits = parsedBody.hits.hits;
+${renderSearchBodyGuard("parsedBody", "\t")}	const hits = parsedBody.hits.hits;
 	const totalHits = parsedBody.hits.total.value;
 	const args = ctx.args;
 	const size = Math.min(args.first || ${options.defaultPageSize}, ${options.maxPageSize});
@@ -880,9 +880,17 @@ function applyFilterSpec(rootSpec, rootInput, rootOutFilters, rootOutMustNots) {
  * from `ctx.stash.queryBody` (set by the prepare function) and issues the
  * OS HTTP request. Tiny on purpose — the heavy filter/aggs construction
  * lives in the prepare function where it has its own 32 KB budget.
+ *
+ * The response handler must fail loudly (issue #150): returning `ctx.result`
+ * unchecked lets a failed search through as `undefined`, which the resolver
+ * after-mapping then dereferences — the AppSync JS runtime reports that as
+ * `ReferenceError: parsedBody is not defined`, naming neither the status code
+ * nor the OpenSearch reason.
  */
 function renderSearchFunction(indexName: string): string {
-	return `export function request(ctx) {
+	return `import { util } from "@aws-appsync/utils";
+
+export function request(ctx) {
 	return {
 		operation: "GET",
 		path: "/${indexName}/_search",
@@ -891,8 +899,35 @@ function renderSearchFunction(indexName: string): string {
 }
 
 export function response(ctx) {
-	return ctx.result;
+	if (ctx.error) {
+		return util.error(ctx.error.message, ctx.error.type, ctx.result);
+	}
+${renderSearchBodyGuard("ctx.result", "\t")}	return ctx.result;
 }
+`;
+}
+
+/**
+ * Guard an OpenSearch response body before anything dereferences `.hits`.
+ *
+ * Covers three failure shapes the datasource can hand back without setting
+ * `ctx.error`: a missing body, an OpenSearch error envelope
+ * (`{ error: { type, reason }, status }` — this is how `too_many_buckets_exception`
+ * arrives), and a raw non-2xx HTTP response (`{ statusCode, body }`). Each one
+ * surfaces the real type and reason instead of a phantom ReferenceError one
+ * line later.
+ */
+function renderSearchBodyGuard(expr: string, indent: string): string {
+	const i = indent;
+	return `${i}if (!${expr} || !${expr}.hits) {
+${i}	const err = ${expr} ? ${expr}.error : null;
+${i}	const status = ${expr} ? ${expr}.status || ${expr}.statusCode : null;
+${i}	return util.error(
+${i}		(err && err.reason) || "OpenSearch search failed" + (status ? " with status " + status : "") + ": " + JSON.stringify(${expr}),
+${i}		(err && err.type) || "OpenSearchError",
+${i}		${expr},
+${i}	);
+${i}}
 `;
 }
 

--- a/src/emit-graphql-resolver.ts
+++ b/src/emit-graphql-resolver.ts
@@ -900,7 +900,7 @@ export function request(ctx) {
 
 export function response(ctx) {
 	if (ctx.error) {
-		return util.error(ctx.error.message, ctx.error.type, ctx.result);
+		return util.error(ctx.error.message, ctx.error.type, null, ctx.result);
 	}
 ${renderSearchBodyGuard("ctx.result", "\t")}	return ctx.result;
 }
@@ -916,6 +916,12 @@ ${renderSearchBodyGuard("ctx.result", "\t")}	return ctx.result;
  * arrives), and a raw non-2xx HTTP response (`{ statusCode, body }`). Each one
  * surfaces the real type and reason instead of a phantom ReferenceError one
  * line later.
+ *
+ * The body travels as `errorInfo` (4th arg), not `data` (3rd): AppSync filters
+ * `data` against the field's query selection set, and an OpenSearch body
+ * (`hits`/`error`/`status`) shares no field with a Connection selection
+ * (`totalCount`/`edges`/`aggregations`), so it would filter down to nothing and
+ * never reach the client. `errorInfo` is not filtered.
  */
 function renderSearchBodyGuard(expr: string, indent: string): string {
 	const i = indent;
@@ -925,6 +931,7 @@ ${i}	const status = ${expr} ? ${expr}.status || ${expr}.statusCode : null;
 ${i}	return util.error(
 ${i}		(err && err.reason) || "OpenSearch search failed" + (status ? " with status " + status : "") + ": " + JSON.stringify(${expr}),
 ${i}		(err && err.type) || "OpenSearchError",
+${i}		null,
 ${i}		${expr},
 ${i}	);
 ${i}}

--- a/test/snapshots/opensearch-baseline/person-search-doc-fn-search.js
+++ b/test/snapshots/opensearch-baseline/person-search-doc-fn-search.js
@@ -10,7 +10,7 @@ export function request(ctx) {
 
 export function response(ctx) {
 	if (ctx.error) {
-		return util.error(ctx.error.message, ctx.error.type, ctx.result);
+		return util.error(ctx.error.message, ctx.error.type, null, ctx.result);
 	}
 	if (!ctx.result || !ctx.result.hits) {
 		const err = ctx.result ? ctx.result.error : null;
@@ -18,6 +18,7 @@ export function response(ctx) {
 		return util.error(
 			(err && err.reason) || "OpenSearch search failed" + (status ? " with status " + status : "") + ": " + JSON.stringify(ctx.result),
 			(err && err.type) || "OpenSearchError",
+			null,
 			ctx.result,
 		);
 	}

--- a/test/snapshots/opensearch-baseline/person-search-doc-fn-search.js
+++ b/test/snapshots/opensearch-baseline/person-search-doc-fn-search.js
@@ -1,3 +1,5 @@
+import { util } from "@aws-appsync/utils";
+
 export function request(ctx) {
 	return {
 		operation: "GET",
@@ -7,5 +9,17 @@ export function request(ctx) {
 }
 
 export function response(ctx) {
+	if (ctx.error) {
+		return util.error(ctx.error.message, ctx.error.type, ctx.result);
+	}
+	if (!ctx.result || !ctx.result.hits) {
+		const err = ctx.result ? ctx.result.error : null;
+		const status = ctx.result ? ctx.result.status || ctx.result.statusCode : null;
+		return util.error(
+			(err && err.reason) || "OpenSearch search failed" + (status ? " with status " + status : "") + ": " + JSON.stringify(ctx.result),
+			(err && err.type) || "OpenSearchError",
+			ctx.result,
+		);
+	}
 	return ctx.result;
 }

--- a/test/snapshots/opensearch-baseline/person-search-doc-resolver.js
+++ b/test/snapshots/opensearch-baseline/person-search-doc-resolver.js
@@ -16,6 +16,7 @@ export function response(ctx) {
 		return util.error(
 			(err && err.reason) || "OpenSearch search failed" + (status ? " with status " + status : "") + ": " + JSON.stringify(parsedBody),
 			(err && err.type) || "OpenSearchError",
+			null,
 			parsedBody,
 		);
 	}

--- a/test/snapshots/opensearch-baseline/person-search-doc-resolver.js
+++ b/test/snapshots/opensearch-baseline/person-search-doc-resolver.js
@@ -10,6 +10,15 @@ export function response(ctx) {
 	}
 
 	const parsedBody = ctx.prev.result;
+	if (!parsedBody || !parsedBody.hits) {
+		const err = parsedBody ? parsedBody.error : null;
+		const status = parsedBody ? parsedBody.status || parsedBody.statusCode : null;
+		return util.error(
+			(err && err.reason) || "OpenSearch search failed" + (status ? " with status " + status : "") + ": " + JSON.stringify(parsedBody),
+			(err && err.type) || "OpenSearchError",
+			parsedBody,
+		);
+	}
 	const hits = parsedBody.hits.hits;
 	const totalHits = parsedBody.hits.total.value;
 	const args = ctx.args;

--- a/test/snapshots/opensearch-baseline/pet-public-search-doc-fn-search.js
+++ b/test/snapshots/opensearch-baseline/pet-public-search-doc-fn-search.js
@@ -10,7 +10,7 @@ export function request(ctx) {
 
 export function response(ctx) {
 	if (ctx.error) {
-		return util.error(ctx.error.message, ctx.error.type, ctx.result);
+		return util.error(ctx.error.message, ctx.error.type, null, ctx.result);
 	}
 	if (!ctx.result || !ctx.result.hits) {
 		const err = ctx.result ? ctx.result.error : null;
@@ -18,6 +18,7 @@ export function response(ctx) {
 		return util.error(
 			(err && err.reason) || "OpenSearch search failed" + (status ? " with status " + status : "") + ": " + JSON.stringify(ctx.result),
 			(err && err.type) || "OpenSearchError",
+			null,
 			ctx.result,
 		);
 	}

--- a/test/snapshots/opensearch-baseline/pet-public-search-doc-fn-search.js
+++ b/test/snapshots/opensearch-baseline/pet-public-search-doc-fn-search.js
@@ -1,3 +1,5 @@
+import { util } from "@aws-appsync/utils";
+
 export function request(ctx) {
 	return {
 		operation: "GET",
@@ -7,5 +9,17 @@ export function request(ctx) {
 }
 
 export function response(ctx) {
+	if (ctx.error) {
+		return util.error(ctx.error.message, ctx.error.type, ctx.result);
+	}
+	if (!ctx.result || !ctx.result.hits) {
+		const err = ctx.result ? ctx.result.error : null;
+		const status = ctx.result ? ctx.result.status || ctx.result.statusCode : null;
+		return util.error(
+			(err && err.reason) || "OpenSearch search failed" + (status ? " with status " + status : "") + ": " + JSON.stringify(ctx.result),
+			(err && err.type) || "OpenSearchError",
+			ctx.result,
+		);
+	}
 	return ctx.result;
 }

--- a/test/snapshots/opensearch-baseline/pet-public-search-doc-resolver.js
+++ b/test/snapshots/opensearch-baseline/pet-public-search-doc-resolver.js
@@ -16,6 +16,7 @@ export function response(ctx) {
 		return util.error(
 			(err && err.reason) || "OpenSearch search failed" + (status ? " with status " + status : "") + ": " + JSON.stringify(parsedBody),
 			(err && err.type) || "OpenSearchError",
+			null,
 			parsedBody,
 		);
 	}

--- a/test/snapshots/opensearch-baseline/pet-public-search-doc-resolver.js
+++ b/test/snapshots/opensearch-baseline/pet-public-search-doc-resolver.js
@@ -10,6 +10,15 @@ export function response(ctx) {
 	}
 
 	const parsedBody = ctx.prev.result;
+	if (!parsedBody || !parsedBody.hits) {
+		const err = parsedBody ? parsedBody.error : null;
+		const status = parsedBody ? parsedBody.status || parsedBody.statusCode : null;
+		return util.error(
+			(err && err.reason) || "OpenSearch search failed" + (status ? " with status " + status : "") + ": " + JSON.stringify(parsedBody),
+			(err && err.type) || "OpenSearchError",
+			parsedBody,
+		);
+	}
 	const hits = parsedBody.hits.hits;
 	const totalHits = parsedBody.hits.total.value;
 	const args = ctx.args;

--- a/test/snapshots/opensearch-baseline/pet-search-doc-fn-search.js
+++ b/test/snapshots/opensearch-baseline/pet-search-doc-fn-search.js
@@ -10,7 +10,7 @@ export function request(ctx) {
 
 export function response(ctx) {
 	if (ctx.error) {
-		return util.error(ctx.error.message, ctx.error.type, ctx.result);
+		return util.error(ctx.error.message, ctx.error.type, null, ctx.result);
 	}
 	if (!ctx.result || !ctx.result.hits) {
 		const err = ctx.result ? ctx.result.error : null;
@@ -18,6 +18,7 @@ export function response(ctx) {
 		return util.error(
 			(err && err.reason) || "OpenSearch search failed" + (status ? " with status " + status : "") + ": " + JSON.stringify(ctx.result),
 			(err && err.type) || "OpenSearchError",
+			null,
 			ctx.result,
 		);
 	}

--- a/test/snapshots/opensearch-baseline/pet-search-doc-fn-search.js
+++ b/test/snapshots/opensearch-baseline/pet-search-doc-fn-search.js
@@ -1,3 +1,5 @@
+import { util } from "@aws-appsync/utils";
+
 export function request(ctx) {
 	return {
 		operation: "GET",
@@ -7,5 +9,17 @@ export function request(ctx) {
 }
 
 export function response(ctx) {
+	if (ctx.error) {
+		return util.error(ctx.error.message, ctx.error.type, ctx.result);
+	}
+	if (!ctx.result || !ctx.result.hits) {
+		const err = ctx.result ? ctx.result.error : null;
+		const status = ctx.result ? ctx.result.status || ctx.result.statusCode : null;
+		return util.error(
+			(err && err.reason) || "OpenSearch search failed" + (status ? " with status " + status : "") + ": " + JSON.stringify(ctx.result),
+			(err && err.type) || "OpenSearchError",
+			ctx.result,
+		);
+	}
 	return ctx.result;
 }

--- a/test/snapshots/opensearch-baseline/pet-search-doc-resolver.js
+++ b/test/snapshots/opensearch-baseline/pet-search-doc-resolver.js
@@ -16,6 +16,7 @@ export function response(ctx) {
 		return util.error(
 			(err && err.reason) || "OpenSearch search failed" + (status ? " with status " + status : "") + ": " + JSON.stringify(parsedBody),
 			(err && err.type) || "OpenSearchError",
+			null,
 			parsedBody,
 		);
 	}

--- a/test/snapshots/opensearch-baseline/pet-search-doc-resolver.js
+++ b/test/snapshots/opensearch-baseline/pet-search-doc-resolver.js
@@ -10,6 +10,15 @@ export function response(ctx) {
 	}
 
 	const parsedBody = ctx.prev.result;
+	if (!parsedBody || !parsedBody.hits) {
+		const err = parsedBody ? parsedBody.error : null;
+		const status = parsedBody ? parsedBody.status || parsedBody.statusCode : null;
+		return util.error(
+			(err && err.reason) || "OpenSearch search failed" + (status ? " with status " + status : "") + ": " + JSON.stringify(parsedBody),
+			(err && err.type) || "OpenSearchError",
+			parsedBody,
+		);
+	}
 	const hits = parsedBody.hits.hits;
 	const totalHits = parsedBody.hits.total.value;
 	const args = ctx.args;

--- a/test/snapshots/opensearch-baseline/tag-search-doc-fn-search.js
+++ b/test/snapshots/opensearch-baseline/tag-search-doc-fn-search.js
@@ -10,7 +10,7 @@ export function request(ctx) {
 
 export function response(ctx) {
 	if (ctx.error) {
-		return util.error(ctx.error.message, ctx.error.type, ctx.result);
+		return util.error(ctx.error.message, ctx.error.type, null, ctx.result);
 	}
 	if (!ctx.result || !ctx.result.hits) {
 		const err = ctx.result ? ctx.result.error : null;
@@ -18,6 +18,7 @@ export function response(ctx) {
 		return util.error(
 			(err && err.reason) || "OpenSearch search failed" + (status ? " with status " + status : "") + ": " + JSON.stringify(ctx.result),
 			(err && err.type) || "OpenSearchError",
+			null,
 			ctx.result,
 		);
 	}

--- a/test/snapshots/opensearch-baseline/tag-search-doc-fn-search.js
+++ b/test/snapshots/opensearch-baseline/tag-search-doc-fn-search.js
@@ -1,3 +1,5 @@
+import { util } from "@aws-appsync/utils";
+
 export function request(ctx) {
 	return {
 		operation: "GET",
@@ -7,5 +9,17 @@ export function request(ctx) {
 }
 
 export function response(ctx) {
+	if (ctx.error) {
+		return util.error(ctx.error.message, ctx.error.type, ctx.result);
+	}
+	if (!ctx.result || !ctx.result.hits) {
+		const err = ctx.result ? ctx.result.error : null;
+		const status = ctx.result ? ctx.result.status || ctx.result.statusCode : null;
+		return util.error(
+			(err && err.reason) || "OpenSearch search failed" + (status ? " with status " + status : "") + ": " + JSON.stringify(ctx.result),
+			(err && err.type) || "OpenSearchError",
+			ctx.result,
+		);
+	}
 	return ctx.result;
 }

--- a/test/snapshots/opensearch-baseline/tag-search-doc-resolver.js
+++ b/test/snapshots/opensearch-baseline/tag-search-doc-resolver.js
@@ -16,6 +16,7 @@ export function response(ctx) {
 		return util.error(
 			(err && err.reason) || "OpenSearch search failed" + (status ? " with status " + status : "") + ": " + JSON.stringify(parsedBody),
 			(err && err.type) || "OpenSearchError",
+			null,
 			parsedBody,
 		);
 	}

--- a/test/snapshots/opensearch-baseline/tag-search-doc-resolver.js
+++ b/test/snapshots/opensearch-baseline/tag-search-doc-resolver.js
@@ -10,6 +10,15 @@ export function response(ctx) {
 	}
 
 	const parsedBody = ctx.prev.result;
+	if (!parsedBody || !parsedBody.hits) {
+		const err = parsedBody ? parsedBody.error : null;
+		const status = parsedBody ? parsedBody.status || parsedBody.statusCode : null;
+		return util.error(
+			(err && err.reason) || "OpenSearch search failed" + (status ? " with status " + status : "") + ": " + JSON.stringify(parsedBody),
+			(err && err.type) || "OpenSearchError",
+			parsedBody,
+		);
+	}
 	const hits = parsedBody.hits.hits;
 	const totalHits = parsedBody.hits.total.value;
 	const args = ctx.args;


### PR DESCRIPTION
Fixes defect (3) of #150.

An OpenSearch failure currently reaches the client as `ReferenceError: parsedBody is not defined` — pointing at a variable that is plainly declared, one line past the real failure, and naming nothing about what actually went wrong. The status code and reason reach neither the client nor the logs. Diagnosing any search failure means reconstructing the emitted query body and replaying it against the cluster by hand.

The search pipeline function returned `ctx.result` without inspecting `ctx.error`, so a failed search arrived at the resolver after-mapping as `undefined`. The AppSync JS runtime reports a `const` bound to `undefined` as a ReferenceError on reference, which is where the phantom comes from.

The emitted search function now raises `ctx.error` through `util.error(message, type, result)`, and both after-mappings (pipeline and monolithic) guard the response body before dereferencing it. The guard covers the two failure shapes that arrive with `ctx.error` unset: an OpenSearch error envelope (`{ error: { type, reason }, status }` — how `too_many_buckets_exception` from the reported bug arrives) and a raw non-2xx response (`{ statusCode, body }`). Each surfaces the real type and reason.

Tests execute the emitted handlers against a stub `util` where `util.error` interrupts evaluation as it does in the runtime, covering both the failure paths and unchanged pass-through on success. The emit baseline is re-captured; the diff is additive and confined to the search functions and after-mappings.

The OpenSearch body reaches the client as `errorInfo`, not `data`: AppSync filters `data` against the field's query selection set, which an OpenSearch body shares no field with.

Defect (1) is already released in v1.31.2. Defect (2) — bounding `date_histogram` — is untouched and still open.

## Size

The 32 KB per-file cap is unaffected where it is tight. The constrained file in the synthetic wide-projection guard is `prepare`, which this change does not touch:

| file | before | after | headroom |
| --- | --- | --- | --- |
| prepare | 32,482 | 32,482 | 286 |
| resolver | 14,056 | 14,458 | 18,310 |
| search | 191 | 732 | 32,036 |

