### PR TITLE
fix(graphql): search @searchable fields inside nested sub-projections

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,8 +292,8 @@ Stacking `@filterable` and `@aggregatable` per field becomes noisy on a typical 
 
 When a field's type is a TypeSpec model (struct) — either inline (`address: Address`) or as an array (`tags: Tag[]`) — `@searchInfer` recurses into the nested model's properties and applies the same inference table. The parent's `<Type>SearchFilter` exposes `<fieldName>: <NestedType>SearchFilter`, and a separate `<NestedType>SearchFilter` input is emitted alongside.
 
-- **`@nested` array** (OS-nested mapping): filter clauses wrap in `bool.filter[ nested + inner ]`.
-- **Inline struct** (no `@nested`): children carry dotted OS field paths (`address.country`) — no nested wrapper.
+- **`@nested` array** (OS-nested mapping): filter clauses wrap in `bool.filter[ nested + inner ]`. Free-text search wraps the same way — see [Free-text search across nested fields](#free-text-search-across-nested-fields).
+- **Inline struct** (no `@nested`): children carry dotted OS field paths (`address.country`) — no nested wrapper, on either the filter or the free-text axis.
 - **Recursion depth**: unbounded; cycles are guarded by a visited-name set.
 - **Opt-out**: `@searchSkip` on the parent's field suppresses the virtual sub-projection (and the parent skips the field when no other decorator keeps it in the projection).
 
@@ -453,7 +453,7 @@ Each resolver file exports `request(ctx)` and `response(ctx)` conforming to APPS
 - **No imports** except `@aws-appsync/utils`
 - **No network I/O** — resolvers are pure request/response transformers
 - `request` builds an OpenSearch `_search` body with:
-  - `multi_match` across all `text` fields when `query` argument is provided
+  - `multi_match` across all `text` fields when `query` argument is provided, plus a `nested`-wrapped `multi_match` per `@nested` sub-model carrying searchable text
   - `term` filters for each `@keyword` field present in the `filter` argument
   - `search_after` cursor pagination (base64-encoded sort values)
   - Deterministic sort: `[_score desc, _id asc]`
@@ -564,8 +564,34 @@ GraphQL intent is derived from the existing OpenSearch mapping — no additional
 | --- | --- |
 | `@keyword` field | Filterable input argument (term match) |
 | `text` field (no `@keyword`) | Included in `multi_match` field list |
+| `text` field inside a sub-projection | Included in free-text search — see below |
 | All projection fields | Output type fields |
 | Sub-projection (`SearchProjection`) | Nested GraphQL type reference |
+
+### Free-text search across nested fields
+
+`@searchable` on a sub-model's `text` field puts that field in free-text search. The `query` argument searches it alongside the root document's fields; no extra decorator opts it in.
+
+How the field is mapped decides the clause:
+
+- **`object` sub-projection** (no `@nested`): the field lives in the root document, so it joins the flat `multi_match` under its dotted path (`owner.fullName`).
+- **`@nested` sub-projection**: nested-mapped fields are separate hidden Lucene documents, unreachable by a bare `multi_match` on `tags.note`. Each `@nested` sub-model carrying searchable text contributes one `nested`-wrapped clause, and the clauses combine under `bool.should` with `minimum_should_match: 1`:
+
+```js
+bool: {
+  should: [
+    { multi_match: { query: queryText, fields: ["name"], type: "best_fields" } },
+    NQ("tags", ["tags.note"], queryText),
+  ],
+  minimum_should_match: 1,
+}
+```
+
+`NQ` is the emitted nested-query helper (`{ nested: { path, score_mode: "max", query: { multi_match: … } } }`). `score_mode: "max"` scores a parent by its best-matching child, so one strong hit ranks a parent the way a root-field hit would.
+
+A projection with no nested searchable text emits the flat `multi_match` alone — no `bool.should`, no helper.
+
+An `@analyzer` on a nested field is honoured: the clause queries the analyzed path, not its `.keyword` sub-field, so edge-ngram partial matching works the same as it does at the root (issue #130).
 
 ### Resolver code-size budget
 
@@ -584,20 +610,25 @@ Each pipeline file gets its own 32,768-byte budget. Splitting the work is what m
 
 Emitted code stays flat as projections widen by keeping specs as data. A projection emits a compact name → spec map — `FILTER_SPEC` for filter inputs, `AGG_SPEC` for aggregations, both using single-letter keys — plus one assembly function that walks the map at runtime. A new field adds map entries; it does not add code.
 
+Where a literal is unavoidable, the repeated skeleton is factored into a module-level helper called with the varying parts — `ADH` for bounds-less `auto_date_histogram` entries, `NQ` for nested free-text clauses. A nested sub-model then costs ~53 bytes instead of ~153.
+
 Inlining a literal per field instead scales code with projection width. That is what breached the cap twice: issue #101 (counterparty resolver at 38,301 bytes, of which 38,257 were the inline `FILTER_SPEC` literal; fixed by collapsing range-suffix expansions) and issue #105 (37,310 bytes after range-collapse; fixed by factoring repeated nested-doc skeletons).
 
 Emitted code must also stay in the APPSYNC_JS supported subset. `src/emit-graphql-resolver.test.ts` runs `@aws-appsync/eslint-plugin` over the output.
 
 #### Guards
 
-Two tests in `src/emit-graphql-resolver.test.ts` assert every emitted file stays under 32,768 bytes. Measured after the per-request bucket budget (issue #155):
+Three tests in `src/emit-graphql-resolver.test.ts` assert every emitted file stays under 32,768 bytes. Measured after the per-request bucket budget (issue #155):
 
 | Projection | Resolver | Prepare | Search | Headroom |
 | --- | --- | --- | --- | --- |
 | counterparty shape (7 nested sub-models) | 8,991 | 24,754 | 742 | 8,014 |
+| counterparty shape, 2 searchable text fields per sub-model | 8,491 | 24,617 | 742 | 8,151 |
 | synthetic wide (14 sub-models) | 14,458 | 32,452 | 732 | **316** |
 
-`prepare` is the constrained file in both, and headroom depends on projection width. The 14-sub-model guard governs: at 316 bytes, the next change touching the prepare function hits the cap. Real projections are not close — the counterparty shape renders 18,319 bytes as a single file and stays monolithic.
+`prepare` is the constrained file in all three, and headroom depends on projection width. The 14-sub-model guard governs: at 316 bytes, the next change touching the prepare function hits the cap. Real projections are not close — the counterparty shape renders 18,319 bytes as a single file and stays monolithic.
+
+Nested free-text search (issue #158) costs ~53 bytes per `@nested` sub-model carrying searchable text (it scales with path length), plus 166 bytes once for the `NQ` helper. It is charged only to projections that have such a field. The 14-sub-model guard is the shape where that matters: its sub-models are all `@keyword`/date, so it pays nothing, but adding searchable text to every sub-model of a projection that wide would exceed the cap — as the 316-byte headroom already implies for any addition.
 
 CI goes red on the guard, and AppSync refuses the deploy. The assertion message prints the current headroom — trust it over these numbers.
 

--- a/src/emit-graphql-resolver.test.ts
+++ b/src/emit-graphql-resolver.test.ts
@@ -27,6 +27,17 @@ function makeProjection(
 	} as unknown as ResolvedProjection;
 }
 
+function makeSubProjection(
+	name: string,
+	fields: ResolvedProjection["fields"],
+): ResolvedProjection {
+	return {
+		projectionModel: { name },
+		sourceModel: { name },
+		fields,
+	} as unknown as ResolvedProjection;
+}
+
 function makeField(
 	overrides: Partial<{
 		name: string;
@@ -35,6 +46,7 @@ function makeField(
 		nested: boolean;
 		optional: boolean;
 		searchable: boolean;
+		analyzer: string;
 		type: Type;
 		aggregations: unknown;
 		filterables: ResolvedProjection["fields"][0]["filterables"];
@@ -48,6 +60,7 @@ function makeField(
 		nested: overrides.nested ?? false,
 		optional: overrides.optional ?? false,
 		searchable: overrides.searchable ?? true,
+		analyzer: overrides.analyzer,
 		type:
 			overrides.type ??
 			({
@@ -290,21 +303,240 @@ describe("emitGraphQLResolver", () => {
 		assert.ok(combinedContent(result).includes('"species","status"'));
 	});
 
-	it("excludes nested and sub-projection fields from text fields", async () => {
-		const subProjection = {
-			projectionModel: { name: "TagSearchDoc" },
-		} as unknown as ResolvedProjection;
-
+	it("wraps a nested sub-projection's searchable fields in a nested clause and takes dotted paths through an object sub-projection", async () => {
 		const projection = makeProjection({
 			fields: [
 				makeField({ name: "name" }),
-				makeField({ name: "tags", nested: true }),
-				makeField({ name: "owner", subProjection }),
+				makeField({
+					name: "tags",
+					nested: true,
+					subProjection: makeSubProjection("TagSearchDoc", [
+						makeField({ name: "label" }),
+					]),
+				}),
+				makeField({
+					name: "owner",
+					subProjection: makeSubProjection("OwnerSearchDoc", [
+						makeField({ name: "fullName" }),
+					]),
+				}),
+			],
+		});
+		const result = await emitGraphQLResolver(projection, defaultOptions);
+		const query = loadBuildQuery(prepareFunctionContent(result))(
+			"rex",
+			undefined,
+			undefined,
+		);
+
+		assert.deepEqual(query, {
+			bool: {
+				must: [
+					{
+						bool: {
+							should: [
+								{
+									multi_match: {
+										query: "rex",
+										fields: ["name", "owner.fullName"],
+										type: "best_fields",
+									},
+								},
+								{
+									nested: {
+										path: "tags",
+										score_mode: "max",
+										query: {
+											multi_match: {
+												query: "rex",
+												fields: ["tags.label"],
+												type: "best_fields",
+											},
+										},
+									},
+								},
+							],
+							minimum_should_match: 1,
+						},
+					},
+				],
+			},
+		});
+	});
+
+	it("keeps the flat multi_match byte-for-byte when no nested sub-projection is searchable", async () => {
+		const withoutNested = makeProjection({
+			fields: [makeField({ name: "name" }), makeField({ name: "description" })],
+		});
+		const withInertNested = makeProjection({
+			fields: [
+				makeField({ name: "name" }),
+				makeField({ name: "description" }),
+				makeField({
+					name: "tags",
+					nested: true,
+					subProjection: makeSubProjection("TagSearchDoc", [
+						// Filter-only and keyword fields carry no free-text surface,
+						// so the nested wrapper must stay off.
+						makeField({ name: "tagId", keyword: true }),
+						makeField({ name: "note", searchable: false }),
+					]),
+				}),
+			],
+		});
+
+		const baseline = combinedContent(
+			await emitGraphQLResolver(withoutNested, defaultOptions),
+		);
+		const actual = combinedContent(
+			await emitGraphQLResolver(withInertNested, defaultOptions),
+		);
+
+		assert.ok(
+			baseline.includes(`		musts.push({
+			multi_match: {
+				query: queryText,
+				fields: ["name","description"],
+				type: "best_fields",
+			},
+		});`),
+		);
+		assert.ok(!baseline.includes("minimum_should_match"));
+		assert.equal(actual, baseline);
+	});
+
+	it("honours @analyzer on a nested field by querying the analyzed path, not .keyword", async () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({ name: "name" }),
+				makeField({
+					name: "references",
+					nested: true,
+					subProjection: makeSubProjection("ReferenceSearchDoc", [
+						makeField({ name: "value", analyzer: "edge_ngram_analyzer" }),
+					]),
+				}),
+			],
+		});
+		const result = await emitGraphQLResolver(projection, defaultOptions);
+		const query = loadBuildQuery(prepareFunctionContent(result))(
+			"ABC",
+			undefined,
+			undefined,
+		) as {
+			bool: {
+				must: [{ bool: { should: [unknown, { nested: { query: unknown } }] } }];
+			};
+		};
+
+		// An @analyzer only takes effect on the analyzed field itself; the
+		// `.keyword` sub-field is not analyzed. The nested clause must query
+		// `references.value` bare for edge-ngram partial matching to work.
+		assert.deepEqual(query.bool.must[0].bool.should[1].nested.query, {
+			multi_match: {
+				query: "ABC",
+				fields: ["references.value"],
+				type: "best_fields",
+			},
+		});
+	});
+
+	it("groups searchable fields by their innermost nested ancestor", async () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "references",
+					nested: true,
+					subProjection: makeSubProjection("ReferenceSearchDoc", [
+						makeField({ name: "value" }),
+						// An object sub-projection inside a nested one stays in the
+						// same hidden document: it extends the path but opens no
+						// second nested clause.
+						makeField({
+							name: "issuer",
+							subProjection: makeSubProjection("IssuerSearchDoc", [
+								makeField({ name: "code" }),
+							]),
+						}),
+					]),
+				}),
+				makeField({
+					name: "tags",
+					nested: true,
+					subProjection: makeSubProjection("TagSearchDoc", [
+						makeField({ name: "label" }),
+					]),
+				}),
+			],
+		});
+		const result = await emitGraphQLResolver(projection, defaultOptions);
+		const query = loadBuildQuery(prepareFunctionContent(result))(
+			"rex",
+			undefined,
+			undefined,
+		);
+
+		// No root-document text field, so no flat clause — only the two
+		// nested groups, each naming its own path.
+		assert.deepEqual(query, {
+			bool: {
+				must: [
+					{
+						bool: {
+							should: [
+								{
+									nested: {
+										path: "references",
+										score_mode: "max",
+										query: {
+											multi_match: {
+												query: "rex",
+												fields: ["references.value", "references.issuer.code"],
+												type: "best_fields",
+											},
+										},
+									},
+								},
+								{
+									nested: {
+										path: "tags",
+										score_mode: "max",
+										query: {
+											multi_match: {
+												query: "rex",
+												fields: ["tags.label"],
+												type: "best_fields",
+											},
+										},
+									},
+								},
+							],
+							minimum_should_match: 1,
+						},
+					},
+				],
+			},
+		});
+	});
+
+	it("resolves nested text fields through @searchAs projected names", async () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "references",
+					projectedName: "refs",
+					nested: true,
+					subProjection: makeSubProjection("ReferenceSearchDoc", [
+						makeField({ name: "value", projectedName: "code" }),
+					]),
+				}),
 			],
 		});
 		const result = await emitGraphQLResolver(projection, defaultOptions);
 
-		assert.ok(combinedContent(result).includes('["name"]'));
+		assert.ok(
+			combinedContent(result).includes('NQ("refs", ["refs.code"], queryText)'),
+		);
 	});
 
 	it("excludes non-searchable filter-only fields from text_fields and keyword_fields but includes them in FILTER_SPEC", async () => {
@@ -3060,6 +3292,69 @@ describe("emitGraphQLResolver wide-projection budget (issue #105)", () => {
 			assert.ok(
 				bytes < 32_768,
 				`wide projection ${file.name} file is ${bytes} bytes; must stay under AppSync's 32,768-byte per-file cap (issue #105). Headroom: ${32_768 - bytes} bytes.`,
+			);
+		}
+	});
+
+	it("counterparty-shape projection with searchable text in every nested sub-model stays under the cap", async () => {
+		// The nested free-text clause (issue #158) is the one part of buildQuery
+		// that scales with sub-model count, so it gets its own width guard: the
+		// counterparty shape with two @searchable text fields per sub-model —
+		// the shape that reported the bug (a nested "find by reference" lookup).
+		const subShapes = [
+			"Approval",
+			"Relation",
+			"Location",
+			"Contact",
+			"Tag",
+			"Group",
+			"Reference",
+		];
+		const projection = makeProjection({
+			name: "CounterpartySearchDoc",
+			indexName: "counterparties_v1",
+			fields: subShapes.map((shape) =>
+				makeField({
+					name: `${shape.toLowerCase()}s`,
+					nested: true,
+					subProjection: makeWideSubProjection(shape, [
+						makeField({ name: "name" }),
+						makeField({ name: "value" }),
+					]),
+					filterables: ["exists"],
+					type: {
+						kind: "Model",
+						name: "Array",
+						indexer: { value: { kind: "Model" } },
+					} as unknown as Type,
+				}),
+			),
+		});
+
+		const result = await emitGraphQLResolver(projection, defaultOptions);
+		const files = [
+			{ name: "resolver", content: result.content },
+			...result.functions.map((fn) => ({ name: fn.name, content: fn.content })),
+		];
+
+		// Every sub-model contributes a nested clause, so the helper must be
+		// carrying them — an inline skeleton per group costs ~150 bytes each.
+		const prepare = files.find((f) => f.name === "prepare");
+		assert.ok(prepare);
+		for (const shape of subShapes) {
+			assert.ok(
+				prepare.content.includes(
+					`NQ("${shape.toLowerCase()}s", ["${shape.toLowerCase()}s.name","${shape.toLowerCase()}s.value"], queryText)`,
+				),
+				`missing nested text clause for ${shape}`,
+			);
+		}
+
+		for (const file of files) {
+			const bytes = Buffer.byteLength(file.content, "utf8");
+			assert.ok(
+				bytes < 32_768,
+				`${file.name} is ${bytes} bytes; must stay under AppSync's 32,768-byte per-file cap. Headroom: ${32_768 - bytes} bytes.`,
 			);
 		}
 	});

--- a/src/emit-graphql-resolver.ts
+++ b/src/emit-graphql-resolver.ts
@@ -10,6 +10,7 @@ import {
 	type SearchFilterShape,
 } from "./filters.js";
 import type {
+	ResolvedProjection,
 	ResolvedProjectionField,
 	TopLevelProjection,
 } from "./projection.js";
@@ -112,6 +113,17 @@ export const MIN_AUTO_DATE_HISTOGRAM_BUCKETS = 256;
  */
 const AUTO_DATE_HISTOGRAM_HELPER = "ADH";
 
+/**
+ * Module-level helper the emitted free-text clause calls for each `@nested`
+ * sub-projection carrying searchable text. The nested-query skeleton is long
+ * and identical bar the path and field list, so factoring it out of the
+ * literal keeps wide projections under AppSync's 32 KB per-function cap —
+ * the same move as AUTO_DATE_HISTOGRAM_HELPER, and the fix issue #105 applied
+ * to the repeated nested-doc skeletons. The call sites stay static literals:
+ * no spec array, no runtime walk.
+ */
+const NESTED_TEXT_QUERY_HELPER = "NQ";
+
 // Bound for the runtime applyFilterSpec walker's fixed-size work slot pool.
 // APPSYNC_JS does not honor self-extending Array iteration, so the emitted
 // function pre-allocates this many slots as a literal. Set well above any
@@ -126,16 +138,7 @@ export async function emitGraphQLResolver(
 	const queryFieldName = toGraphQLQueryFieldName(typeName);
 	const baseName = toKebabCase(typeName);
 
-	const textFields = projection.fields
-		.filter(
-			(f) =>
-				f.searchable &&
-				!f.keyword &&
-				!f.nested &&
-				!f.subProjection &&
-				hasTextType(f),
-		)
-		.map((f) => f.projectedName ?? f.name);
+	const textFields = collectTextFields(projection);
 
 	const keywordFields = projection.fields
 		.filter((f) => f.searchable && f.keyword)
@@ -225,6 +228,159 @@ export async function emitGraphQLResolver(
 	};
 }
 
+/**
+ * Free-text fields grouped by the query clause they belong in. `flat` holds
+ * root-document paths — top-level fields plus `object`-mapped sub-projection
+ * fields, which live in the same Lucene document and so are reachable by a
+ * dotted path. `nested` holds one group per `@nested` sub-projection that
+ * carries at least one `@searchable` text field; those are separate hidden
+ * documents, reachable only through a `nested` query naming their path.
+ */
+interface NestedTextGroup {
+	path: string;
+	fields: string[];
+}
+
+interface TextFieldCollection {
+	flat: string[];
+	nested: NestedTextGroup[];
+}
+
+/**
+ * Path-threading walk over the projection tree, mirroring the filter path's
+ * `buildShapeRecursive` (filters.ts). `@searchable` on a sub-projection's
+ * field is recorded in that sub-projection's own `fields` array, so a flat
+ * pass over `projection.fields` never sees it — the mapping emitter recurses,
+ * the resolver did not, and nested `@searchable` was inert (issue #158).
+ *
+ * Every path is fully known here, so the emitted clause is a static literal:
+ * no runtime spec-walking, and none of the APPSYNC_JS control-flow
+ * constraints that shape `applyFilterSpec` apply.
+ */
+function collectTextFields(
+	projection: ResolvedProjection,
+): TextFieldCollection {
+	const collection: TextFieldCollection = { flat: [], nested: [] };
+	collectTextFieldsRecursive(projection, undefined, undefined, collection);
+	return collection;
+}
+
+function collectTextFieldsRecursive(
+	projection: ResolvedProjection,
+	fieldPrefix: string | undefined,
+	nestedPath: string | undefined,
+	collection: TextFieldCollection,
+): void {
+	if (!projection.fields) return;
+
+	for (const field of projection.fields) {
+		const path = joinFieldPath(fieldPrefix, field.projectedName ?? field.name);
+
+		if (field.subProjection) {
+			// A `nested` sub-projection opens a new nested document; an `object`
+			// one keeps the current document and only extends the dotted path.
+			// OpenSearch accepts a fully-qualified inner path on a `nested`
+			// query, so nesting within nesting groups by the innermost path.
+			collectTextFieldsRecursive(
+				field.subProjection,
+				path,
+				field.nested ? path : nestedPath,
+				collection,
+			);
+			continue;
+		}
+
+		if (
+			!field.searchable ||
+			field.keyword ||
+			field.nested ||
+			!hasTextType(field)
+		) {
+			continue;
+		}
+
+		if (!nestedPath) {
+			collection.flat.push(path);
+			continue;
+		}
+
+		const group = collection.nested.find((g) => g.path === nestedPath);
+		if (group) {
+			group.fields.push(path);
+			continue;
+		}
+		collection.nested.push({ path: nestedPath, fields: [path] });
+	}
+}
+
+function joinFieldPath(parent: string | undefined, segment: string): string {
+	return parent ? `${parent}.${segment}` : segment;
+}
+
+/**
+ * Declaration of the nested-query helper, emitted only when the projection has
+ * nested text to search. `score_mode: "max"` scores a parent document by its
+ * best-matching child rather than by a sum over children, so one strong hit
+ * ranks a parent the way a root-field hit would.
+ */
+function renderNestedTextHelper(textFields: TextFieldCollection): string {
+	if (textFields.nested.length === 0) return "";
+
+	return `
+function ${NESTED_TEXT_QUERY_HELPER}(path, fields, queryText) {
+	return { nested: { path, score_mode: "max", query: { multi_match: { query: queryText, fields, type: "best_fields" } } } };
+}
+`;
+}
+
+/**
+ * The `musts.push(...)` for the free-text clause. With no nested text fields
+ * this is the flat `multi_match` — byte-identical to what the emitter has
+ * always produced, so projections without nested `@searchable` are untouched.
+ * Otherwise each nested group contributes a `nested`-wrapped `multi_match` to
+ * a `bool.should` alongside the root-document clause, and
+ * `minimum_should_match: 1` keeps the clause a real constraint rather than a
+ * scoring hint.
+ */
+function renderTextQueryPush(textFields: TextFieldCollection): string {
+	const flatLiteral = JSON.stringify(textFields.flat);
+
+	if (textFields.nested.length === 0) {
+		return `		musts.push({
+			multi_match: {
+				query: queryText,
+				fields: ${flatLiteral},
+				type: "best_fields",
+			},
+		});`;
+	}
+
+	// A projection whose only searchable text lives in nested sub-models has
+	// no root-document fields to match, and `multi_match` with an empty
+	// `fields` falls back to querying every field — so omit the flat clause
+	// rather than emit one that matches on paths nobody marked @searchable.
+	const shoulds = textFields.flat.length
+		? [
+				`\t\t\t\t\t{ multi_match: { query: queryText, fields: ${flatLiteral}, type: "best_fields" } },`,
+			]
+		: [];
+
+	for (const group of textFields.nested) {
+		shoulds.push(
+			`\t\t\t\t\t${NESTED_TEXT_QUERY_HELPER}(${JSON.stringify(group.path)}, ${JSON.stringify(group.fields)}, queryText),`,
+		);
+	}
+
+	return `		musts.push({
+			bool: {
+				should: [
+${shoulds.join("\n")}
+				],
+				minimum_should_match: 1,
+			},
+		});`;
+}
+
 function hasTextType(field: ResolvedProjectionField): boolean {
 	const type = field.type;
 	if (type.kind === "Scalar") {
@@ -246,7 +402,7 @@ function hasTextType(field: ResolvedProjectionField): boolean {
  * into one when the projection fits under threshold.
  */
 function renderMonolithicResolver(
-	textFields: string[],
+	textFields: TextFieldCollection,
 	keywordFields: string[],
 	textSortFields: string[],
 	aggregations: AggregationEntry[],
@@ -254,7 +410,8 @@ function renderMonolithicResolver(
 	indexName: string,
 	options: ResolverOptions,
 ): string {
-	const textFieldsLiteral = JSON.stringify(textFields);
+	const textQueryPush = renderTextQueryPush(textFields);
+	const nestedTextHelper = renderNestedTextHelper(textFields);
 	const keywordFieldsLiteral = JSON.stringify(keywordFields);
 	const textSortFieldsLiteral = JSON.stringify(textSortFields);
 	const aggsAssignment = renderAggsAssignment(aggregations, "\t");
@@ -322,20 +479,14 @@ ${responseAggregationsPreamble}
 		},
 	};
 }
-${buildAggsFunction}
+${buildAggsFunction}${nestedTextHelper}
 function buildQuery(queryText, filter, searchFilter) {
 	const musts = [];
 	const filters = [];
 	const mustNots = [];
 
 	if (queryText) {
-		musts.push({
-			multi_match: {
-				query: queryText,
-				fields: ${textFieldsLiteral},
-				type: "best_fields",
-			},
-		});
+${textQueryPush}
 	}
 
 	const keywordFields = ${keywordFieldsLiteral};
@@ -609,14 +760,15 @@ ${responseAggregationsPreamble}
  * aggregation mapping) under the 32 KB per-file APPSYNC_JS cap (issue #105).
  */
 function renderPrepareFunction(
-	textFields: string[],
+	textFields: TextFieldCollection,
 	keywordFields: string[],
 	textSortFields: string[],
 	aggregations: AggregationEntry[],
 	searchFilterShape: SearchFilterShape | undefined,
 	options: ResolverOptions,
 ): string {
-	const textFieldsLiteral = JSON.stringify(textFields);
+	const textQueryPush = renderTextQueryPush(textFields);
+	const nestedTextHelper = renderNestedTextHelper(textFields);
 	const keywordFieldsLiteral = JSON.stringify(keywordFields);
 	const textSortFieldsLiteral = JSON.stringify(textSortFields);
 	const aggsAssignment = renderAggsAssignment(aggregations, "\t");
@@ -659,20 +811,14 @@ ${aggsAssignment}
 export function response(ctx) {
 	return ctx.result;
 }
-${buildAggsFunction}
+${buildAggsFunction}${nestedTextHelper}
 function buildQuery(queryText, filter, searchFilter) {
 	const musts = [];
 	const filters = [];
 	const mustNots = [];
 
 	if (queryText) {
-		musts.push({
-			multi_match: {
-				query: queryText,
-				fields: ${textFieldsLiteral},
-				type: "best_fields",
-			},
-		});
+${textQueryPush}
 	}
 
 	const keywordFields = ${keywordFieldsLiteral};

--- a/test/snapshots/opensearch-baseline/pet-search-doc-fn-prepare.js
+++ b/test/snapshots/opensearch-baseline/pet-search-doc-fn-prepare.js
@@ -70,6 +70,10 @@ function buildAggs(selectionSetList) {
 	return requested ? aggs : null;
 }
 
+function NQ(path, fields, queryText) {
+	return { nested: { path, score_mode: "max", query: { multi_match: { query: queryText, fields, type: "best_fields" } } } };
+}
+
 function buildQuery(queryText, filter, searchFilter) {
 	const musts = [];
 	const filters = [];
@@ -77,10 +81,12 @@ function buildQuery(queryText, filter, searchFilter) {
 
 	if (queryText) {
 		musts.push({
-			multi_match: {
-				query: queryText,
-				fields: ["id","name","breed","nickname"],
-				type: "best_fields",
+			bool: {
+				should: [
+					{ multi_match: { query: queryText, fields: ["id","name","breed","nickname"], type: "best_fields" } },
+					NQ("tags", ["tags.note"], queryText),
+				],
+				minimum_should_match: 1,
 			},
 		});
 	}


### PR DESCRIPTION
Closes #158.

`@searchable` on a sub-model's field was recorded in the projection and emitted into the index mapping, then dropped when the free-text field list was built. The field was searchable everywhere except in search. Downstream (stxcommodities/core-services#2679) this silently broke "find by reference" lookups on every projection modelling a child collection as `@nested`.

## Behavior

The resolver collected text fields with a flat pass over the projection's own `fields`, rejecting `nested` and `subProjection` outright. A sub-projection records its own `@searchable` fields in its own `fields` array, so that pass could never see them. The mapping emitter has always recursed; the resolver did not.

The collector now threads paths down the projection tree, the way `buildShapeRecursive` already does on the filter path. How a field is mapped decides where it lands:

- **`object` sub-projection**: same Lucene document, so the field joins the flat `multi_match` under its dotted path (`owner.fullName`).
- **`@nested` sub-projection**: separate hidden documents, unreachable by a bare `multi_match` on `tags.note`. Each `@nested` sub-model carrying searchable text contributes one `nested`-wrapped clause, combined under `bool.should` with `minimum_should_match: 1`. `score_mode: "max"` scores a parent by its best-matching child.

Paths are fully known at emit time, so the clause is a static literal — no runtime spec walk, and none of the APPSYNC_JS control-flow constraints apply.

`@searchable` is the opt-in; no new decorator. It was inert before, so no caller can be relying on today's behavior — but **this widens the `multi_match` of any existing projection with nested `@searchable` fields, which changes relevance scoring downstream even where it is strictly a fix.** Nested matches now rank against root-field matches.

A projection with no nested searchable text emits the flat `multi_match` byte-for-byte, and the helper is not emitted at all. Only `pet-search-doc-fn-prepare.js` moves in the baseline snapshot, and only in that clause.

## Resolver size

The nested clause is the one part of `buildQuery` that scales with sub-model count. Inlining the skeleton per group cost ~157 bytes each; factoring it into an `NQ` helper, as `ADH` already does for histogram entries, cuts that to ~56 plus 166 bytes once and pushes the width at which a projection would hit the 32 KB cap further out. Projections without nested searchable text pay nothing.

| Projection | Before | After |
| --- | --- | --- |
| petstore fixture (`pet-search-doc-fn-prepare.js`, 1 nested group) | 13,728 | 13,994 |
| counterparty shape (7 nested sub-models, 2 text fields each) | — | 24,617 (headroom 8,151) |
| synthetic wide guard (14 sub-models, no nested text) | 32,452 | 32,452 (unchanged) |

The 14-sub-model guard is all `@keyword`/date sub-models, so it pays nothing and stays at its documented 316-byte headroom. A projection that wide *and* with searchable text in every sub-model would exceed the cap: at that width the nested clause adds 984 bytes against 316 bytes of headroom, and the failure surfaces as a deploy-time `BadRequestException`, not a red CI (#101, #105). Real shapes are far from it; the counterparty shape stays monolithic.

## Tests

`src/emit-graphql-resolver.test.ts:293-308` pinned the defect, asserting `["name"]` for a projection containing nested/sub-projection fields. Inverted: its sub-projections now carry real fields and it asserts the wrapped clause. The tests execute the generated `buildQuery` and assert the query object, rather than matching source text.

Covering each acceptance point: the nested wrapper with `minimum_should_match: 1`; object sub-projections resolving via dotted paths; `@analyzer` on a nested field honoured (queries the analyzed path, not `.keyword`); grouping by innermost nested ancestor; `@searchAs` projected names; byte-for-byte flat output when nothing nested is searchable; and a width guard that the nested clause keeps the counterparty shape under the cap.