### PR TITLE
fix(emitter)!: require @indexName for top-level projection emission

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,11 @@ A field is included in the resolved projection if it carries any of `@searchable
 
 Filter-only / agg-only fields are mapped as `keyword` directly (no `text`+`keyword` sub-field) since there is no full-text-search surface. Fields with none of the three decorators are excluded from all projections.
 
-### Index name derivation
+### Index name
 
-- Use `@indexName("my_index_v1")` on a projection model to set an explicit index name.
-- If omitted, the index name is derived from the model name by converting PascalCase to snake_case (e.g. `PetSearchDoc` → `pet_search_doc`).
+- Use `@indexName("my_index_v1")` on a projection model to declare the index it is backed by.
+- A projection needs both `@searchProjection` and `@indexName` to be emitted top-level: Query field, resolver, mapping, and `graphql-resolvers.json` entry.
+- A projection missing either is emitted as a nested type only — a doc type plus a stripped SDL fragment, so a parent projection can reference it as a field type.
 
 ## Usage
 
@@ -263,7 +264,7 @@ In this example:
 | `@analyzer("name")` | `ModelProperty` (string) | Sets the text analyzer in mapping output. | `@analyzer("edge_ngram") name: string;` |
 | `@boost(n)` | `ModelProperty` | Sets field boost factor in mapping output. Must be > 0. | `@boost(2.0) name: string;` |
 | `@ignoreAbove(n)` | `ModelProperty` (string) | Overrides `ignore_above` on the keyword sub-field. Must be > 0. | `@ignoreAbove(1024) name: string;` |
-| `@indexName("name")` | `Model` (projection) | Sets an explicit index name for the projection. | `@indexName("pets_v1") model PetSearchDoc ...` |
+| `@indexName("name")` | `Model` (projection) | Declares the index backing the projection. Required for top-level emission; without it the projection is nested-only. | `@indexName("pets_v1") model PetSearchDoc ...` |
 | `@indexSettings(json)` | `Model` (projection) | Embeds index settings (e.g. analysis config) in the mapping output. Value must be valid JSON. | See example below. |
 | `@searchAs("name")` | `ModelProperty` | Renames the field in mapping and TypeScript output. Can be set on source or projection (projection wins). | `@searchAs("firstName") givenName: string;` |
 | `@aggregatable(...kinds)` / `@aggregatable(kind, options)` | `ModelProperty` | Declares OpenSearch aggregations on the GraphQL connection. Allowed kinds: `"terms"`, `"cardinality"`, `"missing"`, `"sum"`, `"avg"`, `"min"`, `"max"`, `"date_histogram"`, `"range"`. Multi-arg form emits all listed string kinds. The single-kind-with-options form is required for `"date_histogram"`, `"range"`, and `"terms"`-with-sub or `"terms"`-with-`topHits`. `topHits: N` adds a `top_hits: { size: N }` sub-agg so each bucket carries up to N matching docs. `"date_histogram"` takes an optional `bounds: #{ min?, max? }` that pins its range and with it the declared interval; without bounds the emitter caps the bucket count instead — see [Bounding a `date_histogram`](#bounding-a-date_histogram). See [Aggregations](#aggregations-aggregatable). | `@aggregatable("terms", "cardinality") locations: Location[];` / `@aggregatable("terms", #{ topHits: 5 }) tagId: string;` / `@aggregatable("date_histogram", #{ interval: "month", bounds: #{ min: "now-5y", max: "now" } }) validTo: utcDateTime;` |

--- a/src/decorators.test.ts
+++ b/src/decorators.test.ts
@@ -109,7 +109,7 @@ describe("decorators", () => {
 		assert.equal(getIndexName(runner.program, projection), "products_v1");
 	});
 
-	it("derives default index name from model name", async () => {
+	it("has no index name without @indexName (issue #157)", async () => {
 		const runner = await createRunner();
 		const diagnostics = await runner.diagnose(`
       model CounterpartySearchDoc is SearchProjection<Counterparty> {
@@ -127,10 +127,7 @@ describe("decorators", () => {
 			.getGlobalNamespaceType()
 			.models.get("CounterpartySearchDoc");
 		assert.ok(model);
-		assert.equal(
-			getIndexName(runner.program, model),
-			"counterparty_search_doc",
-		);
+		assert.equal(getIndexName(runner.program, model), undefined);
 	});
 
 	it("marks string property as graphql ID (issue #136)", async () => {

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -10,17 +10,6 @@ import { reportDiagnostic, StateKeys } from "./lib.js";
 
 export const namespace = "Kattebak.OpenSearch";
 
-/**
- * Default index name derivation:
- * CounterpartySearchDoc -> counterparty_search_doc
- */
-export function deriveDefaultIndexName(modelName: string): string {
-	return modelName
-		.replace(/([a-z0-9])([A-Z])/g, "$1_$2")
-		.replace(/[-\s]+/g, "_")
-		.toLowerCase();
-}
-
 export function $searchable(
 	context: DecoratorContext,
 	target: ModelProperty,
@@ -271,11 +260,16 @@ export function $indexName(
 	context.program.stateMap(StateKeys.indexName).set(target, name);
 }
 
-export function getIndexName(program: Program, target: Model): string {
-	return (
-		program.stateMap(StateKeys.indexName).get(target) ??
-		deriveDefaultIndexName(target.name)
-	);
+/**
+ * The declared index name, or `undefined` when the model carries no
+ * `@indexName`. Absence is meaningful: it marks the projection as nested-only,
+ * so it gets no backing OpenSearch index and no top-level wiring (issue #157).
+ */
+export function getIndexName(
+	program: Program,
+	target: Model,
+): string | undefined {
+	return program.stateMap(StateKeys.indexName).get(target);
 }
 
 export function $indexSettings(
@@ -854,7 +848,6 @@ export function getSearchAs(
 }
 
 export const __test = {
-	deriveDefaultIndexName,
 	isArrayOfModelType,
 	isStringType,
 };

--- a/src/emit-graphql-resolver.ts
+++ b/src/emit-graphql-resolver.ts
@@ -10,8 +10,8 @@ import {
 	type SearchFilterShape,
 } from "./filters.js";
 import type {
-	ResolvedProjection,
 	ResolvedProjectionField,
+	TopLevelProjection,
 } from "./projection.js";
 import { toKebabCase } from "./utils.js";
 
@@ -119,7 +119,7 @@ const AUTO_DATE_HISTOGRAM_HELPER = "ADH";
 const FILTER_WORK_SLOT_COUNT = 256;
 
 export async function emitGraphQLResolver(
-	projection: ResolvedProjection,
+	projection: TopLevelProjection,
 	options: ResolverOptions,
 ): Promise<EmittedResolverFile> {
 	const typeName = projection.projectionModel.name;

--- a/src/emit-index.ts
+++ b/src/emit-index.ts
@@ -1,12 +1,12 @@
 import { collectSubProjections, toDocTypeFileName } from "./emit-doc-type.js";
-import type { ResolvedProjection } from "./projection.js";
+import type { ResolvedProjection, TopLevelProjection } from "./projection.js";
 
 export interface EmittedIndexFile {
 	fileName: string;
 	content: string;
 }
 
-export function emitIndex(projections: ResolvedProjection[]): EmittedIndexFile {
+export function emitIndex(projections: TopLevelProjection[]): EmittedIndexFile {
 	const sorted = [...projections].sort((a, b) =>
 		a.projectionModel.name.localeCompare(b.projectionModel.name),
 	);

--- a/src/emitter.test.ts
+++ b/src/emitter.test.ts
@@ -3,7 +3,10 @@ import { describe, it } from "node:test";
 import type { Model } from "@typespec/compiler";
 import { createTestHost, createTestWrapper } from "@typespec/compiler/testing";
 import { __test } from "./emitter.js";
-import type { ResolvedProjection } from "./projection.js";
+import {
+	type ResolvedProjection,
+	resolveProjectionModel,
+} from "./projection.js";
 import type { ResolvedRestOperation } from "./rest-operations.js";
 import { OpenSearchEmitterTestLibrary } from "./testing/index.js";
 
@@ -606,5 +609,61 @@ describe("isTemplateDeclaration", () => {
 	it("returns false when model has no node", () => {
 		const model = {} as unknown as Model;
 		assert.equal(__test.isTemplateDeclaration(model), false);
+	});
+});
+
+const DEMOTION_CODE =
+	"@kattebak/typespec-opensearch-emitter/search-projection-without-index-name";
+
+describe("reportDemotedProjections (issue #157)", () => {
+	async function resolveAll(source: string, names: string[]) {
+		const runner = await createRunner();
+		await runner.diagnose(source);
+		const resolved = names.map((name) => {
+			const model = runner.program.getGlobalNamespaceType().models.get(name);
+			assert.ok(model, `fixture model ${name} must exist`);
+			const projection = resolveProjectionModel(runner.program, model);
+			assert.ok(projection);
+			return projection;
+		});
+		return { runner, resolved };
+	}
+
+	const source = `
+      model Widget {
+        @searchable name: string;
+      }
+
+      @searchProjection
+      model DemotedSearchDoc is SearchProjection<Widget> {}
+
+      model UndecoratedSearchDoc is SearchProjection<Widget> {}
+    `;
+
+	it("warns when @searchProjection carries no @indexName", async () => {
+		const { runner, resolved } = await resolveAll(source, ["DemotedSearchDoc"]);
+
+		__test.reportDemotedProjections(runner.program, resolved);
+
+		const relevant = runner.program.diagnostics.filter(
+			(d) => d.code === DEMOTION_CODE,
+		);
+		assert.equal(relevant.length, 1);
+		assert.equal(relevant[0].severity, "warning");
+		assert.ok(relevant[0].message.includes("DemotedSearchDoc"));
+		assert.ok(relevant[0].message.includes("@indexName"));
+	});
+
+	it("stays silent for a projection that never asked to be top-level", async () => {
+		const { runner, resolved } = await resolveAll(source, [
+			"UndecoratedSearchDoc",
+		]);
+
+		__test.reportDemotedProjections(runner.program, resolved);
+
+		assert.equal(
+			runner.program.diagnostics.filter((d) => d.code === DEMOTION_CODE).length,
+			0,
+		);
 	});
 });

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -29,7 +29,7 @@ import {
 	emitRestSdl,
 	restSdlFileName,
 } from "./emit-rest-sdl.js";
-import type { OpenSearchEmitterOptions } from "./lib.js";
+import { type OpenSearchEmitterOptions, reportDiagnostic } from "./lib.js";
 import {
 	isSearchProjectionModel,
 	type ResolvedProjection,
@@ -85,6 +85,8 @@ export async function $onEmit(
 
 	const topLevel = resolved.filter(isTopLevel);
 	const nestedOnly = resolved.filter((projection) => !isTopLevel(projection));
+
+	reportDemotedProjections(context.program, nestedOnly);
 
 	for (const projection of topLevel) {
 		const docTypeFile = emitDocType(context.program, projection);
@@ -493,8 +495,30 @@ function generateGraphQLManifest(
 	return `${JSON.stringify({ resolvers: allResolvers }, null, 2)}\n`;
 }
 
+/**
+ * Issue #157 — `@searchProjection` states an intent for top-level emission.
+ * Without `@indexName` that intent is discarded, and the result is
+ * byte-identical to an undecorated model, so the demotion is invisible in the
+ * build output. Warn per demoted projection: regenerating a downstream package
+ * then enumerates exactly which Query fields it lost.
+ */
+function reportDemotedProjections(
+	program: Program,
+	nestedOnly: ResolvedProjection[],
+): void {
+	for (const projection of nestedOnly) {
+		if (!isSearchProjection(program, projection.projectionModel)) continue;
+		reportDiagnostic(program, {
+			code: "search-projection-without-index-name",
+			format: { name: projection.projectionModel.name },
+			target: projection.projectionModel,
+		});
+	}
+}
+
 export const __test = {
 	collectProjectionModels,
+	reportDemotedProjections,
 	isCandidateModel,
 	isTemplateDeclaration,
 	serializeProjections,

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -34,6 +34,7 @@ import {
 	isSearchProjectionModel,
 	type ResolvedProjection,
 	resolveProjectionModel,
+	type TopLevelProjection,
 } from "./projection.js";
 import {
 	collectRestOperations,
@@ -72,13 +73,18 @@ export async function $onEmit(
 	// are nested-only: they still get a doc type and a stripped SDL fragment
 	// so siblings can reference them, but no top-level wiring. This is a
 	// breaking change for fixtures relying on the old name-based behavior.
-	const topLevel = resolved.filter((projection) =>
-		isSearchProjection(context.program, projection.projectionModel),
-	);
-	const nestedOnly = resolved.filter(
-		(projection) =>
-			!isSearchProjection(context.program, projection.projectionModel),
-	);
+	//
+	// Issue #157 — `@indexName` is the second gate. A projection with no
+	// declared index has no index to query; emitting a Query field for it
+	// produced resolvers that failed at runtime against a nonexistent index.
+	const isTopLevel = (
+		projection: ResolvedProjection,
+	): projection is TopLevelProjection =>
+		isSearchProjection(context.program, projection.projectionModel) &&
+		projection.indexName !== undefined;
+
+	const topLevel = resolved.filter(isTopLevel);
+	const nestedOnly = resolved.filter((projection) => !isTopLevel(projection));
 
 	for (const projection of topLevel) {
 		const docTypeFile = emitDocType(context.program, projection);
@@ -366,7 +372,7 @@ function isTemplateDeclaration(model: Model): boolean {
 	return false;
 }
 
-function serializeProjections(resolved: ResolvedProjection[]) {
+function serializeProjections(resolved: TopLevelProjection[]) {
 	return {
 		projections: resolved.map((projection) => ({
 			name: projection.projectionModel.name,
@@ -447,7 +453,7 @@ interface RestManifestEntry {
 }
 
 function generateGraphQLManifest(
-	projections: ResolvedProjection[],
+	projections: TopLevelProjection[],
 	resolverFiles: EmittedResolverFile[],
 	queryFieldDirectives?: string[][],
 	restEntries?: RestManifestEntry[],

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -101,6 +101,12 @@ export const $lib = createTypeSpecLibrary({
 				default: paramMessage`Property "${"name"}" on projection model is not a @searchable property on source model ${"sourceModel"} and will be ignored.`,
 			},
 		},
+		"search-projection-without-index-name": {
+			severity: "warning",
+			messages: {
+				default: paramMessage`Model "${"name"}" has @searchProjection but no @indexName, so it is emitted as a nested type only: no Query field, no resolver, and no backing index. Declare @indexName to emit it as top-level, or remove @searchProjection if nested-only is intended.`,
+			},
+		},
 		"invalid-index-settings-json": {
 			severity: "error",
 			messages: {

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -66,10 +66,20 @@ export interface ResolvedProjectionField {
 export interface ResolvedProjection {
 	projectionModel: Model;
 	sourceModel: Model;
-	indexName: string;
+	/**
+	 * Set only when the model carries `@indexName`. Absent means the projection
+	 * is nested-only — no backing OpenSearch index exists for it (issue #157).
+	 */
+	indexName?: string;
 	indexSettings?: Record<string, unknown>;
 	fields: ResolvedProjectionField[];
 }
+
+/**
+ * A projection backed by a real OpenSearch index, and therefore eligible for
+ * top-level emission: Query field, resolver, mapping, manifest entry.
+ */
+export type TopLevelProjection = ResolvedProjection & { indexName: string };
 
 export function isSearchProjectionModel(
 	program: Program,

--- a/test/example.js
+++ b/test/example.js
@@ -312,6 +312,91 @@ test("nested-only projections emit a stripped SDL fragment + doc type, no top-le
 	assert.ok(!indexTs.includes("APPROVAL_SEARCH_DOC_INDEX_NAME"));
 });
 
+test("@searchProjection without @indexName is nested-only (issue #157)", async () => {
+	// BankAccountApprovalSearchDoc carries @searchProjection but declares no
+	// @indexName. There is no index for a resolver to query, so it must get
+	// the same nested-only treatment as an undecorated projection.
+	const manifest = JSON.parse(
+		await readFile(`${OUT_DIR}/graphql-resolvers.json`, "utf8"),
+	);
+	const names = manifest.resolvers.map((r) => r.queryFieldName);
+	assert.ok(
+		!names.includes("searchBankAccountApproval"),
+		"index-less projections must not appear in the resolver manifest",
+	);
+	// Every manifest entry that does exist names a real, declared index.
+	for (const resolver of manifest.resolvers.filter((r) => r.indexName)) {
+		assert.ok(
+			resolver.indexName,
+			`${resolver.queryFieldName} must carry a declared index name`,
+		);
+		assert.ok(
+			!resolver.indexName.endsWith("_search_doc") ||
+				[
+					"tag_search_doc",
+					"pet_public_search_doc",
+					"person_search_doc",
+				].includes(resolver.indexName),
+			`${resolver.queryFieldName} must not fall back to a derived index name`,
+		);
+	}
+
+	// No Query field in the SDL fragment, and no Connection plumbing behind it.
+	const sdl = await readFile(
+		`${OUT_DIR}/bank-account-approval-search-doc.graphql`,
+		"utf8",
+	);
+	assert.ok(sdl.includes("type BankAccountApprovalSearchDoc {"));
+	assert.ok(!sdl.includes("BankAccountApprovalSearchDocConnection"));
+	assert.ok(!sdl.includes("searchBankAccountApproval"));
+
+	// Doc type stays — the parent needs the TS shape for the array element.
+	const docType = await readFile(
+		`${OUT_DIR}/bank-account-approval-search-doc.ts`,
+		"utf8",
+	);
+	assert.ok(docType.includes("BankAccountApprovalSearchDoc"));
+
+	// No mapping, no resolver, no index constant.
+	await assert.rejects(
+		readFile(
+			`${OUT_DIR}/bank-account-approval-search-doc-search-mapping.json`,
+			"utf8",
+		),
+		"index-less projections must not emit a mapping file",
+	);
+	await assert.rejects(
+		readFile(`${OUT_DIR}/bank-account-approval-search-doc-resolver.js`, "utf8"),
+		"index-less projections must not emit a resolver",
+	);
+	const indexTs = await readFile(`${OUT_DIR}/index.ts`, "utf8");
+	assert.ok(!indexTs.includes("BANK_ACCOUNT_APPROVAL_SEARCH_DOC_INDEX_NAME"));
+
+	// The parent still references the type through the array element.
+	const petSdl = await readFile(`${OUT_DIR}/pet-search-doc.graphql`, "utf8");
+	assert.ok(
+		petSdl.includes("bankAccountApprovals: [BankAccountApprovalSearchDoc!]!"),
+	);
+});
+
+test("@indexName-backed projections keep their top-level wiring (issue #157)", async () => {
+	const manifest = JSON.parse(
+		await readFile(`${OUT_DIR}/graphql-resolvers.json`, "utf8"),
+	);
+	const byField = new Map(manifest.resolvers.map((r) => [r.queryFieldName, r]));
+
+	for (const [field, indexName] of [
+		["searchPet", "pets_v1"],
+		["searchTag", "tag_search_doc"],
+		["searchPetPublic", "pet_public_search_doc"],
+		["searchPerson", "person_search_doc"],
+	]) {
+		const resolver = byField.get(field);
+		assert.ok(resolver, `${field} must still be emitted`);
+		assert.equal(resolver.indexName, indexName);
+	}
+});
+
 test("emits @graphqlDirectives on response-path types and surfaces them in the manifest (issue #121)", async () => {
 	const sdl = await readFile(`${OUT_DIR}/tag-search-doc.graphql`, "utf8");
 	const manifest = JSON.parse(

--- a/test/example.js
+++ b/test/example.js
@@ -324,20 +324,13 @@ test("@searchProjection without @indexName is nested-only (issue #157)", async (
 		!names.includes("searchBankAccountApproval"),
 		"index-less projections must not appear in the resolver manifest",
 	);
-	// Every manifest entry that does exist names a real, declared index.
-	for (const resolver of manifest.resolvers.filter((r) => r.indexName)) {
+	// Every projection entry names an index. Asserting over the unfiltered
+	// list is the point: filtering to entries that have one would skip the
+	// regression where an index-less projection reaches the manifest.
+	for (const resolver of manifest.resolvers.filter((r) => r.projection)) {
 		assert.ok(
 			resolver.indexName,
 			`${resolver.queryFieldName} must carry a declared index name`,
-		);
-		assert.ok(
-			!resolver.indexName.endsWith("_search_doc") ||
-				[
-					"tag_search_doc",
-					"pet_public_search_doc",
-					"person_search_doc",
-				].includes(resolver.indexName),
-			`${resolver.queryFieldName} must not fall back to a derived index name`,
 		);
 	}
 

--- a/test/main.tsp
+++ b/test/main.tsp
@@ -18,6 +18,7 @@ model Tag {
 // applied to its response-path types and Query field; the other three
 // projections in this fixture stay bare.
 @searchProjection
+@indexName("tag_search_doc")
 @graphqlDirectives("@aws_cognito_user_pools", "@aws_iam")
 model TagSearchDoc is SearchProjection<Tag> {}
 
@@ -37,6 +38,7 @@ model Pet {
 	@searchable score: float64;
 	@searchable active: boolean;
 	@searchable approvals: Approval[];
+	@searchable bankAccountApprovals: BankAccountApproval[];
 	internalNotes: string;
 }
 
@@ -55,6 +57,11 @@ model PetSearchDoc is SearchProjection<Pet> {
 	// (for use as an array element), but no Query field, no resolver, no
 	// OS index, no manifest entry.
 	approvals: ApprovalSearchDoc[];
+
+	// Issue #157 — same nested-only treatment, reached via the other gate:
+	// BankAccountApprovalSearchDoc carries @searchProjection but declares no
+	// @indexName, so there is no index for a Query field to target.
+	bankAccountApprovals: BankAccountApprovalSearchDoc[];
 }
 
 model Approval {
@@ -64,7 +71,20 @@ model Approval {
 
 model ApprovalSearchDoc is SearchProjection<Approval> {}
 
+model BankAccountApproval {
+	@searchable @keyword accountId: string;
+	@searchable @keyword approvedBy: string;
+}
+
+// Issue #157 — @searchProjection with no @indexName. The decorator alone used
+// to mint a top-level resolver pointed at a defaulted
+// `bank_account_approval_search_doc` index that nothing ever creates, so the
+// query failed at runtime with "Not Found".
 @searchProjection
+model BankAccountApprovalSearchDoc is SearchProjection<BankAccountApproval> {}
+
+@searchProjection
+@indexName("pet_public_search_doc")
 model PetPublicSearchDoc is SearchProjection<Pet> {
 	@keyword
 	name: string;
@@ -82,5 +102,6 @@ model Person {
 }
 
 @searchProjection
+@indexName("person_search_doc")
 @searchInfer
 model PersonSearchDoc is SearchProjection<Person> {}

--- a/test/snapshots/opensearch-baseline/bank-account-approval-search-doc.graphql
+++ b/test/snapshots/opensearch-baseline/bank-account-approval-search-doc.graphql
@@ -1,0 +1,4 @@
+type BankAccountApprovalSearchDoc {
+  accountId: String!
+  approvedBy: String!
+}

--- a/test/snapshots/opensearch-baseline/bank-account-approval-search-doc.ts
+++ b/test/snapshots/opensearch-baseline/bank-account-approval-search-doc.ts
@@ -1,0 +1,4 @@
+export interface BankAccountApprovalSearchDoc {
+	accountId: string;
+	approvedBy: string;
+}

--- a/test/snapshots/opensearch-baseline/index.ts
+++ b/test/snapshots/opensearch-baseline/index.ts
@@ -1,5 +1,6 @@
 export type { Address } from "./address.js";
 export type { ApprovalSearchDoc } from "./approval-search-doc.js";
+export type { BankAccountApprovalSearchDoc } from "./bank-account-approval-search-doc.js";
 export type { PersonSearchDoc } from "./person-search-doc.js";
 export const PERSON_SEARCH_DOC_INDEX_NAME = "person_search_doc";
 export type { PetPublicSearchDoc } from "./pet-public-search-doc.js";

--- a/test/snapshots/opensearch-baseline/opensearch-projections.json
+++ b/test/snapshots/opensearch-baseline/opensearch-projections.json
@@ -132,6 +132,12 @@
           "optional": false,
           "keyword": false,
           "nested": false
+        },
+        {
+          "name": "bankAccountApprovals",
+          "optional": false,
+          "keyword": false,
+          "nested": false
         }
       ]
     },
@@ -236,6 +242,12 @@
         },
         {
           "name": "approvals",
+          "optional": false,
+          "keyword": false,
+          "nested": false
+        },
+        {
+          "name": "bankAccountApprovals",
           "optional": false,
           "keyword": false,
           "nested": false

--- a/test/snapshots/opensearch-baseline/pet-public-search-doc-search-mapping.json
+++ b/test/snapshots/opensearch-baseline/pet-public-search-doc-search-mapping.json
@@ -96,6 +96,17 @@
             "type": "keyword"
           }
         }
+      },
+      "bankAccountApprovals": {
+        "type": "object",
+        "properties": {
+          "accountId": {
+            "type": "keyword"
+          },
+          "approvedBy": {
+            "type": "keyword"
+          }
+        }
       }
     }
   }

--- a/test/snapshots/opensearch-baseline/pet-public-search-doc.graphql
+++ b/test/snapshots/opensearch-baseline/pet-public-search-doc.graphql
@@ -14,6 +14,7 @@ type PetPublicSearchDoc {
   score: Float!
   active: Boolean!
   approvals: [String!]!
+  bankAccountApprovals: [String!]!
 }
 
 input PetPublicSearchDocFilter {

--- a/test/snapshots/opensearch-baseline/pet-public-search-doc.ts
+++ b/test/snapshots/opensearch-baseline/pet-public-search-doc.ts
@@ -22,4 +22,8 @@ export interface PetPublicSearchDoc {
 		type: string;
 		grantedBy: string;
 	}[];
+	bankAccountApprovals: {
+		accountId: string;
+		approvedBy: string;
+	}[];
 }

--- a/test/snapshots/opensearch-baseline/pet-search-doc-search-mapping.json
+++ b/test/snapshots/opensearch-baseline/pet-search-doc-search-mapping.json
@@ -104,6 +104,17 @@
             "type": "keyword"
           }
         }
+      },
+      "bankAccountApprovals": {
+        "type": "object",
+        "properties": {
+          "accountId": {
+            "type": "keyword"
+          },
+          "approvedBy": {
+            "type": "keyword"
+          }
+        }
       }
     }
   }

--- a/test/snapshots/opensearch-baseline/pet-search-doc.graphql
+++ b/test/snapshots/opensearch-baseline/pet-search-doc.graphql
@@ -14,6 +14,7 @@ type PetSearchDoc {
   score: Float!
   active: Boolean!
   approvals: [ApprovalSearchDoc!]!
+  bankAccountApprovals: [BankAccountApprovalSearchDoc!]!
 }
 
 input PetSearchDocFilter {

--- a/test/snapshots/opensearch-baseline/pet-search-doc.ts
+++ b/test/snapshots/opensearch-baseline/pet-search-doc.ts
@@ -1,5 +1,6 @@
 import type { TagSearchDoc } from "./tag-search-doc.js";
 import type { ApprovalSearchDoc } from "./approval-search-doc.js";
+import type { BankAccountApprovalSearchDoc } from "./bank-account-approval-search-doc.js";
 
 export interface PetSearchDoc {
 	id: string;
@@ -19,4 +20,5 @@ export interface PetSearchDoc {
 	score: number;
 	active: boolean;
 	approvals: ApprovalSearchDoc[];
+	bankAccountApprovals: BankAccountApprovalSearchDoc[];
 }


### PR DESCRIPTION
Closes #157.

> [!WARNING]
> **Do not merge until the release config is settled.** This repo has no `.releaserc`, so semantic-release runs the **angular** preset, which has no `breakingHeaderPattern` and honours only a `BREAKING CHANGE:` footer. The repo is squash-only with `squash_merge_commit_message: BLANK`, so the release commit is this PR's **title with an empty body** — the footer never reaches `main`. Verified against `@semantic-release/commit-analyzer@13`: title alone → **no release**; title + footer → `major`. Merging as-is publishes nothing. See [Release](#release) below.

## Behavior

`@searchProjection` and `@indexName` are both gates for top-level emission. A projection carrying both gets a Query field, resolver, index mapping, and a `graphql-resolvers.json` entry. A projection missing either is emitted as a nested type only — doc type plus a stripped SDL fragment, so parents can reference it as a field type.

The snake_case default index name is removed. Absence of `@indexName` now means the projection has no backing index, rather than silently naming one that nothing creates. Previously every `@searchProjection` model became a top-level resolver, so nested projections like `ApprovalSearchDoc` got resolvers pointed at indices that never existed and failed at runtime with `Not Found`.

## Diagnostic

A model carrying `@searchProjection` with no `@indexName` gets a `severity: "warning"` diagnostic naming the model, stating that it is emitted as a nested type only with no Query field or resolver, and that declaring `@indexName` makes it top-level.

Without it the demotion is invisible: a demoted projection and an undecorated one produce byte-identical output, so regenerating a downstream package drops Query fields on a green build with nothing naming what was lost. The warning makes regeneration self-documenting — it enumerates exactly which projections got demoted, and each one then gets an index name or loses the decorator.

The rule is "you asked for top-level and are not getting it", which covers both a demoted nested projection and a decorated model referenced by nobody. Emitted artifacts are unchanged; the snapshot baseline stays byte-identical.

## Breaking changes

**1. `@indexName` is now required for a `@searchProjection` model to be emitted as top-level.**

Any `@searchProjection` model that relied on the derived snake_case index name must now declare `@indexName` explicitly to remain top-level:

```diff
  @searchProjection
+ @indexName("pet_search_doc")
  model PetSearchDoc { ... }
```

Without it, the model is emitted as a nested type only: it loses its Query field, resolver, index mapping, and `graphql-resolvers.json` entry. The spec still compiles, and now warns per demoted model. Audit every `@searchProjection` model in a downstream spec before taking this version.

**2. `getIndexName` returns `string | undefined`, was `string`.**

`getIndexName` is exported from `src/index.ts`. Its return type change is a compile break for any downstream TypeScript consumer of the package API, distinct from the spec-level break above. Callers must narrow the result before use.

## Release

This must publish as **2.0.0**, not 1.1.1. Downstream consumers on `^1.1.0` would otherwise auto-update into the silent resolver loss described above.

The commits on this branch carry both `fix(emitter)!:` and `BREAKING CHANGE:` footers, which analyze as `major`. Under squash merge the footers are dropped, and the angular preset cannot express a breaking change from a header, so one of these is needed:

1. Add a `.releaserc` pinning commit-analyzer and release-notes-generator to the `conventionalcommits` preset, which honours `!` in the header. Makes `!` mean what it appears to mean for every future PR.
2. Set the repo's `squash_merge_commit_message` to `PR_BODY` so the footer in a PR body reaches `main`.
3. One-off: merge with an explicit body carrying the footer (`gh pr merge --squash --body "BREAKING CHANGE: ..."`). Leaves the trap in place for the next breaking change.

The `!` in the title is the fail-safe meanwhile: under the current config an accidental merge publishes nothing rather than a 1.1.1 that breaks consumers.

## Types

`ResolvedProjection.indexName` is now optional, and `TopLevelProjection` narrows it back to `string`. The emitters that consume an index name — the resolver, the barrel constants, `serializeProjections`, and the manifest — take `TopLevelProjection`, so the gate is enforced by the type system rather than by convention.

## Tests

`test/main.tsp` gains `BankAccountApprovalSearchDoc` — `@searchProjection`, no `@indexName`, nested inside `PetSearchDoc` — mirroring the reported case. Regression tests cover both acceptance points: it produces no Query field and no manifest entry, while the `@indexName`-backed resolvers keep their wiring. Unit tests assert the diagnostic fires at warning severity for a demoted projection and stays silent for an undecorated one.

The fixture models that are meant to be top-level now declare the index names they previously derived, which holds the byte-identical baseline snapshot to additions only — no existing top-level artifact changes.

## Known issue, not addressed here

`pet-public-search-doc.graphql` gives `bankAccountApprovals: [String!]!` while the doc type and mapping both give a nested object. Pre-existing for `approvals: [String!]!`; the new fixture doubles its footprint in the snapshot but does not change the behavior. Tracked in #160 — fixing it here would rewrite existing snapshot artifacts, which is what this PR's additions-only baseline exists to prevent.