### PR TITLE
fix: make free-text search immune to index-mapping drift

### DIFF
--- a/src/emit-graphql-resolver.test.ts
+++ b/src/emit-graphql-resolver.test.ts
@@ -340,6 +340,7 @@ describe("emitGraphQLResolver", () => {
 										query: "rex",
 										fields: ["name", "owner.fullName"],
 										type: "best_fields",
+										lenient: true,
 									},
 								},
 								{
@@ -351,6 +352,7 @@ describe("emitGraphQLResolver", () => {
 												query: "rex",
 												fields: ["tags.label"],
 												type: "best_fields",
+												lenient: true,
 											},
 										},
 									},
@@ -398,6 +400,7 @@ describe("emitGraphQLResolver", () => {
 				query: queryText,
 				fields: ["name","description"],
 				type: "best_fields",
+				lenient: true,
 			},
 		});`),
 		);
@@ -437,6 +440,7 @@ describe("emitGraphQLResolver", () => {
 				query: "ABC",
 				fields: ["references.value"],
 				type: "best_fields",
+				lenient: true,
 			},
 		});
 	});
@@ -493,6 +497,7 @@ describe("emitGraphQLResolver", () => {
 												query: "rex",
 												fields: ["references.value", "references.issuer.code"],
 												type: "best_fields",
+												lenient: true,
 											},
 										},
 									},
@@ -506,6 +511,7 @@ describe("emitGraphQLResolver", () => {
 												query: "rex",
 												fields: ["tags.label"],
 												type: "best_fields",
+												lenient: true,
 											},
 										},
 									},

--- a/src/emit-graphql-resolver.ts
+++ b/src/emit-graphql-resolver.ts
@@ -328,7 +328,7 @@ function renderNestedTextHelper(textFields: TextFieldCollection): string {
 
 	return `
 function ${NESTED_TEXT_QUERY_HELPER}(path, fields, queryText) {
-	return { nested: { path, score_mode: "max", query: { multi_match: { query: queryText, fields, type: "best_fields" } } } };
+	return { nested: { path, score_mode: "max", query: { multi_match: { query: queryText, fields, type: "best_fields", lenient: true } } } };
 }
 `;
 }
@@ -378,6 +378,7 @@ function renderTextQueryPush(textFields: TextFieldCollection): string {
 				query: queryText,
 				fields: ${flatLiteral},
 				type: "best_fields",
+				lenient: true,
 			},
 		});`;
 	}
@@ -388,7 +389,7 @@ function renderTextQueryPush(textFields: TextFieldCollection): string {
 	// rather than emit one that matches on paths nobody marked @searchable.
 	return `		const shoulds = [];
 		if (TEXT_FIELDS.length > 0) {
-			shoulds.push({ multi_match: { query: queryText, fields: TEXT_FIELDS, type: "best_fields" } });
+			shoulds.push({ multi_match: { query: queryText, fields: TEXT_FIELDS, type: "best_fields", lenient: true } });
 		}
 		for (const group of NESTED_TEXT_GROUPS) {
 			shoulds.push(${NESTED_TEXT_QUERY_HELPER}(group[0], group[1], queryText));

--- a/src/emit-mapping.test.ts
+++ b/src/emit-mapping.test.ts
@@ -57,6 +57,7 @@ describe("mapping emitter", () => {
 		assert.equal(emitted.fileName, "product-search-doc-search-mapping.json");
 
 		const parsed = JSON.parse(emitted.content);
+		assert.equal(parsed.mappings.date_detection, false);
 		assert.equal(parsed.mappings.properties.title.type, "keyword");
 		assert.equal(parsed.mappings.properties.id.type, "text");
 		assert.equal(parsed.mappings.properties.id.analyzer, "edge_ngram");
@@ -75,6 +76,29 @@ describe("mapping emitter", () => {
 		assert.deepEqual(Object.keys(parsed.mappings.properties.tags.properties), [
 			"name",
 		]);
+	});
+
+	it("disables date_detection so string fields are never dynamically mapped as date", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Product {
+        @searchable name: string;
+      }
+
+      model ProductSearchDoc is SearchProjection<Product> {}
+    `);
+		assert.equal(diagnostics.length, 0);
+
+		const projection = runner.program
+			.getGlobalNamespaceType()
+			.models.get("ProductSearchDoc");
+		assert.ok(projection);
+
+		const resolved = resolveProjectionModel(runner.program, projection);
+		assert.ok(resolved);
+		const emitted = emitMapping(runner.program, resolved);
+		const parsed = JSON.parse(emitted.content);
+		assert.equal(parsed.mappings.date_detection, false);
 	});
 
 	it("maps arrays of scalars as text (no @nested)", async () => {

--- a/src/emit-mapping.ts
+++ b/src/emit-mapping.ts
@@ -33,7 +33,9 @@ export function emitMapping(
 		defaultIgnoreAbove,
 	);
 
-	const mappings: Record<string, unknown> = { mappings: { properties } };
+	const mappings: Record<string, unknown> = {
+		mappings: { date_detection: false, properties },
+	};
 
 	if (projection.indexSettings) {
 		(mappings as Record<string, unknown>).settings = projection.indexSettings;

--- a/test/snapshots/opensearch-baseline/person-search-doc-fn-prepare.js
+++ b/test/snapshots/opensearch-baseline/person-search-doc-fn-prepare.js
@@ -81,6 +81,7 @@ function buildQuery(queryText, filter, searchFilter) {
 				query: queryText,
 				fields: [],
 				type: "best_fields",
+				lenient: true,
 			},
 		});
 	}

--- a/test/snapshots/opensearch-baseline/person-search-doc-search-mapping.json
+++ b/test/snapshots/opensearch-baseline/person-search-doc-search-mapping.json
@@ -1,5 +1,6 @@
 {
   "mappings": {
+    "date_detection": false,
     "properties": {
       "id": {
         "type": "keyword"

--- a/test/snapshots/opensearch-baseline/pet-public-search-doc-fn-prepare.js
+++ b/test/snapshots/opensearch-baseline/pet-public-search-doc-fn-prepare.js
@@ -81,6 +81,7 @@ function buildQuery(queryText, filter, searchFilter) {
 				query: queryText,
 				fields: ["id","breed","nickname"],
 				type: "best_fields",
+				lenient: true,
 			},
 		});
 	}

--- a/test/snapshots/opensearch-baseline/pet-public-search-doc-search-mapping.json
+++ b/test/snapshots/opensearch-baseline/pet-public-search-doc-search-mapping.json
@@ -1,5 +1,6 @@
 {
   "mappings": {
+    "date_detection": false,
     "properties": {
       "id": {
         "type": "text",

--- a/test/snapshots/opensearch-baseline/pet-search-doc-fn-prepare.js
+++ b/test/snapshots/opensearch-baseline/pet-search-doc-fn-prepare.js
@@ -74,7 +74,7 @@ const TEXT_FIELDS = ["id","name","breed","nickname"];
 const NESTED_TEXT_GROUPS = [["tags",["tags.note"]]];
 
 function NQ(path, fields, queryText) {
-	return { nested: { path, score_mode: "max", query: { multi_match: { query: queryText, fields, type: "best_fields" } } } };
+	return { nested: { path, score_mode: "max", query: { multi_match: { query: queryText, fields, type: "best_fields", lenient: true } } } };
 }
 
 function buildQuery(queryText, filter, searchFilter) {
@@ -85,7 +85,7 @@ function buildQuery(queryText, filter, searchFilter) {
 	if (queryText) {
 		const shoulds = [];
 		if (TEXT_FIELDS.length > 0) {
-			shoulds.push({ multi_match: { query: queryText, fields: TEXT_FIELDS, type: "best_fields" } });
+			shoulds.push({ multi_match: { query: queryText, fields: TEXT_FIELDS, type: "best_fields", lenient: true } });
 		}
 		for (const group of NESTED_TEXT_GROUPS) {
 			shoulds.push(NQ(group[0], group[1], queryText));

--- a/test/snapshots/opensearch-baseline/pet-search-doc-search-mapping.json
+++ b/test/snapshots/opensearch-baseline/pet-search-doc-search-mapping.json
@@ -1,5 +1,6 @@
 {
   "mappings": {
+    "date_detection": false,
     "properties": {
       "id": {
         "type": "text",

--- a/test/snapshots/opensearch-baseline/tag-search-doc-fn-prepare.js
+++ b/test/snapshots/opensearch-baseline/tag-search-doc-fn-prepare.js
@@ -81,6 +81,7 @@ function buildQuery(queryText, filter, searchFilter) {
 				query: queryText,
 				fields: ["note"],
 				type: "best_fields",
+				lenient: true,
 			},
 		});
 	}

--- a/test/snapshots/opensearch-baseline/tag-search-doc-search-mapping.json
+++ b/test/snapshots/opensearch-baseline/tag-search-doc-search-mapping.json
@@ -1,5 +1,6 @@
 {
   "mappings": {
+    "date_detection": false,
     "properties": {
       "name": {
         "type": "keyword"


### PR DESCRIPTION
Free-text search fails with an HTTP 400 (`parse_exception`) when a live OpenSearch index has dynamically mapped one of the searched fields as `date` — date-detection on an ISO-looking string value. A query as innocuous as "hj" then errors instead of returning results (observed in prod, stxcommodities/core-services#2879).

Two independent defenses:

1. **`lenient: true` on every generated free-text `multi_match`** (top-level and nested). A type mismatch between the query text and a field's mapping becomes a silent 0-hit skip for that field rather than a whole-query parse failure. Immunizes existing indexes that already carry a drifted mapping.

2. **`date_detection: false` in every generated index mapping.** New string fields can never be dynamically mapped as `date`, removing the cause at the source for indexes created from the generated mappings going forward.

Regression snapshots re-captured; unit tests assert both the `lenient` flag on the emitted queries and `date_detection: false` on the emitted mappings.

Refs stxcommodities/core-services#2879


Fixes kattebak/typespec-opensearch-emitter#170