### PR TITLE
fix(graphql): name nested-only projections in the resolver manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,11 +473,16 @@ Maps each projection to its resolver file, SDL file, query field name, and index
       "resolverFile": "pet-search-doc-resolver.js",
       "sdlFile": "pet-search-doc.graphql"
     }
+  ],
+  "nestedTypes": [
+    { "projection": "TagSearchDoc", "sdlFile": "tag-search-doc.graphql" }
   ]
 }
 ```
 
 The consuming CDK construct can read this manifest to wire resolvers without hardcoded knowledge.
+
+`nestedTypes` lists the nested-only projections — those without `@searchProjection` or `@indexName`. They have no Query field, resolver, or index, so they carry no `resolvers[]` entry, but top-level fragments reference their types by name. Assemble a schema from `resolvers[].sdlFile` **plus** `nestedTypes[].sdlFile`; using `resolvers[]` alone leaves those references undefined. The key is omitted when a spec has no nested-only projections.
 
 ### Aggregations (`@aggregatable`)
 

--- a/src/emitter.test.ts
+++ b/src/emitter.test.ts
@@ -442,6 +442,93 @@ describe("generateGraphQLManifest queryFieldDirectives (issue #121)", () => {
 	});
 });
 
+describe("generateNestedTypeEntries (issue #164)", () => {
+	const petSearchDoc = {
+		projectionModel: { name: "PetSearchDoc" },
+		sourceModel: { name: "Pet" },
+		indexName: "pets_v1",
+		fields: [],
+	} as unknown as ResolvedProjection;
+
+	const petResolverFile = {
+		queryFieldName: "searchPet",
+		mode: "monolithic",
+		fileName: "pet-search-doc-resolver.js",
+		content: "",
+		functions: [],
+	};
+
+	const tagSearchDoc = {
+		projectionModel: { name: "TagSearchDoc" },
+		sourceModel: { name: "Tag" },
+		indexName: undefined,
+		fields: [],
+	} as unknown as ResolvedProjection;
+
+	it("names each nested-only projection and its SDL fragment", () => {
+		assert.deepEqual(__test.generateNestedTypeEntries([tagSearchDoc]), [
+			{ projection: "TagSearchDoc", sdlFile: "tag-search-doc.graphql" },
+		]);
+	});
+
+	it("lists the nested type alongside the parent's resolver entry", () => {
+		// The repro: a parent with @indexName referencing a sub-projection
+		// without one. Assembling from resolvers[].sdlFile alone leaves
+		// `tags: [TagSearchDoc!]!` dangling — the fragment is emitted and
+		// exported, only the manifest never named it.
+		const manifest = JSON.parse(
+			__test.generateGraphQLManifest(
+				[petSearchDoc],
+				[petResolverFile],
+				undefined,
+				undefined,
+				__test.generateNestedTypeEntries([tagSearchDoc]),
+			),
+		);
+
+		assert.equal(manifest.resolvers.length, 1);
+		assert.equal(manifest.resolvers[0].projection, "PetSearchDoc");
+		assert.deepEqual(manifest.nestedTypes, [
+			{ projection: "TagSearchDoc", sdlFile: "tag-search-doc.graphql" },
+		]);
+	});
+
+	it("keeps nested types out of resolvers[] — they have no Query field or index", () => {
+		const manifest = JSON.parse(
+			__test.generateGraphQLManifest(
+				[petSearchDoc],
+				[petResolverFile],
+				undefined,
+				undefined,
+				__test.generateNestedTypeEntries([tagSearchDoc]),
+			),
+		);
+
+		assert.ok(
+			!manifest.resolvers.some(
+				(entry: { projection?: string }) => entry.projection === "TagSearchDoc",
+			),
+		);
+	});
+
+	it("omits nestedTypes entirely when no projection is nested-only", () => {
+		const withUndefined = __test.generateGraphQLManifest(
+			[petSearchDoc],
+			[petResolverFile],
+		);
+		const withEmpty = __test.generateGraphQLManifest(
+			[petSearchDoc],
+			[petResolverFile],
+			undefined,
+			undefined,
+			__test.generateNestedTypeEntries([]),
+		);
+
+		assert.equal(withUndefined, withEmpty);
+		assert.ok(!("nestedTypes" in JSON.parse(withEmpty)));
+	});
+});
+
 describe("generateRestManifestEntries (issue #134)", () => {
 	const getPet = {
 		fieldName: "getPet",

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -198,7 +198,9 @@ export async function $onEmit(
 
 		// Nested-only: stripped SDL fragment so parent projections that
 		// reference the type by name get a definition in the assembled
-		// schema. No resolver, no manifest entry — issue #123.
+		// schema. No resolver, no `resolvers[]` entry — issue #123. The
+		// fragment is named in the manifest's `nestedTypes` (issue #164) so a
+		// consumer assembling a schema from the manifest can find it.
 		for (const projection of nestedOnly) {
 			const sdlFile = emitGraphQLSdl(context.program, projection, {
 				...pageOptions,
@@ -270,6 +272,7 @@ export async function $onEmit(
 				resourcePathPrefix,
 				restOptions?.sdlFileName,
 			),
+			generateNestedTypeEntries(nestedOnly),
 		);
 		await emitFile(context.program, {
 			path: resolvePath(context.emitterOutputDir, "graphql-resolvers.json"),
@@ -454,11 +457,33 @@ interface RestManifestEntry {
 	sdlFile: string;
 }
 
+interface NestedTypeManifestEntry {
+	projection: string;
+	sdlFile: string;
+}
+
+/**
+ * Nested-type manifest entries (issue #164). A nested-only projection has no
+ * Query field, resolver, or index, so it has nothing to say in `resolvers[]`
+ * — but its SDL fragment defines a type that top-level fragments reference by
+ * name. Without it in the manifest, a schema assembled from
+ * `resolvers[].sdlFile` alone dangles on that reference.
+ */
+function generateNestedTypeEntries(
+	nestedOnly: ResolvedProjection[],
+): NestedTypeManifestEntry[] {
+	return nestedOnly.map((projection) => ({
+		projection: projection.projectionModel.name,
+		sdlFile: `${toKebabCase(projection.projectionModel.name)}.graphql`,
+	}));
+}
+
 function generateGraphQLManifest(
 	projections: TopLevelProjection[],
 	resolverFiles: EmittedResolverFile[],
 	queryFieldDirectives?: string[][],
 	restEntries?: RestManifestEntry[],
+	nestedTypes?: NestedTypeManifestEntry[],
 ): string {
 	const resolvers = projections.map((projection, i) => {
 		const resolver = resolverFiles[i];
@@ -492,7 +517,16 @@ function generateGraphQLManifest(
 	// present the manifest is byte-identical to the OpenSearch-only emit.
 	const allResolvers = [...resolvers, ...(restEntries ?? [])];
 
-	return `${JSON.stringify({ resolvers: allResolvers }, null, 2)}\n`;
+	// `nestedTypes` (issue #164) is omitted when no projection is nested-only,
+	// so a spec without one emits a byte-identical manifest.
+	return `${JSON.stringify(
+		{
+			resolvers: allResolvers,
+			...(nestedTypes && nestedTypes.length > 0 ? { nestedTypes } : {}),
+		},
+		null,
+		2,
+	)}\n`;
 }
 
 /**
@@ -526,6 +560,7 @@ export const __test = {
 	generateTsConfig,
 	generateGraphQLManifest,
 	generateRestManifestEntries,
+	generateNestedTypeEntries,
 	generateGraphQLEntryPoint,
 	validateResourcePathPrefix,
 };

--- a/test/example.js
+++ b/test/example.js
@@ -372,6 +372,82 @@ test("@searchProjection without @indexName is nested-only (issue #157)", async (
 	);
 });
 
+test("nested-only projections are discoverable through manifest.nestedTypes (issue #164)", async () => {
+	// PetSearchDoc's SDL references ApprovalSearchDoc and
+	// BankAccountApprovalSearchDoc by name. Both fragments are emitted and
+	// exported, but a consumer reading only `resolvers[].sdlFile` never
+	// learns of them and the assembled schema fails with `Unknown type`.
+	const manifest = JSON.parse(
+		await readFile(`${OUT_DIR}/graphql-resolvers.json`, "utf8"),
+	);
+
+	assert.deepEqual(
+		manifest.nestedTypes,
+		[
+			{
+				projection: "ApprovalSearchDoc",
+				sdlFile: "approval-search-doc.graphql",
+			},
+			{
+				projection: "BankAccountApprovalSearchDoc",
+				sdlFile: "bank-account-approval-search-doc.graphql",
+			},
+		],
+		"every nested-only projection must be named with its SDL fragment",
+	);
+
+	// The listed fragments carry the type definitions the parent dangles on.
+	for (const nested of manifest.nestedTypes) {
+		const sdl = await readFile(`${OUT_DIR}/${nested.sdlFile}`, "utf8");
+		assert.ok(
+			sdl.includes(`type ${nested.projection} {`),
+			`${nested.sdlFile} must define type ${nested.projection}`,
+		);
+	}
+
+	// Concatenating resolvers[].sdlFile + nestedTypes[].sdlFile must leave no
+	// referenced type undefined — that concatenation is the manifest's whole
+	// job, so assert it end-to-end rather than per-entry.
+	const sdlFiles = [
+		...manifest.resolvers.map((r) => r.sdlFile),
+		...manifest.nestedTypes.map((n) => n.sdlFile),
+	];
+	const assembled = (
+		await Promise.all(
+			sdlFiles.map((file) => readFile(`${OUT_DIR}/${file}`, "utf8")),
+		)
+	).join("\n");
+
+	const defined = new Set(
+		[...assembled.matchAll(/^(?:type|input|enum|interface)\s+(\w+)/gm)].map(
+			(match) => match[1],
+		),
+	);
+	const referenced = new Set(
+		[...assembled.matchAll(/^\s+\w+(?:\([^)]*\))?:\s*\[?(\w+)/gm)].map(
+			(match) => match[1],
+		),
+	);
+	const scalars = new Set([
+		"String",
+		"Int",
+		"Float",
+		"Boolean",
+		"ID",
+		"AWSJSON",
+	]);
+
+	for (const typeName of referenced) {
+		if (scalars.has(typeName) || defined.has(typeName)) continue;
+		assert.fail(`assembled schema dangles on unknown type "${typeName}"`);
+	}
+
+	// Nested types stay out of resolvers[] — no Query field, no index.
+	const projections = manifest.resolvers.map((r) => r.projection);
+	assert.ok(!projections.includes("ApprovalSearchDoc"));
+	assert.ok(!projections.includes("BankAccountApprovalSearchDoc"));
+});
+
 test("@indexName-backed projections keep their top-level wiring (issue #157)", async () => {
 	const manifest = JSON.parse(
 		await readFile(`${OUT_DIR}/graphql-resolvers.json`, "utf8"),

--- a/test/snapshots/opensearch-baseline/graphql-resolvers.json
+++ b/test/snapshots/opensearch-baseline/graphql-resolvers.json
@@ -84,5 +84,15 @@
         }
       ]
     }
+  ],
+  "nestedTypes": [
+    {
+      "projection": "ApprovalSearchDoc",
+      "sdlFile": "approval-search-doc.graphql"
+    },
+    {
+      "projection": "BankAccountApprovalSearchDoc",
+      "sdlFile": "bank-account-approval-search-doc.graphql"
+    }
   ]
 }


### PR DESCRIPTION
Fixes #164.

A `@searchProjection` model without `@indexName` is emitted as a nested type only. Its SDL fragment is written to disk and exported from the generated package, but `graphql-resolvers.json` listed top-level projections only. A consumer assembling a schema from the manifest had no way to discover the fragment, so every type a parent referenced by name came out undefined — `Unknown type "TagSearchDoc"`.

The manifest is the index of what was emitted. It now says so completely.

## Shape

`nestedTypes` sits beside `resolvers`, naming each nested-only projection and the fragment that defines it:

```json
{
  "resolvers": [ ... ],
  "nestedTypes": [
    { "projection": "TagSearchDoc", "sdlFile": "tag-search-doc.graphql" }
  ]
}
```

Assemble from `resolvers[].sdlFile` plus `nestedTypes[].sdlFile`.

Nested-only projections stay out of `resolvers[]`: they have no Query field, resolver, or backing index, and an entry there would reinstate the resolver-against-a-nonexistent-index failure that #123 and #157 removed.

## Compatibility

Additive. `resolvers[]` entries are byte-identical, verified against the committed baseline. The key is omitted entirely when a spec has no nested-only projection, so those manifests do not change at all — the same convention `queryFieldDirectives` already follows.

The one snapshot change is `test/snapshots/opensearch-baseline/graphql-resolvers.json` gaining the new key; the fixture already contains the repro. Every other baseline file is unchanged.

## Tests

- End-to-end over the real emit of `test/main.tsp`: the manifest names both nested-only projections, each listed fragment defines its type, and concatenating `resolvers[].sdlFile` + `nestedTypes[].sdlFile` leaves no referenced type undefined. Confirmed failing without the emitter change.
- Unit coverage for entry generation, exclusion from `resolvers[]`, and omission when empty.