### PR TITLE
feat(graphql): bound date_histogram bucket count, with a bounds opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ In this example:
 | `@indexName("name")` | `Model` (projection) | Sets an explicit index name for the projection. | `@indexName("pets_v1") model PetSearchDoc ...` |
 | `@indexSettings(json)` | `Model` (projection) | Embeds index settings (e.g. analysis config) in the mapping output. Value must be valid JSON. | See example below. |
 | `@searchAs("name")` | `ModelProperty` | Renames the field in mapping and TypeScript output. Can be set on source or projection (projection wins). | `@searchAs("firstName") givenName: string;` |
-| `@aggregatable(...kinds)` / `@aggregatable(kind, options)` | `ModelProperty` | Declares OpenSearch aggregations on the GraphQL connection. Allowed kinds: `"terms"`, `"cardinality"`, `"missing"`, `"sum"`, `"avg"`, `"min"`, `"max"`, `"date_histogram"`, `"range"`. Multi-arg form emits all listed string kinds. The single-kind-with-options form is required for `"date_histogram"`, `"range"`, and `"terms"`-with-sub or `"terms"`-with-`topHits`. `topHits: N` adds a `top_hits: { size: N }` sub-agg so each bucket carries up to N matching docs. See [Aggregations](#aggregations-aggregatable). | `@aggregatable("terms", "cardinality") locations: Location[];` / `@aggregatable("terms", #{ topHits: 5 }) tagId: string;` |
+| `@aggregatable(...kinds)` / `@aggregatable(kind, options)` | `ModelProperty` | Declares OpenSearch aggregations on the GraphQL connection. Allowed kinds: `"terms"`, `"cardinality"`, `"missing"`, `"sum"`, `"avg"`, `"min"`, `"max"`, `"date_histogram"`, `"range"`. Multi-arg form emits all listed string kinds. The single-kind-with-options form is required for `"date_histogram"`, `"range"`, and `"terms"`-with-sub or `"terms"`-with-`topHits`. `topHits: N` adds a `top_hits: { size: N }` sub-agg so each bucket carries up to N matching docs. `"date_histogram"` takes an optional `bounds: #{ min?, max? }` that pins its range and with it the declared interval; without bounds the emitter caps the bucket count instead — see [Bounding a `date_histogram`](#bounding-a-date_histogram). See [Aggregations](#aggregations-aggregatable). | `@aggregatable("terms", "cardinality") locations: Location[];` / `@aggregatable("terms", #{ topHits: 5 }) tagId: string;` / `@aggregatable("date_histogram", #{ interval: "month", bounds: #{ min: "now-5y", max: "now" } }) validTo: utcDateTime;` |
 | `@filterable(...kinds)` | `ModelProperty` | Declares filter inputs on the GraphQL `<Type>SearchFilter` input. Allowed kinds: `"term"`, `"term_negate"`, `"terms"`, `"exists"`, `"range"`, `"prefix"`, `"match"`. `"terms"` produces a `<field>In: [Type!]` multi-value input (chip-style filters). On a `@nested` array field, `"exists"` becomes a path-level nested-existence check. `"prefix"` (`<field>Prefix: String`, OpenSearch `prefix`) and `"match"` (`<field>Match: String`, OpenSearch `match`) query the **analyzed** field rather than the `.keyword` sub-field, so an `@analyzer` (e.g. edge-ngram) registered on the field is exercised by the query — this is how partial / begins-with / contains matching is expressed. | `@filterable("term", "terms") status: string;` / `@analyzer("edge_ngram") @filterable("prefix", "match") name: string;` |
 | `@searchInfer` | `Model` (projection) | Walks the source model's fields and applies type-driven default `@filterable` / `@aggregatable` / `@sortable` capabilities (see [Inference](#searchinfer-type-driven-defaults)). Explicit decorators on a field always win on their axis. | `@searchInfer model TradeSearchDoc is SearchProjection<Trade> {}` |
 | `@searchSkip` | `ModelProperty` | Opts a field out of `@searchInfer` inference. The field is still included in response shape if `@searchable` / `@nested` apply; without those, the field is excluded entirely. | `@searchable @searchSkip auditTrail: string;` |
@@ -278,7 +278,7 @@ Stacking `@filterable` and `@aggregatable` per field becomes noisy on a typical 
 
 | Field type | Default `@filterable` | Default `@aggregatable` | Default `@sortable` |
 | --- | --- | --- | --- |
-| `utcDateTime` / `plainDate` | `range` | `date_histogram(month)` | yes |
+| `utcDateTime` / `plainDate` | `range` | `date_histogram(month)`, unbounded — see [Bounding a `date_histogram`](#bounding-a-date_histogram) | yes |
 | `string` + `@keyword` | `term`, `terms`, `exists` | `terms` | yes |
 | free-text `string` (no `@keyword`) | (none) | (none) | no |
 | numeric (`int*`, `float*`, `decimal`, …) | `range` | `sum`, `avg`, `min`, `max` | yes |
@@ -369,6 +369,7 @@ In the example above:
 | `graphql.max-page-size` | `number` | `100` | Maximum allowed page size. |
 | `graphql.track-total-hits-up-to` | `number` | `10000` | OpenSearch `track_total_hits` limit. |
 | `graphql.monolithic-threshold-bytes` | `number` | `32000` | Rendered-resolver size above which the pipeline split is emitted instead of a single file. See [Resolver code-size budget](#resolver-code-size-budget). |
+| `graphql.auto-date-histogram-buckets` | `number` | `10000` | Bucket ceiling for a `date_histogram` declared without `bounds`. Decides how wide a range keeps the declared interval before OpenSearch steps to a coarser one. Must stay under `search.max_buckets` (default 65,535). See [Bounding a `date_histogram`](#bounding-a-date_histogram). |
 
 The `emitter-output-dir` option is a standard TypeSpec compiler option that controls the output directory.
 
@@ -526,7 +527,29 @@ Field-name conventions in the generated `*SearchAggregations` type (singular for
 | `date_histogram` | `by<Field>OverTime` | `[DateHistogramBucket!]!` |
 | `range` | `by<Field>Range` | `[RangeBucket!]!` |
 
-`date_histogram` requires `interval` (one of `year`, `quarter`, `month`, `week`, `day`, `hour` — defaults to `month` if omitted). `range` requires `ranges` (array of `{ from?, to?, key? }`; each entry must set at least one of `from` / `to`). `terms` `sub` allows numeric metric sub-aggregations (`sum`/`avg`/`min`/`max`/`cardinality`) keyed by output bucket field name.
+`date_histogram` requires `interval` (one of `year`, `quarter`, `month`, `week`, `day`, `hour` — defaults to `month` if omitted) and takes an optional `bounds` — see [Bounding a date_histogram](#bounding-a-date_histogram). `range` requires `ranges` (array of `{ from?, to?, key? }`; each entry must set at least one of `from` / `to`). `terms` `sub` allows numeric metric sub-aggregations (`sum`/`avg`/`min`/`max`/`cardinality`) keyed by output bucket field name.
+
+#### Bounding a `date_histogram`
+
+A `date_histogram` covers the full range its data spans. A fixed interval over a wide range therefore has no bucket ceiling: a far-future sentinel date — `validTo = 9999-12-31` for "no end date" is ordinary domain data — puts a monthly histogram at roughly 96,000 buckets. OpenSearch caps a search at `search.max_buckets` (default 65,535) and rejects the whole search when it is exceeded, including the aggregations that had nothing to do with the date field.
+
+A fixed interval over an unbounded range cannot survive, so either the interval or the range has to give. The emitter bends the interval and never the range: narrowing the range would silently drop documents from the answer, while a coarser interval still counts every document and only lowers resolution.
+
+**Declare `bounds` when you need the interval fixed.** The bounds pin the range, so the declared interval is emitted as-is:
+
+```typespec
+@searchable
+@aggregatable("date_histogram", #{ interval: "month", bounds: #{ min: "2020-01-01T00:00:00Z", max: "now" } })
+validTo: utcDateTime;
+```
+
+This emits a `date_histogram` with `calendar_interval` and `hard_bounds`. `min` and `max` each accept an ISO 8601 instant or OpenSearch date math (`"now-5y"`); at least one is required, and an omitted end tracks the data. Documents outside the bounds still match the query and count toward `totalCount` — only the buckets stop there.
+
+**Without `bounds`, the emitter caps the bucket count instead.** It emits an `auto_date_histogram` with `minimum_interval` set to your declared interval, so OpenSearch uses that interval whenever the range allows and steps to a coarser one only when it would not fit. Normal data keeps its declared interval; the sentinel case above returns yearly buckets and a chart that renders rather than a failed search. The response reports the interval actually chosen.
+
+The ceiling is 10,000 buckets, configurable via [`graphql.auto-date-histogram-buckets`](#emitter-options). It holds 833 years of monthly buckets, 27 years of daily and 1.1 years of hourly — past any real corpus — and stays an order of magnitude under `search.max_buckets` so one histogram cannot starve the aggregations beside it.
+
+**`week` and `quarter` are the exception.** OpenSearch's `minimum_interval` accepts only `year`, `month`, `day`, `hour`, `minute` and `second`, so these two intervals have no automatic ceiling: flooring at `day` or `month` would silently make the chart finer than declared, and `year` would make it coarser. They keep the plain `date_histogram` they have always emitted, and the emitter warns that `bounds` is the only lever available. Declare `bounds` on a `week` or `quarter` histogram whose field may hold a sentinel.
 
 The `.keyword` sub-field is applied automatically when the underlying type is text. Numeric, date, and `@keyword` fields use the bare field name. Filter-only / agg-only fields (no `@searchable`) are mapped as plain keyword in OpenSearch — see [Decorator coverage](#searchable-and-searchprojectiont) for what each decorator contributes.
 

--- a/src/decorators.test.ts
+++ b/src/decorators.test.ts
@@ -456,7 +456,10 @@ describe("decorators", () => {
 			?.properties.get("validTo");
 		assert.ok(validTo);
 		assert.deepEqual(getAggregatableDirectives(runner.program, validTo), [
-			{ kind: "date_histogram", options: { interval: "month", bounds: { max: "now" } } },
+			{
+				kind: "date_histogram",
+				options: { interval: "month", bounds: { max: "now" } },
+			},
 		]);
 	});
 

--- a/src/decorators.test.ts
+++ b/src/decorators.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 
 import { createTestHost, createTestWrapper } from "@typespec/compiler/testing";
 import {
+	getAggregatableDirectives,
 	getAggregatableKinds,
 	getAnalyzer,
 	getBoost,
@@ -411,6 +412,110 @@ describe("decorators", () => {
 
 		const codes = diagnostics.map((x) => x.code);
 		assert.equal(hasDiagnosticCode(codes, "invalid-aggregation-kind"), true);
+	});
+
+	it("stores date_histogram bounds", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Product {
+        @aggregatable("date_histogram", #{ interval: "month", bounds: #{ min: "2020-01-01T00:00:00Z", max: "now" } })
+        @searchable validTo: utcDateTime;
+      }
+    `);
+
+		assert.equal(diagnostics.length, 0);
+		const validTo = runner.program
+			.getGlobalNamespaceType()
+			.models.get("Product")
+			?.properties.get("validTo");
+		assert.ok(validTo);
+		assert.deepEqual(getAggregatableDirectives(runner.program, validTo), [
+			{
+				kind: "date_histogram",
+				options: {
+					interval: "month",
+					bounds: { min: "2020-01-01T00:00:00Z", max: "now" },
+				},
+			},
+		]);
+	});
+
+	it("accepts date_histogram bounds with only one end", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Product {
+        @aggregatable("date_histogram", #{ interval: "month", bounds: #{ max: "now" } })
+        @searchable validTo: utcDateTime;
+      }
+    `);
+
+		assert.equal(diagnostics.length, 0);
+		const validTo = runner.program
+			.getGlobalNamespaceType()
+			.models.get("Product")
+			?.properties.get("validTo");
+		assert.ok(validTo);
+		assert.deepEqual(getAggregatableDirectives(runner.program, validTo), [
+			{ kind: "date_histogram", options: { interval: "month", bounds: { max: "now" } } },
+		]);
+	});
+
+	it("emits diagnostic for empty date_histogram bounds", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Product {
+        @aggregatable("date_histogram", #{ interval: "month", bounds: #{} })
+        @searchable validTo: utcDateTime;
+      }
+    `);
+
+		const codes = diagnostics.map((x) => x.code);
+		assert.equal(hasDiagnosticCode(codes, "invalid-aggregation-options"), true);
+	});
+
+	// Issue #150: auto_date_histogram's minimum_interval has no week/quarter
+	// spelling, so these two intervals cannot get an automatic bucket ceiling.
+	// Warn rather than error — existing specs must keep compiling.
+	it("warns when a week/quarter date_histogram declares no bounds", async () => {
+		for (const interval of ["week", "quarter"]) {
+			const runner = await createRunner();
+			const diagnostics = await runner.diagnose(`
+        model Product {
+          @aggregatable("date_histogram", #{ interval: "${interval}" })
+          @searchable validTo: utcDateTime;
+        }
+      `);
+
+			const warning = diagnostics.find(
+				(x) => x.code.indexOf("unboundable-date-histogram-interval") !== -1,
+			);
+			assert.ok(warning, `${interval} without bounds should warn`);
+			assert.equal(warning.severity, "warning");
+		}
+	});
+
+	it("does not warn when a week/quarter date_histogram declares bounds", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Product {
+        @aggregatable("date_histogram", #{ interval: "week", bounds: #{ min: "now-1y", max: "now" } })
+        @searchable validTo: utcDateTime;
+      }
+    `);
+
+		assert.equal(diagnostics.length, 0);
+	});
+
+	it("does not warn for an interval auto_date_histogram can floor", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Product {
+        @aggregatable("date_histogram", #{ interval: "month" })
+        @searchable validTo: utcDateTime;
+      }
+    `);
+
+		assert.equal(diagnostics.length, 0);
 	});
 
 	it("stores @filterable kinds with single argument", async () => {

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -373,8 +373,41 @@ export interface RangeBucketSpec {
 	to?: number;
 }
 
+/**
+ * Intervals that `auto_date_histogram`'s `minimum_interval` accepts. OpenSearch
+ * takes only `year`, `month`, `day`, `hour`, `minute` and `second` there — the
+ * `week` and `quarter` that `date_histogram`'s `calendar_interval` accepts have
+ * no `minimum_interval` spelling. Issue #150.
+ */
+export const MINIMUM_INTERVAL_SUPPORTED = [
+	"year",
+	"month",
+	"day",
+	"hour",
+] as const;
+
+export function supportsMinimumInterval(interval: DateHistogramInterval) {
+	return (MINIMUM_INTERVAL_SUPPORTED as readonly string[]).includes(interval);
+}
+
+/**
+ * `hard_bounds` for a `date_histogram`. Values are whatever OpenSearch accepts
+ * as a date: an ISO 8601 instant (`"2020-01-01T00:00:00Z"`) or date math
+ * (`"now-5y"`). At least one end is required; an omitted end tracks the data.
+ */
+export interface DateHistogramBounds {
+	min?: string;
+	max?: string;
+}
+
 export interface DateHistogramOptions {
 	interval: DateHistogramInterval;
+	/**
+	 * Bounds the histogram's range, which pins the bucket interval to the
+	 * declared `interval`. Absent, the emitter bounds the *bucket count*
+	 * instead by emitting `auto_date_histogram` — see issue #150.
+	 */
+	bounds?: DateHistogramBounds;
 }
 
 export interface RangeOptions {
@@ -425,6 +458,40 @@ function isSubAggKind(value: unknown): value is SubAggKind {
 	);
 }
 
+function validateDateHistogramBounds(
+	context: DecoratorContext,
+	target: ModelProperty,
+	kind: AggregationKind,
+	raw: unknown,
+): DateHistogramBounds | undefined {
+	const reason = (detail: string) => {
+		reportDiagnostic(context.program, {
+			code: "invalid-aggregation-options",
+			format: { kind, reason: detail },
+			target,
+		});
+		return undefined;
+	};
+	if (!isPlainObject(raw)) {
+		return reason("bounds must be an object of { min?, max? }");
+	}
+	const bounds: DateHistogramBounds = {};
+	for (const end of ["min", "max"] as const) {
+		const value = raw[end];
+		if (value === undefined) {
+			continue;
+		}
+		if (typeof value !== "string" || value.length === 0) {
+			return reason(`bounds.${end} must be a non-empty date string`);
+		}
+		bounds[end] = value;
+	}
+	if (bounds.min === undefined && bounds.max === undefined) {
+		return reason("bounds requires at least one of min or max");
+	}
+	return bounds;
+}
+
 function validateOptions(
 	context: DecoratorContext,
 	target: ModelProperty,
@@ -452,7 +519,21 @@ function validateOptions(
 			});
 			return undefined;
 		}
-		return { interval };
+		if (raw.bounds === undefined) {
+			if (!supportsMinimumInterval(interval)) {
+				reportDiagnostic(context.program, {
+					code: "unboundable-date-histogram-interval",
+					format: { interval },
+					target,
+				});
+			}
+			return { interval };
+		}
+		const bounds = validateDateHistogramBounds(context, target, kind, raw.bounds);
+		if (!bounds) {
+			return undefined;
+		}
+		return { interval, bounds };
 	}
 	if (kind === "range") {
 		if (!isPlainObject(raw) || !Array.isArray(raw.ranges)) {

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -529,7 +529,12 @@ function validateOptions(
 			}
 			return { interval };
 		}
-		const bounds = validateDateHistogramBounds(context, target, kind, raw.bounds);
+		const bounds = validateDateHistogramBounds(
+			context,
+			target,
+			kind,
+			raw.bounds,
+		);
 		if (!bounds) {
 			return undefined;
 		}

--- a/src/emit-graphql-resolver.test.ts
+++ b/src/emit-graphql-resolver.test.ts
@@ -1106,9 +1106,7 @@ describe("emitGraphQLResolver", () => {
 		const result = await emitGraphQLResolver(projection, defaultOptions);
 		const content = combinedContent(result);
 		assert.ok(
-			content.includes(
-				'{n:"byValidFromOverTime",a:ADH("validFrom", "month")}',
-			),
+			content.includes('{n:"byValidFromOverTime",a:ADH("validFrom", "month")}'),
 		);
 		assert.ok(
 			content.includes(

--- a/src/emit-graphql-resolver.test.ts
+++ b/src/emit-graphql-resolver.test.ts
@@ -4,7 +4,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it } from "node:test";
 import type { Type } from "@typespec/compiler";
-import { emitGraphQLResolver } from "./emit-graphql-resolver.js";
+import {
+	DEFAULT_AUTO_DATE_HISTOGRAM_BUCKETS,
+	emitGraphQLResolver,
+} from "./emit-graphql-resolver.js";
 import type { ResolvedProjection } from "./projection.js";
 
 function makeProjection(
@@ -1088,7 +1091,7 @@ describe("emitGraphQLResolver", () => {
 		);
 	});
 
-	it("emits date_histogram with calendar_interval option", async () => {
+	it("emits an auto_date_histogram floored at the declared interval when no bounds are given", async () => {
 		const projection = makeProjection({
 			fields: [
 				makeField({
@@ -1101,16 +1104,166 @@ describe("emitGraphQLResolver", () => {
 			],
 		});
 		const result = await emitGraphQLResolver(projection, defaultOptions);
+		const content = combinedContent(result);
 		assert.ok(
-			combinedContent(result).includes(
-				'{n:"byValidFromOverTime",a:{ date_histogram: { field: "validFrom", calendar_interval: "month" } }}',
+			content.includes(
+				'{n:"byValidFromOverTime",a:ADH("validFrom", "month")}',
 			),
+		);
+		assert.ok(
+			content.includes(
+				`const ADH = (f, m) => ({ auto_date_histogram: { field: f, minimum_interval: m, buckets: ${DEFAULT_AUTO_DATE_HISTOGRAM_BUCKETS} } });`,
+			),
+			"the bounds-less form must cap buckets rather than the range",
+		);
+		assert.ok(
+			!content.includes("calendar_interval"),
+			"an unbounded histogram must not pin a fixed interval over an unbounded range",
 		);
 		assert.ok(
 			combinedContent(result).includes(
 				"byValidFromOverTime: (_a.byValidFromOverTime?.buckets ?? []).map((b) => ({ key: `${b.key_as_string ?? b.key}`, keyAsString: b.key_as_string ?? null, count: b.doc_count }))",
 			),
 			"date_histogram response must use template-literal coercion (APPSYNC_JS forbids String()) and surface keyAsString",
+		);
+	});
+
+	it("emits a real date_histogram at the declared interval when bounds are given", async () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "validFrom",
+					type: { kind: "Scalar", name: "utcDateTime" } as unknown as Type,
+					aggregations: [
+						{
+							kind: "date_histogram",
+							options: {
+								interval: "month",
+								bounds: { min: "2020-01-01T00:00:00Z", max: "now" },
+							},
+						},
+					],
+				}),
+			],
+		});
+		const result = await emitGraphQLResolver(projection, defaultOptions);
+		const content = combinedContent(result);
+		assert.ok(
+			content.includes(
+				'{n:"byValidFromOverTime",a:{ date_histogram: { field: "validFrom", calendar_interval: "month", hard_bounds: {"min":"2020-01-01T00:00:00Z","max":"now"} } }}',
+			),
+			"declared bounds pin the range, so the declared interval is safe to emit",
+		);
+		assert.ok(
+			!content.includes("ADH"),
+			"a bounded histogram needs no auto_date_histogram helper",
+		);
+	});
+
+	it("keeps a week/quarter histogram at its declared interval (no minimum_interval spelling exists)", async () => {
+		for (const interval of ["week", "quarter"] as const) {
+			const projection = makeProjection({
+				fields: [
+					makeField({
+						name: "validFrom",
+						type: { kind: "Scalar", name: "utcDateTime" } as unknown as Type,
+						aggregations: [{ kind: "date_histogram", options: { interval } }],
+					}),
+				],
+			});
+			const result = await emitGraphQLResolver(projection, defaultOptions);
+			const content = combinedContent(result);
+			assert.ok(
+				content.includes(
+					`{n:"byValidFromOverTime",a:{ date_histogram: { field: "validFrom", calendar_interval: "${interval}" } }}`,
+				),
+				`${interval} must keep its declared interval rather than silently shift resolution`,
+			);
+			assert.ok(
+				!content.includes("auto_date_histogram"),
+				`auto_date_histogram cannot express a ${interval} floor`,
+			);
+		}
+	});
+
+	it("honours a configured auto-date-histogram bucket ceiling", async () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "validFrom",
+					type: { kind: "Scalar", name: "utcDateTime" } as unknown as Type,
+					aggregations: [
+						{ kind: "date_histogram", options: { interval: "day" } },
+					],
+				}),
+			],
+		});
+		const result = await emitGraphQLResolver(projection, {
+			...defaultOptions,
+			autoDateHistogramBuckets: 512,
+		});
+		assert.ok(combinedContent(result).includes("buckets: 512 } });"));
+	});
+
+	// Issue #150 (2): an open-ended adoption carries a far-future sentinel
+	// `validTo`. A monthly histogram over that range spans ~96,000 buckets and
+	// OpenSearch rejects the whole search past search.max_buckets (65,535).
+	it("emits a bounded-bucket query for sentinel-dated nested date fields (issue #150)", async () => {
+		const projection = makeProjection({
+			name: "PetSearchDoc",
+			indexName: "pets",
+			fields: [
+				makeField({
+					name: "adoptions",
+					nested: true,
+					filterables: ["exists"],
+					type: {
+						kind: "Model",
+						name: "Array",
+						indexer: { value: { kind: "Model" } },
+					} as unknown as Type,
+					subProjection: {
+						projectionModel: { name: "AdoptionSearchDoc" },
+						sourceModel: { name: "Adoption" },
+						indexName: "adoptions",
+						fields: [
+							makeField({
+								name: "status",
+								keyword: true,
+								filterables: ["term"],
+								aggregations: ["terms"],
+							}),
+							makeField({
+								name: "validTo",
+								type: {
+									kind: "Scalar",
+									name: "utcDateTime",
+								} as unknown as Type,
+								aggregations: [
+									{ kind: "date_histogram", options: { interval: "month" } },
+								],
+							}),
+						],
+					} as unknown as ResolvedProjection,
+				}),
+			],
+		});
+		const result = await emitGraphQLResolver(projection, defaultOptions);
+		const content = combinedContent(result);
+		assert.ok(
+			content.includes('a:ADH("adoptions.validTo", "month")'),
+			"the sentinel-prone field must cap its bucket count",
+		);
+		// The bucket ceiling is what makes the query survivable: OpenSearch
+		// returns at most this many buckets whatever the range holds, so a
+		// year-9999 sentinel yields coarser buckets instead of a rejected search.
+		assert.ok(
+			DEFAULT_AUTO_DATE_HISTOGRAM_BUCKETS < 65_535,
+			"the ceiling must sit under OpenSearch's default search.max_buckets",
+		);
+		assert.ok(
+			!content.includes("calendar_interval"),
+			"no unbounded fixed-interval histogram may survive in the emitted query",
 		);
 	});
 

--- a/src/emit-graphql-resolver.ts
+++ b/src/emit-graphql-resolver.ts
@@ -1,4 +1,8 @@
 import { type AggregationEntry, collectAggregations } from "./aggregations.js";
+import {
+	type DateHistogramOptions,
+	supportsMinimumInterval,
+} from "./decorators.js";
 import { toGraphQLQueryFieldName } from "./emit-graphql-sdl.js";
 import {
 	buildSearchFilterShape,
@@ -55,9 +59,39 @@ export interface ResolverOptions {
 	 * minus headroom). Measured against the rendered monolithic content.
 	 */
 	monolithicThresholdBytes?: number;
+	/**
+	 * `buckets` for the `auto_date_histogram` emitted when a date_histogram
+	 * aggregation declares no bounds. See DEFAULT_AUTO_DATE_HISTOGRAM_BUCKETS.
+	 */
+	autoDateHistogramBuckets?: number;
 }
 
 const DEFAULT_MONOLITHIC_THRESHOLD_BYTES = 32_000;
+
+/**
+ * `buckets` ceiling for a bounds-less `auto_date_histogram` (issue #150).
+ *
+ * `auto_date_histogram` returns at most this many buckets, picking the finest
+ * interval at or above `minimum_interval` that fits. The value therefore sets
+ * how wide a range still keeps the author's declared interval: at 10,000 that
+ * is 833 years of monthly buckets, 27 years of daily, and 1.1 years of hourly
+ * — past any real corpus, so declared intervals survive. A 9999-12-31 sentinel
+ * (~96,000 months) does not fit and steps down to yearly (~8,000 buckets),
+ * which renders instead of failing.
+ *
+ * It stays an order of magnitude under OpenSearch's 65,535 `search.max_buckets`
+ * on purpose: that cap counts every bucket in the request, so leaving headroom
+ * keeps one histogram from starving the other aggregations beside it.
+ */
+export const DEFAULT_AUTO_DATE_HISTOGRAM_BUCKETS = 10_000;
+
+/**
+ * Module-level helper the emitted AGG_SPEC calls for each bounds-less
+ * date_histogram. `buckets` is identical across every such entry and the
+ * `auto_date_histogram` key is long, so factoring both out of the literal keeps
+ * wide projections under AppSync's 32 KB per-function cap (issues #99, #105).
+ */
+const AUTO_DATE_HISTOGRAM_HELPER = "ADH";
 
 // Bound for the runtime applyFilterSpec walker's fixed-size work slot pool.
 // APPSYNC_JS does not honor self-extending Array iteration, so the emitted
@@ -205,7 +239,7 @@ function renderMonolithicResolver(
 	const keywordFieldsLiteral = JSON.stringify(keywordFields);
 	const textSortFieldsLiteral = JSON.stringify(textSortFields);
 	const aggsAssignment = renderAggsAssignment(aggregations, "\t");
-	const aggSpecDeclaration = renderAggSpecDeclaration(aggregations);
+	const aggSpecDeclaration = renderAggSpecDeclaration(aggregations, options);
 	const buildAggsFunction = renderBuildAggsFunction(aggregations);
 	const filterSpecLiteral = renderFilterSpecLiteral(searchFilterShape);
 	const slotsLiteral = `[${"null,".repeat(FILTER_WORK_SLOT_COUNT).slice(0, -1)}]`;
@@ -567,7 +601,7 @@ function renderPrepareFunction(
 	const keywordFieldsLiteral = JSON.stringify(keywordFields);
 	const textSortFieldsLiteral = JSON.stringify(textSortFields);
 	const aggsAssignment = renderAggsAssignment(aggregations, "\t");
-	const aggSpecDeclaration = renderAggSpecDeclaration(aggregations);
+	const aggSpecDeclaration = renderAggSpecDeclaration(aggregations, options);
 	const buildAggsFunction = renderBuildAggsFunction(aggregations);
 	const filterSpecLiteral = renderFilterSpecLiteral(searchFilterShape);
 	// `null` (4 chars) instead of `undefined` (9 chars) keeps the literal small
@@ -979,11 +1013,38 @@ function stringifyNode(node: FilterSpecNode): string {
  * under. `buildAggs` reads it at request time. Returns "" when the projection
  * has no aggregations at all.
  */
-function renderAggSpecDeclaration(aggregations: AggregationEntry[]): string {
+function renderAggSpecDeclaration(
+	aggregations: AggregationEntry[],
+	options: ResolverOptions,
+): string {
 	if (aggregations.length === 0) {
 		return "";
 	}
-	return `\nconst AGG_SPEC = ${renderAggSpecLiteral(aggregations)};\n`;
+	const buckets =
+		options.autoDateHistogramBuckets ?? DEFAULT_AUTO_DATE_HISTOGRAM_BUCKETS;
+	const helper = aggregations.some(usesAutoDateHistogram)
+		? `\nconst ${AUTO_DATE_HISTOGRAM_HELPER} = (f, m) => ({ auto_date_histogram: { field: f, minimum_interval: m, buckets: ${buckets} } });\n`
+		: "";
+	return `${helper}\nconst AGG_SPEC = ${renderAggSpecLiteral(aggregations)};\n`;
+}
+
+/**
+ * True when the entry renders through the AUTO_DATE_HISTOGRAM_HELPER: a
+ * date_histogram with no author-declared bounds, at an interval OpenSearch can
+ * express as a `minimum_interval`.
+ */
+function usesAutoDateHistogram(entry: AggregationEntry): boolean {
+	if (entry.kind !== "date_histogram") {
+		return false;
+	}
+	const opts =
+		entry.options && "interval" in entry.options
+			? (entry.options as DateHistogramOptions)
+			: undefined;
+	if (opts?.bounds) {
+		return false;
+	}
+	return supportsMinimumInterval(opts?.interval ?? "month");
 }
 
 /**
@@ -1150,11 +1211,27 @@ function renderAggInner(entry: AggregationEntry): string {
 	const fieldLit = JSON.stringify(entry.openSearchField);
 
 	if (entry.kind === "date_histogram") {
-		const interval =
+		const opts =
 			entry.options && "interval" in entry.options
-				? entry.options.interval
-				: "month";
-		return `{ ${aggType}: { field: ${fieldLit}, calendar_interval: ${JSON.stringify(interval)} } }`;
+				? (entry.options as DateHistogramOptions)
+				: undefined;
+		const interval = opts?.interval ?? "month";
+		const intervalLit = JSON.stringify(interval);
+		// Author-declared bounds pin the range, so the declared interval can
+		// never blow the bucket count: emit the real thing.
+		if (opts?.bounds) {
+			return `{ ${aggType}: { field: ${fieldLit}, calendar_interval: ${intervalLit}, hard_bounds: ${JSON.stringify(opts.bounds)} } }`;
+		}
+		// No bounds: bound the bucket count instead of the range, so every
+		// document still counts and only the resolution gives way (issue #150).
+		if (supportsMinimumInterval(interval)) {
+			return `${AUTO_DATE_HISTOGRAM_HELPER}(${fieldLit}, ${intervalLit})`;
+		}
+		// `week`/`quarter` have no `minimum_interval` spelling. Emitting a
+		// coarser floor would silently drop resolution the author asked for and
+		// a finer one would silently add detail, so keep the declared histogram
+		// as-is; the decorator warns that bounds are the only lever here.
+		return `{ ${aggType}: { field: ${fieldLit}, calendar_interval: ${intervalLit} } }`;
 	}
 	if (entry.kind === "range") {
 		const ranges =

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -12,6 +12,7 @@ import {
 	toDocTypeFileName,
 } from "./emit-doc-type.js";
 import {
+	DEFAULT_AUTO_DATE_HISTOGRAM_BUCKETS,
 	type EmittedResolverFile,
 	emitGraphQLResolver,
 } from "./emit-graphql-resolver.js";
@@ -157,6 +158,9 @@ export async function $onEmit(
 			trackTotalHitsUpTo: graphqlOptions["track-total-hits-up-to"] ?? 10000,
 			monolithicThresholdBytes:
 				graphqlOptions["monolithic-threshold-bytes"] ?? 32000,
+			autoDateHistogramBuckets:
+				graphqlOptions["auto-date-histogram-buckets"] ??
+				DEFAULT_AUTO_DATE_HISTOGRAM_BUCKETS,
 		};
 
 		// Top-level projections get the full SDL + resolver + manifest entry.

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -23,6 +23,16 @@ export interface GraphQLEmitterOptions {
 	 * cap minus headroom). Issue #112.
 	 */
 	"monolithic-threshold-bytes"?: number;
+	/**
+	 * `buckets` for the `auto_date_histogram` emitted when a
+	 * `@aggregatable("date_histogram", ...)` declares no bounds. It is the
+	 * ceiling on returned buckets, so it decides how wide a range still keeps
+	 * the declared interval before OpenSearch steps to a coarser one. Default:
+	 * 10000 — 833 years of monthly buckets, 27 years of daily, and an order of
+	 * magnitude under the 65,535 `search.max_buckets` a request may not exceed.
+	 * Issue #150.
+	 */
+	"auto-date-histogram-buckets"?: number;
 	directives?: GraphQLDirectivesOptions;
 }
 
@@ -95,6 +105,12 @@ export const $lib = createTypeSpecLibrary({
 			severity: "error",
 			messages: {
 				default: "@indexSettings value must be valid JSON.",
+			},
+		},
+		"unboundable-date-histogram-interval": {
+			severity: "warning",
+			messages: {
+				default: paramMessage`@aggregatable("date_histogram", { interval: "${"interval"}" }) has no bounds, and OpenSearch cannot express a "${"interval"}" floor for auto_date_histogram. This histogram spans whatever range the data holds, so a far-future sentinel date (e.g. 9999-12-31) will exceed search.max_buckets and fail the search. Add bounds: { min, max } to pin the range.`,
 			},
 		},
 		"positive-boost-required": {
@@ -251,6 +267,11 @@ export const $lib = createTypeSpecLibrary({
 							type: "number",
 							nullable: true,
 							default: 32000,
+						},
+						"auto-date-histogram-buckets": {
+							type: "number",
+							nullable: true,
+							default: 10000,
 						},
 						directives: {
 							type: "object",


### PR DESCRIPTION
Defect (2) of #150.

A `date_histogram` spans whatever range its data holds, so a fixed interval has no bucket ceiling. A far-future sentinel — `validTo = 9999-12-31` for "no end date" is ordinary domain data — puts a monthly histogram at ~96,000 buckets. OpenSearch caps a search at `search.max_buckets` (default 65,535) and rejects the entire search when it is exceeded, taking down aggregations that never touched the date field.

A fixed interval over an unbounded range cannot survive; either the interval or the range has to give. This bends the interval and never the range. Narrowing the range would silently drop documents from the answer. A coarser interval still counts every document, only lowers resolution, and the response reports the interval chosen, so the choice is inspectable rather than invisible.

**`bounds` is the lever when the interval must be fixed.** `@aggregatable("date_histogram", #{ interval: "month", bounds: #{ min: "now-5y", max: "now" } })` pins the range, so the declared interval is emitted as a real `date_histogram` with `hard_bounds`. Bounds are the author's own decision about the range; documents outside them still match the query and count toward `totalCount`.

**Absent bounds, the emitter caps the bucket count instead**, emitting `auto_date_histogram` with `minimum_interval` at the declared interval. The ceiling is 10,000 buckets — 833 years of monthly, 27 years of daily, past any real corpus, and an order of magnitude under `search.max_buckets` so one histogram cannot starve the aggregations beside it. Configurable via `graphql.auto-date-histogram-buckets`. Normal data keeps its declared interval; the sentinel case returns yearly buckets and a chart that renders instead of a failed query.

`week` and `quarter` are the exception. OpenSearch's `minimum_interval` accepts only `year`/`month`/`day`/`hour`/`minute`/`second`, so no automatic ceiling can express them: flooring at `day` or `month` would silently make the chart finer than declared, `year` coarser. They keep the `date_histogram` they already emitted, and a new warning names `bounds` as the only lever available.

No breaking change — existing specs compile unchanged and keep their chart shape for normal data. Ships as a minor.

### Size

`AGG_SPEC` lives in `prepare`, which had 286 bytes of headroom under AppSync's 32,768-byte cap. Emitting the new fields inline on every entry would have cost ~280 of them. The repeated `buckets` value and the `auto_date_histogram` key are instead factored into one module-level helper the spec entries call, which leaves the budget better than it found it:

| | prepare | headroom |
| --- | --- | --- |
| before | 32,482 | 286 |
| after | 31,953 | 815 |

Measured on the `pipelines a synthetic wide projection (14 sub-models)` guard.

Closes #150 (2).
