### PR TITLE
fix(graphql): map int64/uint64/safeint response context to Float (OF-206)

### DIFF
--- a/src/emit-graphql-sdl.test.ts
+++ b/src/emit-graphql-sdl.test.ts
@@ -929,9 +929,10 @@ describe("emitGraphQLSdl SearchFilter input", () => {
 		assert.ok(result.content.includes("updatedAtGte: String"));
 		assert.ok(!result.content.includes("createdAtGte: Int"));
 		assert.ok(!result.content.includes("updatedAtGte: Int"));
-		// Response type for int64 fields is unchanged (still Int) — out of scope
-		// for this fix; only filter inputs overflow at GraphQL parse time.
-		assert.ok(result.content.match(/createdAt: Int(?!\w)/));
+		// Response type for int64 fields maps to Float: AppSync rejects values
+		// > 2^31-1 during response coercion, nulling the whole query response.
+		assert.ok(result.content.match(/createdAt: Float(?!\w)/));
+		assert.ok(!result.content.match(/createdAt: Int(?!\w)/));
 	});
 
 	it("preserves Int for int32 range filter inputs (only int64 / uint64 are remapped)", () => {

--- a/src/graphql-types.test.ts
+++ b/src/graphql-types.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { Program, Scalar, Type } from "@typespec/compiler";
+import { type GraphQLEmitContext, toGraphQLType } from "./graphql-types.js";
+
+const dummyProgram = {} as unknown as Program;
+
+function scalar(name: string): Type {
+	return { kind: "Scalar", name } as unknown as Type;
+}
+
+function map(name: string, context: GraphQLEmitContext): string {
+	return toGraphQLType(dummyProgram, scalar(name), undefined, context);
+}
+
+describe("scalarToGraphQL 64-bit integer mapping", () => {
+	it("maps int64/uint64 response to Float (avoids Int32 overflow at AppSync response coercion)", () => {
+		assert.equal(map("int64", "response"), "Float");
+		assert.equal(map("uint64", "response"), "Float");
+	});
+
+	it("maps int64/uint64 rest to Float", () => {
+		assert.equal(map("int64", "rest"), "Float");
+		assert.equal(map("uint64", "rest"), "Float");
+	});
+
+	it("maps int64/uint64 filter to String (64-bit values can exceed 2^53)", () => {
+		assert.equal(map("int64", "filter"), "String");
+		assert.equal(map("uint64", "filter"), "String");
+	});
+
+	it("maps safeint response and rest to Float", () => {
+		assert.equal(map("safeint", "response"), "Float");
+		assert.equal(map("safeint", "rest"), "Float");
+	});
+
+	it("keeps int32 as Int across contexts", () => {
+		assert.equal(map("int32", "response"), "Int");
+		assert.equal(map("int32", "filter"), "Int");
+		assert.equal(map("int32", "rest"), "Int");
+	});
+});

--- a/src/graphql-types.ts
+++ b/src/graphql-types.ts
@@ -52,22 +52,16 @@ function scalarToGraphQL(scalar: Scalar, context: GraphQLEmitContext): string {
 				return "String";
 			case "int64":
 			case "uint64":
-				// AppSync GraphQL has no Long scalar; Int is 32-bit (max ~2.1B) so
-				// realistic int64 values (e.g. epoch-ms timestamps ~1.7T) overflow at
-				// parse time on filter inputs. Emit String for filter inputs so callers
-				// can serialize the 64-bit value as a numeric string. Response types
-				// keep Int for backward compatibility (a separate concern, since the
-				// resolver-side serialization path is already constrained by AppSync).
-				// The REST target maps to Float (issue #138): AppSync rejects values
-				// > 2^31-1 during response coercion, and Float (IEEE double) is exact
-				// for integers up to 2^53 — fine for epoch-ms timestamps.
-				if (context === "rest") return "Float";
-				return context === "filter" ? "String" : "Int";
+				// AppSync GraphQL has no Long scalar and its Int is 32-bit (max ~2.1B),
+				// so realistic values (epoch-ms ~1.7T) overflow. Response and rest map to
+				// Float: AppSync rejects values > 2^31-1 during response coercion (nulling
+				// the whole query response), and Float (IEEE double) is exact to 2^53.
+				// Filter maps to String because 64-bit values can exceed 2^53.
+				return context === "filter" ? "String" : "Float";
 			case "safeint":
-				// safeint spans up to 2^53, which also overflows GraphQL's 32-bit Int.
-				// The REST target maps it to Float (issue #138); the OpenSearch paths
-				// keep Int unchanged.
-				return context === "rest" ? "Float" : "Int";
+				// safeint spans up to 2^53, overflowing GraphQL's 32-bit Int. Response and
+				// rest map to Float (exact to 2^53); AppSync coerces the response otherwise.
+				return context === "filter" ? "Int" : "Float";
 			case "int32":
 			case "integer":
 			case "uint8":

--- a/test/snapshots/opensearch-baseline/pet-public-search-doc.graphql
+++ b/test/snapshots/opensearch-baseline/pet-public-search-doc.graphql
@@ -10,7 +10,7 @@ type PetPublicSearchDoc {
   aliases: [String!]!
   nickname: String
   rank: Int!
-  stock: Int!
+  stock: Float!
   score: Float!
   active: Boolean!
   approvals: [Approval!]!

--- a/test/snapshots/opensearch-baseline/pet-search-doc.graphql
+++ b/test/snapshots/opensearch-baseline/pet-search-doc.graphql
@@ -10,7 +10,7 @@ type PetSearchDoc {
   aliases: [String!]!
   nickname: String
   rank: Int!
-  stock: Int!
+  stock: Float!
   score: Float!
   active: Boolean!
   approvals: [ApprovalSearchDoc!]!


### PR DESCRIPTION
## OF-206: int64 GraphQL response fields overflow 32-bit Int

The GraphQL response context mapped `int64` / `uint64` / `safeint` to `Int`. GraphQL's `Int` is 32-bit (max ~2.1B), so realistic 64-bit values — epoch-ms timestamps such as `createdAt: 1784010516680` (~1.78 trillion) — exceed it. AppSync rejects an out-of-range integer during **response coercion** and nulls the **entire query response**, not just the offending field.

Map the response context to `Float`. Float (IEEE-754 double) is exact for integers up to 2^53, which covers epoch-ms. This matches the REST target's fix (#138), which already maps these scalars to Float for the same reason.

### Mapping change (`scalarToGraphQL`)
- `int64` / `uint64` — response: `Int` → `Float`. Filter stays `String` (64-bit values can exceed 2^53); rest stays `Float`.
- `safeint` — response: `Int` → `Float`. Rest stays `Float`; filter unchanged.

No other scalar or context is touched.

### Tests & snapshots
- New `src/graphql-types.test.ts` asserts the response/filter/rest mapping for `int64` / `uint64` / `safeint` and that `int32` is unchanged.
- Updated the `int64` SDL test to assert the response field is `Float`.
- OpenSearch baseline snapshots re-captured: the only diff is the `int64` response field `stock: Int! → Float!` in `pet-search-doc.graphql` and `pet-public-search-doc.graphql`.

Refs OF-206.
