### PR TITLE
fix(graphql): budget histogram buckets per request, not per aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,7 +547,7 @@ This emits a `date_histogram` with `calendar_interval` and `hard_bounds`. `min` 
 
 **Without `bounds`, the emitter caps the bucket count instead.** It emits an `auto_date_histogram` with `minimum_interval` set to your declared interval, so OpenSearch uses that interval whenever the range allows and steps to a coarser one only when it would not fit. Normal data keeps its declared interval; the sentinel case above returns yearly buckets and a chart that renders rather than a failed search. The response reports the interval actually chosen.
 
-The ceiling is 10,000 buckets, configurable via [`graphql.auto-date-histogram-buckets`](#emitter-options). It holds 833 years of monthly buckets, 27 years of daily and 1.1 years of hourly — past any real corpus — and stays an order of magnitude under `search.max_buckets` so one histogram cannot starve the aggregations beside it.
+The per-histogram ceiling is 10,000 buckets, configurable via [`graphql.auto-date-histogram-buckets`](#emitter-options) — 833 years of monthly buckets, 27 years of daily, 1.1 years of hourly, past any real corpus. `search.max_buckets` counts every bucket in a request, not one aggregation, so a request selecting several histograms divides a soft budget across them: a third of `search.max_buckets` (≈21,845) split by the number of histograms actually selected, capped at the ceiling and floored at 256 so a chart stays legible. Their sum stays under the request limit however many are selected, and the alias fallback that sends every aggregation counts toward the same budget.
 
 **`week` and `quarter` are the exception.** OpenSearch's `minimum_interval` accepts only `year`, `month`, `day`, `hour`, `minute` and `second`, so these two intervals have no automatic ceiling: flooring at `day` or `month` would silently make the chart finer than declared, and `year` would make it coarser. They keep the plain `date_histogram` they have always emitted, and the emitter warns that `bounds` is the only lever available. Declare `bounds` on a `week` or `quarter` histogram whose field may hold a sentinel.
 
@@ -589,14 +589,14 @@ Emitted code must also stay in the APPSYNC_JS supported subset. `src/emit-graphq
 
 #### Guards
 
-Two tests in `src/emit-graphql-resolver.test.ts` assert every emitted file stays under 32,768 bytes. Measured on `277755b`:
+Two tests in `src/emit-graphql-resolver.test.ts` assert every emitted file stays under 32,768 bytes. Measured after the per-request bucket budget (issue #155):
 
 | Projection | Resolver | Prepare | Search | Headroom |
 | --- | --- | --- | --- | --- |
-| counterparty shape (7 nested sub-models) | 8,991 | 24,497 | 742 | 8,271 |
-| synthetic wide (14 sub-models) | 14,458 | 32,482 | 732 | **286** |
+| counterparty shape (7 nested sub-models) | 8,991 | 24,754 | 742 | 8,014 |
+| synthetic wide (14 sub-models) | 14,458 | 32,452 | 732 | **316** |
 
-`prepare` is the constrained file in both, and headroom depends on projection width. The 14-sub-model guard governs: at 286 bytes, the next change touching the prepare function hits the cap. Real projections are not close — the counterparty shape renders 18,319 bytes as a single file and stays monolithic.
+`prepare` is the constrained file in both, and headroom depends on projection width. The 14-sub-model guard governs: at 316 bytes, the next change touching the prepare function hits the cap. Real projections are not close — the counterparty shape renders 18,319 bytes as a single file and stays monolithic.
 
 CI goes red on the guard, and AppSync refuses the deploy. The assertion message prints the current headroom — trust it over these numbers.
 

--- a/src/emit-graphql-resolver.test.ts
+++ b/src/emit-graphql-resolver.test.ts
@@ -7,6 +7,8 @@ import type { Type } from "@typespec/compiler";
 import {
 	DEFAULT_AUTO_DATE_HISTOGRAM_BUCKETS,
 	emitGraphQLResolver,
+	MIN_AUTO_DATE_HISTOGRAM_BUCKETS,
+	PER_REQUEST_BUCKET_BUDGET,
 } from "./emit-graphql-resolver.js";
 import type { ResolvedProjection } from "./projection.js";
 
@@ -1105,14 +1107,26 @@ describe("emitGraphQLResolver", () => {
 		});
 		const result = await emitGraphQLResolver(projection, defaultOptions);
 		const content = combinedContent(result);
+		// The `,h:1` marker lets buildAggs count the entry against the
+		// per-request bucket budget (issue #155).
 		assert.ok(
-			content.includes('{n:"byValidFromOverTime",a:ADH("validFrom", "month")}'),
+			content.includes(
+				'{n:"byValidFromOverTime",a:ADH("validFrom", "month"),h:1}',
+			),
+		);
+		// buildAggs sets `buckets` per request from the divided budget, so the
+		// helper no longer bakes a fixed ceiling.
+		assert.ok(
+			content.includes(
+				"const ADH = (f, m) => ({ auto_date_histogram: { field: f, minimum_interval: m } });",
+			),
+			"the bounds-less form must cap buckets rather than the range",
 		);
 		assert.ok(
 			content.includes(
-				`const ADH = (f, m) => ({ auto_date_histogram: { field: f, minimum_interval: m, buckets: ${DEFAULT_AUTO_DATE_HISTOGRAM_BUCKETS} } });`,
+				`if (budget > ${DEFAULT_AUTO_DATE_HISTOGRAM_BUCKETS}) budget = ${DEFAULT_AUTO_DATE_HISTOGRAM_BUCKETS};`,
 			),
-			"the bounds-less form must cap buckets rather than the range",
+			"the per-histogram ceiling is applied in buildAggs' budget division",
 		);
 		assert.ok(
 			!content.includes("calendar_interval"),
@@ -1200,7 +1214,19 @@ describe("emitGraphQLResolver", () => {
 			...defaultOptions,
 			autoDateHistogramBuckets: 512,
 		});
-		assert.ok(combinedContent(result).includes("buckets: 512 } });"));
+		// The configured value is the per-histogram ceiling buildAggs applies
+		// when dividing the per-request bucket budget (issue #155).
+		assert.ok(
+			combinedContent(result).includes("if (budget > 512) budget = 512;"),
+		);
+		const body = evalRequestBody(prepareFunctionContent(result), {
+			selectionSetList: ["aggregations", "aggregations/byValidFromOverTime"],
+		});
+		const aggs = body.aggs as Record<
+			string,
+			{ auto_date_histogram: { buckets: number } }
+		>;
+		assert.equal(aggs.byValidFromOverTime.auto_date_histogram.buckets, 512);
 	});
 
 	// Issue #150 (2): an open-ended adoption carries a far-future sentinel
@@ -2686,6 +2712,235 @@ describe("emitGraphQLResolver datasource error propagation (issue #150)", () => 
 			result: okBody,
 		}) as { totalCount: number };
 		assert.equal(shaped.totalCount, 1);
+	});
+});
+
+describe("emitGraphQLResolver histogram bucket budget (issue #155)", () => {
+	// search.max_buckets (65,535) caps the whole request, not one aggregation.
+	// A request selecting several histograms divides a per-request budget across
+	// them rather than giving each its own ceiling, so their sum stays under the
+	// cap however many are selected.
+	function histogramProjection(count: number): ResolvedProjection {
+		return makeProjection({
+			fields: Array.from({ length: count }, (_, i) =>
+				makeField({
+					name: `h${i}`,
+					type: { kind: "Scalar", name: "utcDateTime" } as unknown as Type,
+					aggregations: [
+						{ kind: "date_histogram", options: { interval: "month" } },
+					],
+				}),
+			),
+		});
+	}
+
+	// Reads the auto_date_histogram agg names (marked `,h:1`) straight off the
+	// emitted AGG_SPEC, so the tests don't depend on the field-name → agg-name
+	// derivation.
+	function histogramAggNames(source: string): string[] {
+		const names: string[] = [];
+		const re = /\{n:"([^"]+)"[^}]*,h:1\}/g;
+		let match = re.exec(source);
+		while (match) {
+			names.push(match[1]);
+			match = re.exec(source);
+		}
+		return names;
+	}
+
+	function bucketsOf(body: Record<string, unknown>, name: string): number {
+		const aggs = body.aggs as Record<
+			string,
+			{ auto_date_histogram?: { buckets?: number } }
+		>;
+		const buckets = aggs[name]?.auto_date_histogram?.buckets;
+		assert.equal(
+			typeof buckets,
+			"number",
+			`expected numeric buckets on ${name}; got aggs=${JSON.stringify(aggs)}`,
+		);
+		return buckets as number;
+	}
+
+	function expectedBudget(
+		selected: number,
+		cap = DEFAULT_AUTO_DATE_HISTOGRAM_BUCKETS,
+	): number {
+		let budget = Math.floor(PER_REQUEST_BUCKET_BUDGET / selected);
+		if (budget > cap) budget = cap;
+		if (budget < MIN_AUTO_DATE_HISTOGRAM_BUCKETS)
+			budget = MIN_AUTO_DATE_HISTOGRAM_BUCKETS;
+		return budget;
+	}
+
+	function aggSelection(names: string[]): { selectionSetList: string[] } {
+		return {
+			selectionSetList: [
+				"aggregations",
+				...names.map((n) => `aggregations/${n}`),
+			],
+		};
+	}
+
+	it("divides the per-request budget across the histograms actually selected", async () => {
+		const result = await emitGraphQLResolver(
+			histogramProjection(5),
+			defaultOptions,
+		);
+		const source = prepareFunctionContent(result);
+		const names = histogramAggNames(source);
+		assert.equal(names.length, 5);
+
+		const body = evalRequestBody(source, aggSelection(names));
+		const expected = expectedBudget(5); // floor(21845 / 5) = 4369
+		for (const name of names) {
+			assert.equal(bucketsOf(body, name), expected);
+		}
+	});
+
+	it("budgets against the selected count, not every declared histogram", async () => {
+		const result = await emitGraphQLResolver(
+			histogramProjection(5),
+			defaultOptions,
+		);
+		const source = prepareFunctionContent(result);
+		const selected = histogramAggNames(source).slice(0, 3);
+
+		const body = evalRequestBody(source, aggSelection(selected));
+		assert.deepEqual(
+			Object.keys(body.aggs as Record<string, unknown>).sort(),
+			[...selected].sort(),
+		);
+		const expected = expectedBudget(3); // floor(21845 / 3) = 7281
+		for (const name of selected) {
+			assert.equal(bucketsOf(body, name), expected);
+		}
+	});
+
+	it("gives a single selected histogram the full per-histogram ceiling", async () => {
+		const result = await emitGraphQLResolver(
+			histogramProjection(1),
+			defaultOptions,
+		);
+		const source = prepareFunctionContent(result);
+		const [name] = histogramAggNames(source);
+
+		const body = evalRequestBody(source, aggSelection([name]));
+		// floor(21845 / 1) exceeds the ceiling, so the ceiling wins.
+		assert.equal(bucketsOf(body, name), DEFAULT_AUTO_DATE_HISTOGRAM_BUCKETS);
+	});
+
+	it("floors the per-histogram budget so a wide selection stays legible", async () => {
+		const result = await emitGraphQLResolver(
+			histogramProjection(100),
+			defaultOptions,
+		);
+		const source = prepareFunctionContent(result);
+		const names = histogramAggNames(source);
+		assert.equal(names.length, 100);
+
+		const body = evalRequestBody(source, aggSelection(names));
+		// floor(21845 / 100) = 218 < the floor, so every histogram clamps to it.
+		for (const name of names) {
+			assert.equal(bucketsOf(body, name), MIN_AUTO_DATE_HISTOGRAM_BUCKETS);
+		}
+	});
+
+	it("counts the alias fallback's histograms against the same budget", async () => {
+		// An aliased aggregation names no AGG_SPEC entry, so the fallback sends
+		// every aggregation. Those histograms must divide the budget too, or the
+		// fallback reintroduces the per-request blowout.
+		const result = await emitGraphQLResolver(
+			histogramProjection(5),
+			defaultOptions,
+		);
+		const source = prepareFunctionContent(result);
+		const names = histogramAggNames(source);
+
+		const body = evalRequestBody(source, {
+			selectionSetList: [
+				"aggregations",
+				"aggregations/whateverAlias",
+				"aggregations/whateverAlias/key",
+			],
+		});
+		assert.deepEqual(
+			Object.keys(body.aggs as Record<string, unknown>).sort(),
+			[...names].sort(),
+		);
+		const expected = expectedBudget(names.length); // 5 -> 4369
+		for (const name of names) {
+			assert.equal(bucketsOf(body, name), expected);
+		}
+	});
+
+	it("leaves an author-bounded histogram out of the budget (bounds opt-out)", async () => {
+		// Declared bounds pin the range, so the histogram is the author's
+		// explicit choice: it keeps its fixed interval and hard_bounds, carries
+		// no bucket cap, and does not consume the auto-histogram budget.
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "bounded",
+					type: { kind: "Scalar", name: "utcDateTime" } as unknown as Type,
+					aggregations: [
+						{
+							kind: "date_histogram",
+							options: {
+								interval: "month",
+								bounds: { min: "now-5y", max: "now" },
+							},
+						},
+					],
+				}),
+				...Array.from({ length: 4 }, (_, i) =>
+					makeField({
+						name: `auto${i}`,
+						type: { kind: "Scalar", name: "utcDateTime" } as unknown as Type,
+						aggregations: [
+							{ kind: "date_histogram", options: { interval: "month" } },
+						],
+					}),
+				),
+			],
+		});
+		const result = await emitGraphQLResolver(projection, defaultOptions);
+		const source = prepareFunctionContent(result);
+		const autoNames = histogramAggNames(source);
+		assert.equal(
+			autoNames.length,
+			4,
+			"only the bounds-less histograms carry the h:1 budget marker",
+		);
+
+		const body = evalRequestBody(source, {
+			selectionSetList: [
+				"aggregations",
+				"aggregations/byBoundedOverTime",
+				...autoNames.map((n) => `aggregations/${n}`),
+			],
+		});
+		const aggs = body.aggs as Record<
+			string,
+			{
+				date_histogram?: { hard_bounds?: unknown };
+				auto_date_histogram?: { buckets?: number };
+			}
+		>;
+		assert.ok(
+			aggs.byBoundedOverTime.date_histogram?.hard_bounds,
+			"a bounded histogram keeps its declared hard_bounds",
+		);
+		assert.equal(
+			aggs.byBoundedOverTime.auto_date_histogram,
+			undefined,
+			"a bounded histogram is not emitted as an auto_date_histogram",
+		);
+		// Only the 4 auto histograms divide the budget; the bounded one does not.
+		const expected = expectedBudget(4); // floor(21845 / 4) = 5461
+		for (const name of autoNames) {
+			assert.equal(bucketsOf(body, name), expected);
+		}
 	});
 });
 

--- a/src/emit-graphql-resolver.ts
+++ b/src/emit-graphql-resolver.ts
@@ -69,7 +69,10 @@ export interface ResolverOptions {
 const DEFAULT_MONOLITHIC_THRESHOLD_BYTES = 32_000;
 
 /**
- * `buckets` ceiling for a bounds-less `auto_date_histogram` (issue #150).
+ * Per-histogram `buckets` ceiling for a bounds-less `auto_date_histogram`
+ * (issue #150). This is the most any single histogram gets; the emitted
+ * `buildAggs` lowers it when a request selects several histograms so their sum
+ * stays under the per-request budget (issue #155).
  *
  * `auto_date_histogram` returns at most this many buckets, picking the finest
  * interval at or above `minimum_interval` that fits. The value therefore sets
@@ -78,18 +81,34 @@ const DEFAULT_MONOLITHIC_THRESHOLD_BYTES = 32_000;
  * — past any real corpus, so declared intervals survive. A 9999-12-31 sentinel
  * (~96,000 months) does not fit and steps down to yearly (~8,000 buckets),
  * which renders instead of failing.
- *
- * It stays an order of magnitude under OpenSearch's 65,535 `search.max_buckets`
- * on purpose: that cap counts every bucket in the request, so leaving headroom
- * keeps one histogram from starving the other aggregations beside it.
  */
 export const DEFAULT_AUTO_DATE_HISTOGRAM_BUCKETS = 10_000;
 
 /**
+ * Soft per-request bucket budget: a third of OpenSearch's default
+ * `search.max_buckets` (65,535). That cap counts every bucket in the whole
+ * request, not one aggregation, so the emitted `buildAggs` divides this budget
+ * across the `auto_date_histogram` aggregations a request actually selects
+ * (issue #155). A request that reaches the hard cap is already a 503; a third
+ * leaves room for the terms and metric buckets sharing the request.
+ */
+export const PER_REQUEST_BUCKET_BUDGET = 21_845;
+
+/**
+ * Lower bound on the per-histogram bucket count after the budget is divided, so
+ * a request selecting many histograms still renders a legible chart instead of
+ * a handful of buckets. Below ~256 buckets a time series stops being readable;
+ * this floor only binds past ~85 selected histograms.
+ */
+export const MIN_AUTO_DATE_HISTOGRAM_BUCKETS = 256;
+
+/**
  * Module-level helper the emitted AGG_SPEC calls for each bounds-less
- * date_histogram. `buckets` is identical across every such entry and the
- * `auto_date_histogram` key is long, so factoring both out of the literal keeps
- * wide projections under AppSync's 32 KB per-function cap (issues #99, #105).
+ * date_histogram. The `auto_date_histogram` key is long and repeats across
+ * every such entry, so factoring it out of the literal keeps wide projections
+ * under AppSync's 32 KB per-function cap (issues #99, #105). `buckets` is set
+ * per request by `buildAggs`, not baked here, so it can vary with how many
+ * histograms a request selects (issue #155).
  */
 const AUTO_DATE_HISTOGRAM_HELPER = "ADH";
 
@@ -239,8 +258,8 @@ function renderMonolithicResolver(
 	const keywordFieldsLiteral = JSON.stringify(keywordFields);
 	const textSortFieldsLiteral = JSON.stringify(textSortFields);
 	const aggsAssignment = renderAggsAssignment(aggregations, "\t");
-	const aggSpecDeclaration = renderAggSpecDeclaration(aggregations, options);
-	const buildAggsFunction = renderBuildAggsFunction(aggregations);
+	const aggSpecDeclaration = renderAggSpecDeclaration(aggregations);
+	const buildAggsFunction = renderBuildAggsFunction(aggregations, options);
 	const filterSpecLiteral = renderFilterSpecLiteral(searchFilterShape);
 	const slotsLiteral = `[${"null,".repeat(FILTER_WORK_SLOT_COUNT).slice(0, -1)}]`;
 	const responseAggregationsPreamble =
@@ -601,8 +620,8 @@ function renderPrepareFunction(
 	const keywordFieldsLiteral = JSON.stringify(keywordFields);
 	const textSortFieldsLiteral = JSON.stringify(textSortFields);
 	const aggsAssignment = renderAggsAssignment(aggregations, "\t");
-	const aggSpecDeclaration = renderAggSpecDeclaration(aggregations, options);
-	const buildAggsFunction = renderBuildAggsFunction(aggregations);
+	const aggSpecDeclaration = renderAggSpecDeclaration(aggregations);
+	const buildAggsFunction = renderBuildAggsFunction(aggregations, options);
 	const filterSpecLiteral = renderFilterSpecLiteral(searchFilterShape);
 	// `null` (4 chars) instead of `undefined` (9 chars) keeps the literal small
 	// — saves ~5 bytes per slot. The walker never reads these init values; it
@@ -1013,17 +1032,12 @@ function stringifyNode(node: FilterSpecNode): string {
  * under. `buildAggs` reads it at request time. Returns "" when the projection
  * has no aggregations at all.
  */
-function renderAggSpecDeclaration(
-	aggregations: AggregationEntry[],
-	options: ResolverOptions,
-): string {
+function renderAggSpecDeclaration(aggregations: AggregationEntry[]): string {
 	if (aggregations.length === 0) {
 		return "";
 	}
-	const buckets =
-		options.autoDateHistogramBuckets ?? DEFAULT_AUTO_DATE_HISTOGRAM_BUCKETS;
 	const helper = aggregations.some(usesAutoDateHistogram)
-		? `\nconst ${AUTO_DATE_HISTOGRAM_HELPER} = (f, m) => ({ auto_date_histogram: { field: f, minimum_interval: m, buckets: ${buckets} } });\n`
+		? `\nconst ${AUTO_DATE_HISTOGRAM_HELPER} = (f, m) => ({ auto_date_histogram: { field: f, minimum_interval: m } });\n`
 		: "";
 	return `${helper}\nconst AGG_SPEC = ${renderAggSpecLiteral(aggregations)};\n`;
 }
@@ -1033,6 +1047,15 @@ function renderAggSpecDeclaration(
  * date_histogram with no author-declared bounds, at an interval OpenSearch can
  * express as a `minimum_interval`.
  */
+/**
+ * `,h:1` marks an AGG_SPEC entry that renders through the helper, so buildAggs
+ * can count it against the per-request bucket budget and set its `buckets`
+ * (issue #155). Empty for every other aggregation kind.
+ */
+function histogramFlag(entry: AggregationEntry): string {
+	return usesAutoDateHistogram(entry) ? ",h:1" : "";
+}
+
 function usesAutoDateHistogram(entry: AggregationEntry): boolean {
 	if (entry.kind !== "date_histogram") {
 		return false;
@@ -1080,7 +1103,7 @@ function renderAggSpecLiteral(aggregations: AggregationEntry[]): string {
 			if (flatSeen.has(entry.aggName)) continue;
 			flatSeen.add(entry.aggName);
 			flatItems.push(
-				`{n:${JSON.stringify(entry.aggName)},a:${renderAggInner(entry)}}`,
+				`{n:${JSON.stringify(entry.aggName)},a:${renderAggInner(entry)}${histogramFlag(entry)}}`,
 			);
 			continue;
 		}
@@ -1102,7 +1125,7 @@ function renderAggSpecLiteral(aggregations: AggregationEntry[]): string {
 		const pathLit = JSON.stringify(path);
 		for (const entry of group) {
 			groupItems.push(
-				`{n:${JSON.stringify(entry.aggName)},g:${groupKey},p:${pathLit},a:${renderAggInner(entry)}}`,
+				`{n:${JSON.stringify(entry.aggName)},g:${groupKey},p:${pathLit},a:${renderAggInner(entry)}${histogramFlag(entry)}}`,
 			);
 		}
 	}
@@ -1135,12 +1158,44 @@ function renderAggSpecLiteral(aggregations: AggregationEntry[]): string {
  * aggregation (`byAlias: bySpecies`) reads as declared, so no fallback fires and
  * the wrong aggregation is sent — undetectable from `selectionSetList` alone.
  *
+ * Each selected `auto_date_histogram` (marked `h:1`) has its `buckets` set from
+ * a per-request budget divided across the histograms actually sent, so their
+ * sum stays under OpenSearch's `search.max_buckets` however many are selected
+ * (issue #155). The alias fallback selects every aggregation, so its histograms
+ * count toward the same budget.
+ *
  * Returns "" when the projection has no aggregations at all.
  */
-function renderBuildAggsFunction(aggregations: AggregationEntry[]): string {
+function renderBuildAggsFunction(
+	aggregations: AggregationEntry[],
+	options: ResolverOptions,
+): string {
 	if (aggregations.length === 0) {
 		return "";
 	}
+	const cap =
+		options.autoDateHistogramBuckets ?? DEFAULT_AUTO_DATE_HISTOGRAM_BUCKETS;
+	// Only projections with a bounds-less date_histogram carry `h:1` markers, so
+	// only they need the per-request budget division (issue #155). Everything
+	// else keeps the leaner selection-only assembly.
+	const hasAuto = aggregations.some(usesAutoDateHistogram);
+	const trackHistogram = hasAuto
+		? "\n\t\t\tif (spec.h) histograms.push(spec);"
+		: "";
+	const histogramDecl = hasAuto ? "\n\tconst histograms = [];" : "";
+	const budgetBlock = hasAuto
+		? `
+	// search.max_buckets caps the whole request: divide a soft budget across the
+	// selected histograms, capped and floored per histogram (issue #155).
+	if (histograms.length > 0) {
+		let budget = Math.floor(${PER_REQUEST_BUCKET_BUDGET} / histograms.length);
+		if (budget > ${cap}) budget = ${cap};
+		if (budget < ${MIN_AUTO_DATE_HISTOGRAM_BUCKETS}) budget = ${MIN_AUTO_DATE_HISTOGRAM_BUCKETS};
+		for (const spec of histograms) {
+			spec.a.auto_date_histogram.buckets = budget;
+		}
+	}`
+		: "";
 	return `
 function buildAggs(selectionSetList) {
 	// A first segment under \`aggregations/\` naming no AGG_SPEC entry is an
@@ -1161,10 +1216,10 @@ function buildAggs(selectionSetList) {
 	}
 	// \`null\` means nothing was requested, and the request omits \`aggs\` entirely.
 	const aggs = {};
-	let requested = false;
+	let requested = false;${histogramDecl}
 	for (const spec of AGG_SPEC) {
 		if (aliased || selectionSetList.indexOf("aggregations/" + spec.n) >= 0) {
-			requested = true;
+			requested = true;${trackHistogram}
 			if (spec.g) {
 				const group = aggs[spec.g] || { nested: { path: spec.p }, aggs: {} };
 				group.aggs[spec.n] = spec.a;
@@ -1173,7 +1228,7 @@ function buildAggs(selectionSetList) {
 				aggs[spec.n] = spec.a;
 			}
 		}
-	}
+	}${budgetBlock}
 	return requested ? aggs : null;
 }
 `;


### PR DESCRIPTION
Fixes #155.

`auto_date_histogram` was capped at 10,000 buckets per aggregation, but OpenSearch's `search.max_buckets` (default 65,535) is a per-request total. A request selecting N histograms budgeted N × 10,000, so enough selected histograms broke the request limit while each aggregation stayed within its own bound. The alias fallback made this worse: it attached every aggregation regardless of selection, so N was not client-controlled.

The emitted `buildAggs` now divides a per-request bucket budget across the histograms a request actually selects: a soft third of `search.max_buckets` (~21,845) split by the number selected, capped at the configured per-histogram ceiling and floored at 256 so a chart stays legible. The alias fallback sends every aggregation as before, and its histograms count toward the same budget, so the fallback can no longer blow the request limit.

Author-declared `bounds` stay untouched — a bounded histogram keeps its fixed interval and `hard_bounds` and is excluded from the budget, so the #154 opt-out is unchanged. Bounds-less histograms carry an `h:1` marker in `AGG_SPEC` so the budget logic is emitted only for projections that need it, keeping the AppSync 32 KB per-function budget intact (governing guard headroom 316 bytes).

Tests exercise the emitted `buildAggs` at runtime: budget division across the selected histograms, selection-count vs declared-count, the single-histogram ceiling, the floor, the alias fallback counting against the budget, and the bounds opt-out staying out of it.
