### PR TITLE
fix(graphql): emit object types for model fields in SDL

### DIFF
--- a/src/emit-graphql-sdl.test.ts
+++ b/src/emit-graphql-sdl.test.ts
@@ -280,6 +280,66 @@ describe("emitGraphQLSdl", () => {
 		assert.ok(result.content.includes("tags: [TagSearchDoc!]!"));
 	});
 
+	it("emits object type and a matching `type <Model>` block for a model-array field not redeclared as a projection (issue #160)", () => {
+		// A `@searchable` array-of-model field with no sub-projection (not
+		// redeclared, not on a `@searchInfer` path). The doc type and mapping
+		// describe it as a nested object; before the fix the SDL emitted
+		// `[String!]!`, contradicting both. Assert the object shape so the
+		// pre-fix fallback fails this test.
+		const typeProp = {
+			name: "type",
+			type: { kind: "Scalar", name: "string" },
+			optional: false,
+		};
+		const grantedByProp = {
+			name: "grantedBy",
+			type: { kind: "Scalar", name: "string" },
+			optional: false,
+		};
+		const approvalModel = {
+			kind: "Model",
+			name: "Approval",
+			properties: new Map([
+				["type", typeProp],
+				["grantedBy", grantedByProp],
+			]),
+		};
+		const searchable = new Set([typeProp, grantedByProp]);
+		const program = {
+			stateSet: () => searchable,
+			stateMap: () => ({ get: () => undefined, has: () => false }),
+		} as never;
+
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "approvals",
+					type: {
+						kind: "Model",
+						name: "Array",
+						indexer: { value: approvalModel },
+					} as unknown as Type,
+				}),
+			],
+		});
+
+		const result = emitGraphQLSdl(program, projection, defaultOptions);
+		assert.ok(
+			result.content.includes("approvals: [Approval!]!"),
+			"response field references the model by name, not String",
+		);
+		assert.ok(
+			!result.content.includes("approvals: [String!]!"),
+			"the String fallback must not appear",
+		);
+		assert.ok(
+			result.content.match(/^type Approval \{/m),
+			"emits `type Approval { ... }` block",
+		);
+		assert.ok(result.content.includes("type: String!"));
+		assert.ok(result.content.includes("grantedBy: String!"));
+	});
+
 	it("emits `type <Name>` block for nested struct virtual sub-projections referenced from response shape", () => {
 		// Issue: when a projection references a nested struct (e.g. Address)
 		// via @searchInfer auto-recursion, only `input AddressSearchFilter`

--- a/src/emit-graphql-sdl.ts
+++ b/src/emit-graphql-sdl.ts
@@ -1,4 +1,10 @@
-import { type Model, NoTarget, type Program } from "@typespec/compiler";
+import {
+	type Model,
+	type ModelProperty,
+	NoTarget,
+	type Program,
+	type Type,
+} from "@typespec/compiler";
 import {
 	type AggregationEntry,
 	aggregationsTypeName,
@@ -170,12 +176,57 @@ function renderObjectType(
 		.filter((field) => field.searchable)
 		.map((field) => {
 			const gqlName = field.projectedName ?? field.name;
-			const gqlType = toGraphQLType(program, field.type, field);
+			const gqlType = responseFieldType(program, field);
 			const nullable = field.optional ? "" : "!";
 			return `  ${gqlName}: ${gqlType}${nullable}`;
 		});
 
 	return `type ${typeName}${directiveSuffix(directives)} {\n${fieldLines.join("\n")}\n}`;
+}
+
+/**
+ * GraphQL type reference for a response field. A field redeclared as a
+ * projection type or reached via `@searchInfer` recursion carries a
+ * `subProjection`, and `toGraphQLType` renders it. A plain model-typed field
+ * (or array-of-model) that is not redeclared has no `subProjection`; the doc
+ * type and the index mapping both describe it as a nested object, so the SDL
+ * must too — reference it by the model's own name and emit a matching
+ * `type <Model> { ... }` block (see `collectNestedStructTypes`). Without this
+ * the field falls back to `String`, contradicting the other two artifacts
+ * (issue #160).
+ */
+function responseFieldType(
+	program: Program,
+	field: ResolvedProjection["fields"][number],
+): string {
+	if (!field.subProjection) {
+		const struct = structModelOf(field.type);
+		if (struct) {
+			return isArrayType(field.type) ? `[${struct.name}!]` : struct.name;
+		}
+	}
+	return toGraphQLType(program, field.type, field);
+}
+
+/**
+ * The named struct model a field's type resolves to, or undefined for
+ * scalars, arrays of scalars, records, unions, and enums. Unwraps a single
+ * level of array so `Approval[]` and `Approval` both resolve to `Approval`.
+ */
+function structModelOf(type: Type): Model | undefined {
+	if (type.kind !== "Model") return undefined;
+	if (type.name === "Array" && type.indexer?.value) {
+		return structModelOf(type.indexer.value);
+	}
+	if (type.name === "Record") return undefined;
+	if (type.name && type.properties.size > 0) return type;
+	return undefined;
+}
+
+function isArrayType(type: Type): boolean {
+	return (
+		type.kind === "Model" && type.name === "Array" && !!type.indexer?.value
+	);
 }
 
 /**
@@ -209,7 +260,17 @@ function collectNestedStructTypes(
 ): void {
 	for (const field of projection.fields) {
 		if (!field.searchable) continue;
-		if (!field.subProjection) continue;
+		if (!field.subProjection) {
+			// A model-typed field with no sub-projection (not redeclared, not on a
+			// `@searchInfer` path) still describes a nested object in the doc type
+			// and mapping. Emit a `type <Model> { ... }` block for it so the SDL
+			// agrees (issue #160).
+			const struct = structModelOf(field.type);
+			if (struct) {
+				collectRawStructType(program, struct, out, seen, defaults);
+			}
+			continue;
+		}
 		if (!isVirtualSubProjection(field.subProjection)) continue;
 		const sub = field.subProjection;
 		const name = sub.projectionModel.name;
@@ -227,6 +288,52 @@ function collectNestedStructTypes(
 		out.push(renderVirtualStructType(program, sub, subDirectives));
 		collectNestedStructTypes(program, sub, out, seen, defaults);
 	}
+}
+
+/**
+ * Emit a `type <Model> { ... }` block for a plain struct model referenced from
+ * a response field, recursing into its own struct-typed properties. Mirrors the
+ * doc-type and mapping emitters: fields are the model's `@searchable`
+ * properties, projected names honored, in declaration order.
+ */
+function collectRawStructType(
+	program: Program,
+	model: Model,
+	out: string[],
+	seen: Set<string>,
+	defaults: string[] | undefined,
+): void {
+	if (seen.has(model.name)) return;
+	seen.add(model.name);
+
+	const children: Model[] = [];
+	const fieldLines: string[] = [];
+	for (const prop of model.properties.values()) {
+		if (!isSearchable(program, prop)) continue;
+		const gqlName = getSearchAs(program, prop) ?? prop.name;
+		const gqlType = rawPropType(program, prop);
+		const nullable = prop.optional ? "" : "!";
+		fieldLines.push(`  ${gqlName}: ${gqlType}${nullable}`);
+		const child = structModelOf(prop.type);
+		if (child) children.push(child);
+	}
+
+	const directives = resolveDirectives(program, model, defaults);
+	out.push(
+		`type ${model.name}${directiveSuffix(directives)} {\n${fieldLines.join("\n")}\n}`,
+	);
+
+	for (const child of children) {
+		collectRawStructType(program, child, out, seen, defaults);
+	}
+}
+
+function rawPropType(program: Program, prop: ModelProperty): string {
+	const struct = structModelOf(prop.type);
+	if (struct) {
+		return isArrayType(prop.type) ? `[${struct.name}!]` : struct.name;
+	}
+	return toGraphQLType(program, prop.type);
 }
 
 function isVirtualSubProjection(sub: ResolvedProjection): boolean {

--- a/test/snapshots/opensearch-baseline/pet-public-search-doc.graphql
+++ b/test/snapshots/opensearch-baseline/pet-public-search-doc.graphql
@@ -5,16 +5,35 @@ type PetPublicSearchDoc {
   breed: String
   birthDate: String!
   createdAt: String!
-  tags: [String!]!
-  owner: String!
+  tags: [Tag!]!
+  owner: Owner!
   aliases: [String!]!
   nickname: String
   rank: Int!
   stock: Int!
   score: Float!
   active: Boolean!
-  approvals: [String!]!
-  bankAccountApprovals: [String!]!
+  approvals: [Approval!]!
+  bankAccountApprovals: [BankAccountApproval!]!
+}
+
+type Tag {
+  name: String!
+  note: String
+}
+
+type Owner {
+  name: String!
+}
+
+type Approval {
+  type: String!
+  grantedBy: String!
+}
+
+type BankAccountApproval {
+  accountId: String!
+  approvedBy: String!
 }
 
 input PetPublicSearchDocFilter {

--- a/test/snapshots/opensearch-baseline/pet-search-doc.graphql
+++ b/test/snapshots/opensearch-baseline/pet-search-doc.graphql
@@ -6,7 +6,7 @@ type PetSearchDoc {
   birthDate: String!
   createdAt: String!
   tags: [TagSearchDoc!]!
-  owner: String!
+  owner: Owner!
   aliases: [String!]!
   nickname: String
   rank: Int!
@@ -15,6 +15,10 @@ type PetSearchDoc {
   active: Boolean!
   approvals: [ApprovalSearchDoc!]!
   bankAccountApprovals: [BankAccountApprovalSearchDoc!]!
+}
+
+type Owner {
+  name: String!
 }
 
 input PetSearchDocFilter {


### PR DESCRIPTION
A `@searchable` model-typed field that is not redeclared as a projection type emitted `String` (or `[String!]!` for an array) in the GraphQL SDL, while the doc type and the index mapping both describe the field as a nested object. The SDL is the contract client codegen reads, so consumers got a `string` type for data OpenSearch returns as an object.

The SDL now resolves such a field to the model's own name and emits a matching `type <Model> { ... }` block, recursing into nested struct properties the same way the doc-type and mapping emitters do (searchable properties, projected names, declaration order). All three artifacts now agree.

## Before / after

`pet-public-search-doc.graphql`:

```diff
-  tags: [String!]!
-  owner: String!
+  tags: [Tag!]!
+  owner: Owner!
-  approvals: [String!]!
-  bankAccountApprovals: [String!]!
+  approvals: [Approval!]!
+  bankAccountApprovals: [BankAccountApproval!]!
```

with the referenced `type Tag`, `type Owner`, `type Approval`, and `type BankAccountApproval` blocks now emitted in the file. `pet-search-doc.graphql` gets the same treatment for its `owner` field.

Fields redeclared as a `SearchProjection` type or reached through `@searchInfer` recursion already carried a sub-projection and were unaffected; scalar and array-of-scalar fields are unchanged.

Closes #160
