### PR TITLE
feat(graphql): split an over-threshold prepare across further NONE functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ In the example above:
 | `graphql.max-page-size` | `number` | `100` | Maximum allowed page size. |
 | `graphql.track-total-hits-up-to` | `number` | `10000` | OpenSearch `track_total_hits` limit. |
 | `graphql.monolithic-threshold-bytes` | `number` | `32000` | Rendered-resolver size above which the pipeline split is emitted instead of a single file. See [Resolver code-size budget](#resolver-code-size-budget). |
+| `graphql.function-threshold-bytes` | `number` | `32000` | Rendered-function size above which the pipeline `prepare` splits into further `NONE` functions — by workload, then by spec entry. See [Splitting `prepare`](#splitting-prepare). |
 | `graphql.auto-date-histogram-buckets` | `number` | `10000` | Bucket ceiling for a `date_histogram` declared without `bounds`. Decides how wide a range keeps the declared interval before OpenSearch steps to a coarser one. Must stay under `search.max_buckets` (default 65,535). See [Bounding a `date_histogram`](#bounding-a-date_histogram). |
 
 The `emitter-output-dir` option is a standard TypeSpec compiler option that controls the output directory.
@@ -608,8 +609,20 @@ The emitter renders the single-file shape, measures it, and picks a mode:
 | --- | --- | --- |
 | ≤ `graphql.monolithic-threshold-bytes` (default `32000`) | `monolithic` | `*-resolver.js` |
 | above the threshold | `pipeline` | `*-resolver.js` (after-mapping), `*-fn-prepare.js` (`NONE`), `*-fn-search.js` (`OPENSEARCH`) |
+| pipeline, and `prepare` above `graphql.function-threshold-bytes` (default `32000`) | `pipeline` | `*-resolver.js`, `*-fn-prepare-query[-N].js` (`NONE`), `*-fn-prepare-aggs[-N].js` (`NONE`), `*-fn-search.js` (`OPENSEARCH`) |
 
 Each pipeline file gets its own 32,768-byte budget. Splitting the work is what makes wide `@searchInfer` projections deployable: the filter and aggregation specs stop competing with the response mapping for one budget.
+
+#### Splitting `prepare`
+
+`prepare` is data-dominated — `FILTER_SPEC` and `AGG_SPEC` grow with every searchable/aggregatable field — so on a wide enough projection it outgrows its own budget while the other pipeline files stay small. When the rendered `prepare` exceeds `graphql.function-threshold-bytes`, the emitter splits it along the same threshold-driven principle as the monolithic→pipeline flip, recursively:
+
+1. **By workload.** `prepareQuery` (`NONE`) carries `FILTER_SPEC`, the free-text spec, keyword filters and sort — it stashes `ctx.stash.musts/filters/mustNots/sort`. `prepareAggs` (`NONE`) carries `AGG_SPEC` and stashes `ctx.stash.aggs` (omitted entirely for projections without aggregations).
+2. **By spec entry.** A workload function still over the threshold partitions its spec across further functions (`prepareQuery2…`, `prepareAggs2…`), packed greedily on rendered bytes. Partial shares merge cleanly: bool `filter`/`must_not` members are commutative, and aggregation shares merge by key into the stashed map. Alias detection and the per-request histogram bucket budget read full-projection name lists (`AGG_NAMES`, `AGG_H_NAMES`), so behavior is identical to the unsplit emit.
+
+The final `search` function (`OPENSEARCH`) assembles the request body from the stash — still one OpenSearch round-trip; the extra `NONE` functions are pure compute. Consumers wire the manifest's `functions[]` in order, as before; function names stay AppSync-safe (`[_A-Za-z][_0-9A-Za-z]*`).
+
+AWS caps a pipeline resolver at **10 functions** (not adjustable), bounding the split at 9 `NONE` shares plus `search`. If a function still exceeds the threshold at that ceiling — or a single spec entry alone is too large — the emitter reports a `pipeline-function-over-threshold` error naming the function and its size, and emits the artifact anyway so downstream size guards can print exact numbers. Past the ceiling the escape hatch is a different data source (e.g. Lambda), which is out of the emitter's scope.
 
 #### Staying inside the budget
 
@@ -642,7 +655,7 @@ CI goes red on the guard, and AppSync refuses the deploy. The assertion message 
 The message names the file and its size. Work in this order:
 
 1. **Check whether the growth is per-field.** Code that repeats once per field or per sub-model belongs in a spec entry, not in the emitted body. This is the fix for #101 and #105 and the first thing to try.
-2. **Check the mode.** A monolithic projection tipping past the threshold falls back to the pipeline split on its own. A pipeline file over the cap has no further automatic split.
+2. **Check the mode.** A monolithic projection tipping past the threshold falls back to the pipeline split on its own, and a `prepare` over `graphql.function-threshold-bytes` splits further on its own (see [Splitting `prepare`](#splitting-prepare)). A red guard on a split function means the 10-function ceiling or a single oversized spec entry — the `pipeline-function-over-threshold` diagnostic names it.
 3. **Fall back to spec-as-data-asset.** Loading `FILTER_SPEC` from a data source instead of inlining it removes the size bound entirely, at the cost of one indirection. This is lever 3 from #101 and is not implemented.
 
 Do not raise the constant in the assertion. 32,768 is an AWS limit, not a project policy — a green test with a raised cap fails at deploy instead.

--- a/src/emit-graphql-resolver.test.ts
+++ b/src/emit-graphql-resolver.test.ts
@@ -3710,3 +3710,553 @@ describe("emitGraphQLResolver two-stage emit (issue #112)", () => {
 		}
 	});
 });
+
+describe("emitGraphQLResolver prepare split (function threshold)", () => {
+	const splitBase = {
+		defaultPageSize: 20,
+		maxPageSize: 100,
+		trackTotalHitsUpTo: 10000,
+		monolithicThresholdBytes: 0,
+	};
+
+	function lowerFirst(s: string): string {
+		return s[0].toLowerCase() + s.slice(1);
+	}
+
+	/**
+	 * Wide fixture whose 2-fn `prepare` renders to ~31.6 KB: 14 nested
+	 * sub-models each carrying filterables, aggregations (incl. a bounds-less
+	 * date_histogram) and a searchable text field, plus flat keyword/range/text
+	 * fields — every workload the split has to partition.
+	 */
+	function makeSplitProjection(): ResolvedProjection {
+		const subShapes = Array.from({ length: 14 }, (_, i) => `Sub${i}`);
+		return makeProjection({
+			name: "WideSearchDoc",
+			indexName: "wide_v1",
+			fields: [
+				makeField({ name: "name" }),
+				makeField({
+					name: "status",
+					keyword: true,
+					filterables: ["term", "terms", "exists"],
+					aggregations: ["terms"],
+				}),
+				makeField({
+					name: "counterpartyId",
+					keyword: true,
+					filterables: ["term", "terms", "exists"],
+					aggregations: ["terms"],
+				}),
+				makeField({
+					name: "createdAt",
+					filterables: ["range"],
+					type: { kind: "Scalar", name: "utcDateTime" } as unknown as Type,
+					aggregations: [
+						"sum",
+						"avg",
+						"min",
+						"max",
+						{ kind: "date_histogram", options: { interval: "month" } },
+					],
+				}),
+				...subShapes.map((shape) =>
+					makeField({
+						name: `${shape.toLowerCase()}s`,
+						nested: true,
+						subProjection: {
+							projectionModel: { name: `${shape}SearchDoc` },
+							sourceModel: { name: shape },
+							indexName: shape.toLowerCase(),
+							fields: [
+								makeField({ name: "label" }),
+								makeField({
+									name: `${lowerFirst(shape)}Id`,
+									keyword: true,
+									filterables: ["term", "terms", "exists"],
+									aggregations: ["terms"],
+								}),
+								makeField({
+									name: "type",
+									keyword: true,
+									filterables: ["term", "terms", "exists"],
+									aggregations: ["terms"],
+								}),
+								makeField({
+									name: "createdAt",
+									filterables: ["range"],
+									type: {
+										kind: "Scalar",
+										name: "utcDateTime",
+									} as unknown as Type,
+									aggregations: [
+										"sum",
+										"avg",
+										"min",
+										"max",
+										{ kind: "date_histogram", options: { interval: "month" } },
+									],
+								}),
+								makeField({
+									name: "updatedAt",
+									filterables: ["range"],
+									type: {
+										kind: "Scalar",
+										name: "utcDateTime",
+									} as unknown as Type,
+									aggregations: ["sum", "avg", "min", "max"],
+								}),
+							],
+						} as unknown as ResolvedProjection,
+						filterables: ["exists"],
+						type: {
+							kind: "Model",
+							name: "Array",
+							indexer: { value: { kind: "Model" } },
+						} as unknown as Type,
+					}),
+				),
+			],
+		});
+	}
+
+	/**
+	 * Evaluates a split pipeline end-to-end: runs each NONE function's request
+	 * handler against one shared ctx (stash mutations persist between pipeline
+	 * functions, as in the AppSync runtime) and returns the body the final
+	 * OPENSEARCH function's request assembles.
+	 */
+	function evalPipelineBody(
+		result: EmitResult,
+		info: { selectionSetList: string[] },
+		args: Record<string, unknown> = {},
+	): Record<string, unknown> {
+		const utilStub = {
+			base64Decode: (s: string) => Buffer.from(s, "base64").toString("utf8"),
+			base64Encode: (s: string) => Buffer.from(s, "utf8").toString("base64"),
+			error: (msg: string) => {
+				throw new Error(msg);
+			},
+		};
+		const ctx = { args, info, stash: {} as Record<string, unknown> };
+		for (const fn of result.functions) {
+			const stripped = fn.content
+				.replace(/^import \{ util \} from "@aws-appsync\/utils";?\n?/m, "")
+				.replace(/^export function /gm, "function ");
+			const factory = new Function("util", `${stripped}\nreturn request;`) as (
+				util: unknown,
+			) => (c: unknown) => { params?: { body?: Record<string, unknown> } };
+			const ret = factory(utilStub)(ctx);
+			if (fn.dataSource === "OPENSEARCH") {
+				if (!ret?.params?.body) {
+					throw new Error("search request produced no body");
+				}
+				return ret.params.body;
+			}
+		}
+		throw new Error("pipeline had no OPENSEARCH function");
+	}
+
+	/**
+	 * The split emits chunk-local clauses in chunk order, while the unsplit
+	 * prepare finalizes every nested wrapper after every direct clause — same
+	 * clauses, different array order. bool `filter`/`must_not` members are
+	 * commutative (filter context, no scoring), so compare them as multisets.
+	 */
+	function withSortedClauses(
+		body: Record<string, unknown>,
+	): Record<string, unknown> {
+		const clone = structuredClone(body) as {
+			query?: { bool?: Record<string, unknown> };
+		};
+		const bool = clone.query?.bool;
+		if (bool) {
+			for (const key of ["filter", "must_not"]) {
+				const clauses = bool[key];
+				if (Array.isArray(clauses)) {
+					bool[key] = [...clauses].sort((a, b) =>
+						JSON.stringify(a).localeCompare(JSON.stringify(b)),
+					);
+				}
+			}
+		}
+		return clone;
+	}
+
+	const fullArgs = {
+		query: "acme",
+		filter: { counterpartyId: "c9" },
+		searchFilter: {
+			status: "Active",
+			counterpartyIdIn: ["c1", "c2"],
+			createdAtGte: 100,
+			createdAtLt: 900,
+			sub0sExists: true,
+			sub0s: { sub0Id: "a", typeIn: ["T1"], createdAtGte: 1 },
+			sub7s: { typeExists: false },
+			sub13s: { sub13Id: "z", updatedAtLte: 42 },
+		},
+		sortBy: [{ field: "counterpartyId", direction: "ASC" }],
+		after: Buffer.from(JSON.stringify([123, "abc"])).toString("base64"),
+		first: 30,
+	};
+	const fullSelection = {
+		selectionSetList: [
+			"edges",
+			"edges/node",
+			"edges/node/name",
+			"aggregations",
+			"aggregations/byStatus",
+			"aggregations/bySub0Type",
+			"aggregations/bySub13Type",
+			"aggregations/sub13UpdatedAtSum",
+		],
+	};
+
+	it("splits an over-threshold prepare by workload, then by spec entry, and every file fits", async () => {
+		const result = await emitGraphQLResolver(makeSplitProjection(), {
+			...splitBase,
+			functionThresholdBytes: 12_000,
+		});
+
+		assert.equal(result.mode, "pipeline");
+		assert.deepEqual(
+			result.functions.map((f) => f.name),
+			[
+				"prepareQuery",
+				"prepareQuery2",
+				"prepareAggs",
+				"prepareAggs2",
+				"prepareAggs3",
+				"search",
+			],
+		);
+		assert.deepEqual(
+			result.functions.map((f) => f.dataSource),
+			["NONE", "NONE", "NONE", "NONE", "NONE", "OPENSEARCH"],
+		);
+		assert.deepEqual(
+			result.functions.map((f) => f.fileName),
+			[
+				"wide-search-doc-fn-prepare-query.js",
+				"wide-search-doc-fn-prepare-query-2.js",
+				"wide-search-doc-fn-prepare-aggs.js",
+				"wide-search-doc-fn-prepare-aggs-2.js",
+				"wide-search-doc-fn-prepare-aggs-3.js",
+				"wide-search-doc-fn-search.js",
+			],
+		);
+		for (const fn of result.functions) {
+			// Consumers embed fn.name in AppSync Function names, whose pattern
+			// is [_A-Za-z][_0-9A-Za-z]* — a hyphenated name fails at deploy.
+			assert.match(fn.name, /^[A-Za-z][0-9A-Za-z]*$/);
+			const bytes = Buffer.byteLength(fn.content, "utf-8");
+			assert.ok(
+				bytes <= 12_000,
+				`${fn.name} is ${bytes} bytes; every split file must fit the 12,000-byte function threshold`,
+			);
+		}
+		assert.equal(result.oversizedFunctions, undefined);
+	});
+
+	it("keeps the 2-function pipeline byte-identical when prepare fits the function threshold", async () => {
+		const projection = makeSplitProjection();
+		const unsplit = await emitGraphQLResolver(projection, {
+			...splitBase,
+			functionThresholdBytes: 1_000_000_000,
+		});
+		const defaulted = await emitGraphQLResolver(projection, splitBase);
+
+		assert.deepEqual(
+			unsplit.functions.map((f) => f.name),
+			["prepare", "search"],
+		);
+		// This fixture's prepare renders under the 32,000-byte default, so the
+		// defaulted emit must be byte-identical to the effectively-unlimited one.
+		assert.deepEqual(defaulted, unsplit);
+	});
+
+	it("split pipeline assembles the same OpenSearch body as the unsplit prepare", async () => {
+		const projection = makeSplitProjection();
+		const split = await emitGraphQLResolver(projection, {
+			...splitBase,
+			functionThresholdBytes: 12_000,
+		});
+		const unsplit = await emitGraphQLResolver(projection, {
+			...splitBase,
+			functionThresholdBytes: 1_000_000_000,
+		});
+
+		const splitBody = evalPipelineBody(split, fullSelection, fullArgs);
+		const unsplitBody = evalRequestBody(
+			prepareFunctionContent(unsplit),
+			fullSelection,
+			fullArgs,
+		);
+		assert.deepEqual(
+			withSortedClauses(splitBody),
+			withSortedClauses(unsplitBody),
+		);
+
+		// No args at all: match_all, no aggs key — on both shapes.
+		const emptySelection = { selectionSetList: [] as string[] };
+		const splitEmpty = evalPipelineBody(split, emptySelection, {});
+		const unsplitEmpty = evalRequestBody(
+			prepareFunctionContent(unsplit),
+			emptySelection,
+			{},
+		);
+		assert.deepEqual(splitEmpty, unsplitEmpty);
+		assert.deepEqual(splitEmpty.query, { match_all: {} });
+		assert.ok(!("aggs" in splitEmpty));
+	});
+
+	it("divides the histogram bucket budget by the request-wide selection, not per function", async () => {
+		const split = await emitGraphQLResolver(makeSplitProjection(), {
+			...splitBase,
+			functionThresholdBytes: 12_000,
+		});
+
+		// Three bounds-less histograms selected across different prepareAggs
+		// functions: the budget divides by 3 everywhere, exactly as unsplit.
+		const selection = {
+			selectionSetList: [
+				"aggregations/byCreatedAtOverTime",
+				"aggregations/bySub0CreatedAtOverTime",
+				"aggregations/bySub13CreatedAtOverTime",
+			],
+		};
+		const body = evalPipelineBody(split, selection, {}) as {
+			aggs: Record<
+				string,
+				{
+					auto_date_histogram?: { buckets: number };
+					aggs?: Record<string, { auto_date_histogram: { buckets: number } }>;
+				}
+			>;
+		};
+
+		const expected = Math.floor(PER_REQUEST_BUCKET_BUDGET / 3);
+		assert.ok(expected < DEFAULT_AUTO_DATE_HISTOGRAM_BUCKETS);
+		assert.ok(expected > MIN_AUTO_DATE_HISTOGRAM_BUCKETS);
+		assert.equal(
+			body.aggs.byCreatedAtOverTime.auto_date_histogram?.buckets,
+			expected,
+		);
+		assert.equal(
+			body.aggs._sub0s.aggs?.bySub0CreatedAtOverTime.auto_date_histogram
+				.buckets,
+			expected,
+		);
+		assert.equal(
+			body.aggs._sub13s.aggs?.bySub13CreatedAtOverTime.auto_date_histogram
+				.buckets,
+			expected,
+		);
+	});
+
+	it("falls back to sending every aggregation on an alias, in every function's share", async () => {
+		const projection = makeSplitProjection();
+		const split = await emitGraphQLResolver(projection, {
+			...splitBase,
+			functionThresholdBytes: 12_000,
+		});
+		const unsplit = await emitGraphQLResolver(projection, {
+			...splitBase,
+			functionThresholdBytes: 1_000_000_000,
+		});
+
+		// `renamed` names no declared aggregation anywhere — every function must
+		// read it as an alias and contribute its full share.
+		const selection = { selectionSetList: ["aggregations/renamed"] };
+		const splitBody = evalPipelineBody(split, selection, {});
+		const unsplitBody = evalRequestBody(
+			prepareFunctionContent(unsplit),
+			selection,
+			{},
+		);
+		assert.deepEqual(splitBody, unsplitBody);
+
+		const aggs = splitBody.aggs as Record<string, unknown>;
+		assert.ok(aggs.byStatus, "flat share from the first function");
+		assert.ok(aggs._sub13s, "nested share from the last function");
+	});
+
+	it("respects the 10-function pipeline ceiling and reports still-oversized functions", async () => {
+		const result = await emitGraphQLResolver(makeSplitProjection(), {
+			...splitBase,
+			functionThresholdBytes: 3_000,
+		});
+
+		assert.ok(result.functions.length <= 10);
+		assert.equal(result.functions.at(-1)?.name, "search");
+		assert.ok(result.oversizedFunctions);
+		assert.ok(result.oversizedFunctions.length > 0);
+		for (const oversized of result.oversizedFunctions) {
+			assert.ok(oversized.bytes > 3_000);
+			assert.equal(oversized.thresholdBytes, 3_000);
+			assert.ok(
+				result.functions.some((f) => f.name === oversized.functionName),
+			);
+		}
+	});
+
+	it("omits prepareAggs functions entirely for a projection without aggregations", async () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({ name: "name" }),
+				makeField({
+					name: "species",
+					keyword: true,
+					filterables: ["term", "terms", "exists"],
+				}),
+				makeField({
+					name: "rank",
+					filterables: ["range"],
+					type: { kind: "Scalar", name: "int32" } as unknown as Type,
+				}),
+			],
+		});
+		const split = await emitGraphQLResolver(projection, {
+			...splitBase,
+			functionThresholdBytes: 0,
+		});
+		const unsplit = await emitGraphQLResolver(projection, {
+			...splitBase,
+			functionThresholdBytes: 1_000_000_000,
+		});
+
+		assert.ok(split.functions.every((f) => !f.name.startsWith("prepareAggs")));
+		const selection = { selectionSetList: [] as string[] };
+		const args = {
+			query: "rex",
+			searchFilter: { species: "dog", rankGte: 3 },
+		};
+		const splitBody = evalPipelineBody(split, selection, args);
+		const unsplitBody = evalRequestBody(
+			prepareFunctionContent(unsplit),
+			selection,
+			args,
+		);
+		assert.deepEqual(
+			withSortedClauses(splitBody),
+			withSortedClauses(unsplitBody),
+		);
+		assert.ok(!("aggs" in splitBody));
+	});
+
+	it("split output passes @aws-appsync/eslint-plugin recommended config", async () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "species",
+					keyword: true,
+					filterables: ["term", "term_negate"],
+					aggregations: ["terms", "cardinality", "missing"],
+				}),
+				makeField({
+					name: "rank",
+					filterables: ["range"],
+					type: { kind: "Scalar", name: "int32" } as unknown as Type,
+				}),
+				makeField({
+					name: "validFrom",
+					type: { kind: "Scalar", name: "utcDateTime" } as unknown as Type,
+					aggregations: [
+						{ kind: "date_histogram", options: { interval: "month" } },
+					],
+				}),
+				makeField({
+					name: "tags",
+					nested: true,
+					subProjection: makeSubProjection("TagSearchDoc", [
+						makeField({ name: "value" }),
+						makeField({
+							name: "key",
+							keyword: true,
+							filterables: ["term", "terms"],
+							aggregations: ["terms"],
+						}),
+					]),
+					filterables: ["exists"],
+					type: {
+						kind: "Model",
+						name: "Array",
+						indexer: { value: { kind: "Model" } },
+					} as unknown as Type,
+				}),
+			],
+		});
+		const result = await emitGraphQLResolver(projection, {
+			...splitBase,
+			functionThresholdBytes: 0,
+		});
+		assert.ok(result.functions.length > 2, "fixture must actually split");
+
+		const { ESLint } = await import("eslint");
+		// @ts-expect-error — plugin ships no type declarations.
+		const { default: appsyncPlugin } = await import(
+			"@aws-appsync/eslint-plugin"
+		);
+
+		const dir = await mkdtemp(join(tmpdir(), "appsync-lint-split-"));
+		try {
+			const files = [
+				{ fileName: "resolver.js", content: result.content },
+				...result.functions,
+			];
+			for (const file of files) {
+				await writeFile(join(dir, file.fileName), file.content);
+			}
+			await writeFile(
+				join(dir, "tsconfig.json"),
+				JSON.stringify({
+					compilerOptions: {
+						target: "ES2022",
+						module: "ES2022",
+						allowJs: true,
+						checkJs: false,
+						noEmit: true,
+					},
+					include: files.map((f) => f.fileName),
+				}),
+			);
+			const eslint = new ESLint({
+				cwd: dir,
+				overrideConfigFile: true,
+				overrideConfig: [
+					{
+						...appsyncPlugin.configs.recommended,
+						languageOptions: {
+							...appsyncPlugin.configs.recommended.languageOptions,
+							sourceType: "module",
+							ecmaVersion: 2022,
+							parserOptions: {
+								project: "./tsconfig.json",
+								tsconfigRootDir: dir,
+								ecmaVersion: 2022,
+								sourceType: "module",
+							},
+						},
+					},
+				],
+			});
+			const lintResults = await eslint.lintFiles(
+				files.map((f) => join(dir, f.fileName)),
+			);
+			const messages = lintResults.flatMap((r) =>
+				r.messages.map(
+					(m) =>
+						`[${m.ruleId ?? "fatal"}] ${r.filePath.split("/").pop()} line ${m.line ?? "?"}: ${m.message}`,
+				),
+			);
+			assert.deepEqual(
+				messages,
+				[],
+				`@aws-appsync/eslint-plugin reported issues on split output:\n${messages.join("\n")}`,
+			);
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	});
+});

--- a/src/emit-graphql-resolver.ts
+++ b/src/emit-graphql-resolver.ts
@@ -46,8 +46,29 @@ export interface EmittedResolverFile {
 	 * across functions keeps each file's APPSYNC_JS code under the 32 KB
 	 * per-function cap, which a single-resolver shape would exceed on wide
 	 * @searchInfer projections (issue #105). Empty for `mode === "monolithic"`.
+	 *
+	 * Two functions (`prepare` + `search`) when `prepare` fits the function
+	 * threshold; otherwise the prepare work splits across `prepareQuery[N]` /
+	 * `prepareAggs[N]` NONE functions that each stash their share of the
+	 * request body, assembled by the final `search` function. Function names
+	 * stay AppSync-safe (`[_A-Za-z][_0-9A-Za-z]*`) — consumers embed them in
+	 * AppSync Function names.
 	 */
 	functions: EmittedPipelineFunction[];
+	/**
+	 * Functions still over `functionThresholdBytes` after best-effort
+	 * splitting (a single spec entry too large, or the 10-function pipeline
+	 * ceiling reached). The emitter surfaces these as diagnostics; the
+	 * artifact is emitted regardless so the consumer's own guards can report
+	 * exact bytes.
+	 */
+	oversizedFunctions?: OversizedPipelineFunction[];
+}
+
+export interface OversizedPipelineFunction {
+	functionName: string;
+	bytes: number;
+	thresholdBytes: number;
 }
 
 export interface ResolverOptions {
@@ -65,9 +86,23 @@ export interface ResolverOptions {
 	 * aggregation declares no bounds. See DEFAULT_AUTO_DATE_HISTOGRAM_BUCKETS.
 	 */
 	autoDateHistogramBuckets?: number;
+	/**
+	 * Byte threshold above which a pipeline `prepare` function is split
+	 * further: first by workload (query vs aggregations), then by spec entry
+	 * across additional NONE functions. Measured against each rendered
+	 * function. Default 32,000 (32K cap minus headroom), matching the
+	 * monolithic threshold's convention.
+	 */
+	functionThresholdBytes?: number;
 }
 
 const DEFAULT_MONOLITHIC_THRESHOLD_BYTES = 32_000;
+
+const DEFAULT_FUNCTION_THRESHOLD_BYTES = 32_000;
+
+// AWS hard ceiling on functions per pipeline resolver (not adjustable):
+// at most 9 NONE prepare functions plus the OPENSEARCH search function.
+const MAX_PIPELINE_FUNCTIONS = 10;
 
 /**
  * Per-histogram `buckets` ceiling for a bounds-less `auto_date_histogram`
@@ -203,29 +238,171 @@ export async function emitGraphQLResolver(
 		searchFilterShape,
 		options,
 	);
-	const searchContent = renderSearchFunction(projection.indexName);
 	const resolverContent = renderResolver(aggregations, options);
+	const functionThreshold =
+		options.functionThresholdBytes ?? DEFAULT_FUNCTION_THRESHOLD_BYTES;
+
+	if (Buffer.byteLength(prepareContent, "utf-8") <= functionThreshold) {
+		const searchContent = renderSearchFunction(projection.indexName);
+		return {
+			queryFieldName,
+			mode: "pipeline",
+			fileName: `${baseName}-resolver.js`,
+			content: resolverContent,
+			functions: [
+				{
+					name: "prepare",
+					fileName: `${baseName}-fn-prepare.js`,
+					content: prepareContent,
+					dataSource: "NONE",
+				},
+				{
+					name: "search",
+					fileName: `${baseName}-fn-search.js`,
+					content: searchContent,
+					dataSource: "OPENSEARCH",
+				},
+			],
+		};
+	}
+
+	// `prepare` itself is over the function threshold: split its independent
+	// workloads (query building vs aggregation assembly) across NONE functions,
+	// each partitioned further by spec entry while still over the threshold.
+	// The final search function assembles the request body from the stash —
+	// still one OpenSearch round-trip.
+	return renderSplitPipeline(
+		queryFieldName,
+		baseName,
+		projection.indexName,
+		textFields,
+		keywordFields,
+		textSortFields,
+		aggregations,
+		searchFilterShape,
+		options,
+		functionThreshold,
+		resolverContent,
+	);
+}
+
+function renderSplitPipeline(
+	queryFieldName: string,
+	baseName: string,
+	indexName: string,
+	textFields: TextFieldCollection,
+	keywordFields: string[],
+	textSortFields: string[],
+	aggregations: AggregationEntry[],
+	searchFilterShape: SearchFilterShape | undefined,
+	options: ResolverOptions,
+	functionThreshold: number,
+	resolverContent: string,
+): EmittedResolverFile {
+	const specNodes = searchFilterShape?.nodes ?? [];
+	const aggEntries = orderedAggEntries(aggregations);
+	const reservedForAggs = aggEntries.length > 0 ? 1 : 0;
+
+	const queryContents = packChunks(
+		specNodes,
+		(chunk, chunkIndex) =>
+			renderPrepareQueryFunction(
+				chunk,
+				chunkIndex === 0,
+				textFields,
+				keywordFields,
+				textSortFields,
+			),
+		functionThreshold,
+		MAX_PIPELINE_FUNCTIONS - 1 - reservedForAggs,
+	);
+	const aggsContents =
+		aggEntries.length === 0
+			? []
+			: packChunks(
+					aggEntries,
+					(chunk) => renderPrepareAggsFunction(chunk, aggEntries, options),
+					functionThreshold,
+					MAX_PIPELINE_FUNCTIONS - 1 - queryContents.length,
+				);
+
+	const functions: EmittedPipelineFunction[] = [
+		...queryContents.map((content, i) => ({
+			name: i === 0 ? "prepareQuery" : `prepareQuery${i + 1}`,
+			fileName:
+				i === 0
+					? `${baseName}-fn-prepare-query.js`
+					: `${baseName}-fn-prepare-query-${i + 1}.js`,
+			content,
+			dataSource: "NONE" as const,
+		})),
+		...aggsContents.map((content, i) => ({
+			name: i === 0 ? "prepareAggs" : `prepareAggs${i + 1}`,
+			fileName:
+				i === 0
+					? `${baseName}-fn-prepare-aggs.js`
+					: `${baseName}-fn-prepare-aggs-${i + 1}.js`,
+			content,
+			dataSource: "NONE" as const,
+		})),
+		{
+			name: "search",
+			fileName: `${baseName}-fn-search.js`,
+			content: renderAssembleSearchFunction(indexName, options),
+			dataSource: "OPENSEARCH" as const,
+		},
+	];
+
+	const oversizedFunctions = functions
+		.map((fn) => ({
+			functionName: fn.name,
+			bytes: Buffer.byteLength(fn.content, "utf-8"),
+			thresholdBytes: functionThreshold,
+		}))
+		.filter((fn) => fn.bytes > functionThreshold);
 
 	return {
 		queryFieldName,
 		mode: "pipeline",
 		fileName: `${baseName}-resolver.js`,
 		content: resolverContent,
-		functions: [
-			{
-				name: "prepare",
-				fileName: `${baseName}-fn-prepare.js`,
-				content: prepareContent,
-				dataSource: "NONE",
-			},
-			{
-				name: "search",
-				fileName: `${baseName}-fn-search.js`,
-				content: searchContent,
-				dataSource: "OPENSEARCH",
-			},
-		],
+		functions,
+		...(oversizedFunctions.length > 0 ? { oversizedFunctions } : {}),
 	};
+}
+
+/**
+ * Greedy sequential pack of spec entries into rendered chunks: entries join
+ * the current chunk until its rendered form exceeds the threshold, measured
+ * on real bytes rather than a size model so fixed per-function overhead (the
+ * applyFilterSpec engine, buildAggs, helpers) is priced in exactly. Capped at
+ * `maxChunks` — the remainder folds into the last chunk, and the caller
+ * reports any still-oversized function as a diagnostic.
+ */
+function packChunks<T>(
+	items: T[],
+	render: (chunk: T[], chunkIndex: number) => string,
+	thresholdBytes: number,
+	maxChunks: number,
+): string[] {
+	const cap = Math.max(1, maxChunks);
+	const chunks: T[][] = [[]];
+	for (const item of items) {
+		const current = chunks[chunks.length - 1];
+		if (
+			current.length > 0 &&
+			chunks.length < cap &&
+			Buffer.byteLength(
+				render([...current, item], chunks.length - 1),
+				"utf-8",
+			) > thresholdBytes
+		) {
+			chunks.push([item]);
+			continue;
+		}
+		current.push(item);
+	}
+	return chunks.map((chunk, i) => render(chunk, i));
 }
 
 /**
@@ -932,6 +1109,265 @@ ${renderSearchBodyGuard("ctx.result", "\t")}	return ctx.result;
 }
 
 /**
+ * Split-mode NONE function carrying (a share of) the query-building workload.
+ * The first function owns everything that exists exactly once — free-text
+ * musts, keyword filters, sort — plus its FILTER_SPEC share; later functions
+ * carry only a FILTER_SPEC share and the applyFilterSpec engine. Every clause
+ * lands in `ctx.stash.musts/filters/mustNots` (bool `filter`/`must_not`
+ * members are commutative, so shares merge cleanly); the search function
+ * assembles the final body.
+ */
+function renderPrepareQueryFunction(
+	chunk: FilterSpecNode[],
+	isFirst: boolean,
+	textFields: TextFieldCollection,
+	keywordFields: string[],
+	textSortFields: string[],
+): string {
+	const filterSpecLiteral = stringifySpec(chunk);
+	const slotsLiteral = `[${"null,".repeat(FILTER_WORK_SLOT_COUNT).slice(0, -1)}]`;
+	const applyFilterSpecFunction = renderApplyFilterSpecFunction(slotsLiteral);
+
+	if (!isFirst) {
+		return `import { util } from "@aws-appsync/utils";
+
+const FILTER_SPEC = ${filterSpecLiteral};
+
+export function request(ctx) {
+	const args = ctx.args;
+	if (args.searchFilter) {
+		const filters = ctx.stash.filters;
+		const mustNots = ctx.stash.mustNots;
+		applyFilterSpec(FILTER_SPEC, args.searchFilter, filters, mustNots);
+		ctx.stash.filters = filters;
+		ctx.stash.mustNots = mustNots;
+	}
+	return { payload: null };
+}
+
+export function response(ctx) {
+	return ctx.result;
+}
+
+${applyFilterSpecFunction}`;
+	}
+
+	const textQueryPush = renderTextQueryPush(textFields);
+	const textSpecDeclaration = renderTextSpecDeclaration(textFields);
+	const nestedTextHelper = renderNestedTextHelper(textFields);
+	const keywordFieldsLiteral = JSON.stringify(keywordFields);
+	const textSortFieldsLiteral = JSON.stringify(textSortFields);
+	const buildSortFunction = renderBuildSortFunction();
+
+	return `import { util } from "@aws-appsync/utils";
+
+const FILTER_SPEC = ${filterSpecLiteral};
+
+export function request(ctx) {
+	const args = ctx.args;
+	const queryText = args.query;
+	const filter = args.filter;
+	const musts = [];
+	const filters = [];
+	const mustNots = [];
+
+	if (queryText) {
+${textQueryPush}
+	}
+
+	const keywordFields = ${keywordFieldsLiteral};
+	if (filter) {
+		for (const field of keywordFields) {
+			if (filter[field] != null) {
+				filters.push({ term: { [field]: filter[field] } });
+			}
+		}
+	}
+
+	if (args.searchFilter) {
+		applyFilterSpec(FILTER_SPEC, args.searchFilter, filters, mustNots);
+	}
+
+	ctx.stash.musts = musts;
+	ctx.stash.filters = filters;
+	ctx.stash.mustNots = mustNots;
+	ctx.stash.sort = buildSort(args.sortBy);
+	return { payload: null };
+}
+
+export function response(ctx) {
+	return ctx.result;
+}
+${textSpecDeclaration}${nestedTextHelper}
+const TEXT_SORT_FIELDS = ${textSortFieldsLiteral};
+
+${buildSortFunction}
+${applyFilterSpecFunction}`;
+}
+
+/**
+ * Split-mode NONE function carrying a share of the aggregation workload. Each
+ * function merges its selected AGG_SPEC entries into `ctx.stash.aggs`
+ * (assigned only when something was requested, so the search function can
+ * omit `aggs` entirely). AGG_NAMES carries every declared aggregation name —
+ * not just this function's share — so the alias fallback fires identically to
+ * the unsplit emit; AGG_H_NAMES likewise carries every auto-histogram name so
+ * the per-request bucket budget is divided by the request-wide selection
+ * count, not a per-function one (issue #155).
+ */
+function renderPrepareAggsFunction(
+	chunk: AggregationEntry[],
+	allEntries: AggregationEntry[],
+	options: ResolverOptions,
+): string {
+	const chunkLiteral = `[${chunk.map(renderAggSpecItem).join(", ")}]`;
+	const helper = chunk.some(usesAutoDateHistogram)
+		? `\nconst ${AUTO_DATE_HISTOGRAM_HELPER} = (f, m) => ({ auto_date_histogram: { field: f, minimum_interval: m } });`
+		: "";
+	const aggNamesLiteral = JSON.stringify(allEntries.map((e) => e.aggName));
+
+	const hasAuto = chunk.some(usesAutoDateHistogram);
+	const cap =
+		options.autoDateHistogramBuckets ?? DEFAULT_AUTO_DATE_HISTOGRAM_BUCKETS;
+	const histogramNamesDeclaration = hasAuto
+		? `\nconst AGG_H_NAMES = ${JSON.stringify(
+				allEntries.filter(usesAutoDateHistogram).map((e) => e.aggName),
+			)};`
+		: "";
+	const histogramDecl = hasAuto ? "\n\tconst histograms = [];" : "";
+	const trackHistogram = hasAuto
+		? "\n\t\t\tif (spec.h) histograms.push(spec);"
+		: "";
+	const budgetBlock = hasAuto
+		? `
+	// search.max_buckets caps the whole request: divide a soft budget across
+	// the selected histograms, counted over AGG_H_NAMES (every prepareAggs
+	// function's share) so the split shares one request-wide budget (issue #155).
+	if (histograms.length > 0) {
+		let selected = 0;
+		for (const name of AGG_H_NAMES) {
+			if (aliased || selectionSetList.indexOf("aggregations/" + name) >= 0) {
+				selected = selected + 1;
+			}
+		}
+		let budget = Math.floor(${PER_REQUEST_BUCKET_BUDGET} / selected);
+		if (budget > ${cap}) budget = ${cap};
+		if (budget < ${MIN_AUTO_DATE_HISTOGRAM_BUCKETS}) budget = ${MIN_AUTO_DATE_HISTOGRAM_BUCKETS};
+		for (const spec of histograms) {
+			spec.a.auto_date_histogram.buckets = budget;
+		}
+	}`
+		: "";
+
+	return `import { util } from "@aws-appsync/utils";
+${helper}
+const AGG_SPEC = ${chunkLiteral};
+const AGG_NAMES = ${aggNamesLiteral};${histogramNamesDeclaration}
+
+export function request(ctx) {
+	const aggs = ctx.stash.aggs || {};
+	if (buildAggs(ctx.info.selectionSetList, aggs)) {
+		ctx.stash.aggs = aggs;
+	}
+	return { payload: null };
+}
+
+export function response(ctx) {
+	return ctx.result;
+}
+
+function buildAggs(selectionSetList, aggs) {
+	// A first segment under \`aggregations/\` naming no declared aggregation is
+	// an alias, whose target is not recoverable here — send every aggregation
+	// rather than none. AGG_NAMES holds every declared name, not just this
+	// function's AGG_SPEC share, so detection matches the unsplit emit.
+	let aliased = false;
+	for (const path of selectionSetList) {
+		if (path.indexOf("aggregations/") === 0) {
+			const rest = path.substring(13);
+			const slash = rest.indexOf("/");
+			const name = slash < 0 ? rest : rest.substring(0, slash);
+			if (AGG_NAMES.indexOf(name) < 0 && name !== "__typename") aliased = true;
+		}
+	}
+	let requested = false;${histogramDecl}
+	for (const spec of AGG_SPEC) {
+		if (aliased || selectionSetList.indexOf("aggregations/" + spec.n) >= 0) {
+			requested = true;${trackHistogram}
+			if (spec.g) {
+				const group = aggs[spec.g] || { nested: { path: spec.p }, aggs: {} };
+				group.aggs[spec.n] = spec.a;
+				aggs[spec.g] = group;
+			} else {
+				aggs[spec.n] = spec.a;
+			}
+		}
+	}${budgetBlock}
+	return requested;
+}
+`;
+}
+
+/**
+ * Split-mode OPENSEARCH function: assembles the request body from the stash
+ * shares the prepare functions wrote and executes the search — one OpenSearch
+ * round-trip, same body shape (and key order) as the unsplit prepare built.
+ */
+function renderAssembleSearchFunction(
+	indexName: string,
+	options: ResolverOptions,
+): string {
+	return `import { util } from "@aws-appsync/utils";
+
+export function request(ctx) {
+	const args = ctx.args;
+	const size = Math.min(args.first || ${options.defaultPageSize}, ${options.maxPageSize});
+	const musts = ctx.stash.musts || [];
+	const filters = ctx.stash.filters || [];
+	const mustNots = ctx.stash.mustNots || [];
+
+	const query =
+		musts.length === 0 && filters.length === 0 && mustNots.length === 0
+			? { match_all: {} }
+			: {
+					bool: {
+						...(musts.length > 0 ? { must: musts } : {}),
+						...(filters.length > 0 ? { filter: filters } : {}),
+						...(mustNots.length > 0 ? { must_not: mustNots } : {}),
+					},
+				};
+
+	const body = {
+		size: size + 1,
+		track_total_hits: ${options.trackTotalHitsUpTo},
+		sort: ctx.stash.sort,
+		query,
+	};
+
+	if (args.after) {
+		body.search_after = JSON.parse(util.base64Decode(args.after));
+	}
+	if (ctx.stash.aggs) {
+		body.aggs = ctx.stash.aggs;
+	}
+
+	return {
+		operation: "GET",
+		path: "/${indexName}/_search",
+		params: { body },
+	};
+}
+
+export function response(ctx) {
+	if (ctx.error) {
+		return util.error(ctx.error.message, ctx.error.type, null, ctx.result);
+	}
+${renderSearchBodyGuard("ctx.result", "\t")}	return ctx.result;
+}
+`;
+}
+
+/**
  * Guard an OpenSearch response body before anything dereferences `.hits`.
  *
  * Covers three failure shapes the datasource can hand back without setting
@@ -1064,8 +1500,19 @@ function renderAggSpecLiteral(aggregations: AggregationEntry[]): string {
 	if (aggregations.length === 0) {
 		return "[]";
 	}
+	return `[${orderedAggEntries(aggregations).map(renderAggSpecItem).join(", ")}]`;
+}
 
-	const flatItems: string[] = [];
+/**
+ * The ordered, deduped aggregation entry list behind AGG_SPEC: flat entries
+ * first, then nested ones grouped by path, first-wins on duplicate aggName
+ * (matching the response-side mapping). Shared by the single-function literal
+ * and the split-mode chunking so both see the same entries in the same order.
+ */
+function orderedAggEntries(
+	aggregations: AggregationEntry[],
+): AggregationEntry[] {
+	const flat: AggregationEntry[] = [];
 	const flatSeen = new Set<string>();
 	const byPath = new Map<string, AggregationEntry[]>();
 	const seenInPath = new Map<string, Set<string>>();
@@ -1073,9 +1520,7 @@ function renderAggSpecLiteral(aggregations: AggregationEntry[]): string {
 		if (!entry.nestedPath) {
 			if (flatSeen.has(entry.aggName)) continue;
 			flatSeen.add(entry.aggName);
-			flatItems.push(
-				`{n:${JSON.stringify(entry.aggName)},a:${renderAggInner(entry)}${histogramFlag(entry)}}`,
-			);
+			flat.push(entry);
 			continue;
 		}
 		const seen = seenInPath.get(entry.nestedPath) ?? new Set<string>();
@@ -1089,19 +1534,14 @@ function renderAggSpecLiteral(aggregations: AggregationEntry[]): string {
 			byPath.set(entry.nestedPath, [entry]);
 		}
 	}
+	return [...flat, ...[...byPath.values()].flat()];
+}
 
-	const groupItems: string[] = [];
-	for (const [path, group] of byPath) {
-		const groupKey = JSON.stringify(nestedAggGroupKey(path));
-		const pathLit = JSON.stringify(path);
-		for (const entry of group) {
-			groupItems.push(
-				`{n:${JSON.stringify(entry.aggName)},g:${groupKey},p:${pathLit},a:${renderAggInner(entry)}${histogramFlag(entry)}}`,
-			);
-		}
+function renderAggSpecItem(entry: AggregationEntry): string {
+	if (!entry.nestedPath) {
+		return `{n:${JSON.stringify(entry.aggName)},a:${renderAggInner(entry)}${histogramFlag(entry)}}`;
 	}
-
-	return `[${[...flatItems, ...groupItems].join(", ")}]`;
+	return `{n:${JSON.stringify(entry.aggName)},g:${JSON.stringify(nestedAggGroupKey(entry.nestedPath))},p:${JSON.stringify(entry.nestedPath)},a:${renderAggInner(entry)}${histogramFlag(entry)}}`;
 }
 
 /**
@@ -1404,4 +1844,7 @@ export const __test = {
 	renderBuildAggsFunction,
 	renderResponseAggregations,
 	DEFAULT_MONOLITHIC_THRESHOLD_BYTES,
+	DEFAULT_FUNCTION_THRESHOLD_BYTES,
+	MAX_PIPELINE_FUNCTIONS,
+	packChunks,
 };

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -166,6 +166,8 @@ export async function $onEmit(
 			trackTotalHitsUpTo: graphqlOptions["track-total-hits-up-to"] ?? 10000,
 			monolithicThresholdBytes:
 				graphqlOptions["monolithic-threshold-bytes"] ?? 32000,
+			functionThresholdBytes:
+				graphqlOptions["function-threshold-bytes"] ?? 32000,
 			autoDateHistogramBuckets:
 				graphqlOptions["auto-date-histogram-buckets"] ??
 				DEFAULT_AUTO_DATE_HISTOGRAM_BUCKETS,
@@ -183,6 +185,17 @@ export async function $onEmit(
 				projection,
 				resolverOptions,
 			);
+			for (const oversized of resolverFile.oversizedFunctions ?? []) {
+				reportDiagnostic(context.program, {
+					code: "pipeline-function-over-threshold",
+					format: {
+						functionName: oversized.functionName,
+						bytes: String(oversized.bytes),
+						threshold: String(oversized.thresholdBytes),
+					},
+					target: projection.projectionModel,
+				});
+			}
 			resolverFiles.push(resolverFile);
 			await emitFile(context.program, {
 				path: resolvePath(context.emitterOutputDir, resolverFile.fileName),

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -24,6 +24,14 @@ export interface GraphQLEmitterOptions {
 	 */
 	"monolithic-threshold-bytes"?: number;
 	/**
+	 * Byte threshold above which a pipeline `prepare` function is split
+	 * further: by workload (query vs aggregations), then by spec entry across
+	 * additional NONE functions, up to AppSync's 10-functions-per-pipeline
+	 * ceiling. Measured against each rendered function. Default: 32000 (32K
+	 * AppSync per-file cap minus headroom).
+	 */
+	"function-threshold-bytes"?: number;
+	/**
 	 * `buckets` for the `auto_date_histogram` emitted when a
 	 * `@aggregatable("date_histogram", ...)` declares no bounds. It is the
 	 * ceiling on returned buckets, so it decides how wide a range still keeps
@@ -175,6 +183,12 @@ export const $lib = createTypeSpecLibrary({
 					"Decorator @filterable requires at least one filter kind argument.",
 			},
 		},
+		"pipeline-function-over-threshold": {
+			severity: "error",
+			messages: {
+				default: paramMessage`Pipeline function "${"functionName"}" renders to ${"bytes"} bytes, over the ${"threshold"}-byte function threshold even after splitting (AppSync rejects APPSYNC_JS files over 32,768 bytes). Reduce the projection's filterable/aggregatable surface, or raise graphql.function-threshold-bytes if the AppSync cap still leaves headroom.`,
+			},
+		},
 		"searchfilter-name-collision": {
 			severity: "error",
 			messages: {
@@ -270,6 +284,11 @@ export const $lib = createTypeSpecLibrary({
 							default: 10000,
 						},
 						"monolithic-threshold-bytes": {
+							type: "number",
+							nullable: true,
+							default: 32000,
+						},
+						"function-threshold-bytes": {
 							type: "number",
 							nullable: true,
 							default: 32000,


### PR DESCRIPTION
## Problem

A pipeline `prepare` over the cap has no further automatic split (README, §Resolver code-size budget). `prepare` is data-dominated — `FILTER_SPEC`/`AGG_SPEC` grow with every searchable/aggregatable field — so a wide enough projection emits an undeployable >32,768-byte function while `tsp compile` stays green and the break lands at AppSync deploy time.

Live case (COS counterparty projection, emitter 2.0.6): the current shape renders `prepare` at 30,426 B (92.9% of the cap); re-adding the trading-account filterability that was cut in June to fit the cap renders **44,167 B (134.8%)** — and the emitter still emits the 2-function pipeline. Section breakdown of that file: FILTER_SPEC 13,374 · AGG_SPEC 17,743 · free-text spec 1,837 · engine 11,213.

## Change

When the rendered `prepare` exceeds the new `graphql.function-threshold-bytes` (default 32000), split it recursively along the same threshold-driven principle as the existing monolithic→pipeline flip:

1. **By workload** — `prepareQuery` (NONE) carries FILTER_SPEC + free-text spec + keyword filters + sort and stashes `ctx.stash.musts/filters/mustNots/sort`; `prepareAggs` (NONE) carries AGG_SPEC and merges its share into `ctx.stash.aggs` (omitted for projections without aggregations).
2. **By spec entry** — a workload function still over the threshold partitions its spec across further functions (`prepareQuery2…`, `prepareAggs2…`), greedily packed on rendered bytes. Shares merge cleanly: bool `filter`/`must_not` members are commutative; aggregation shares merge by key.

The final `search` (OPENSEARCH) function assembles the body from the stash — still one OpenSearch round-trip. A projection at or under the threshold emits **byte-identically to today**; services don't observe the split (no new decorators, no `.tsp` changes, manifest `functions[]` just grows).

Behavioral identity with the unsplit emit is kept deliberately: alias detection reads `AGG_NAMES` (every declared aggregation, not the function's share) and the per-request histogram bucket budget divides by the request-wide selection via `AGG_H_NAMES` (issue #155 semantics preserved).

Bounded by AWS's 10-functions-per-pipeline ceiling (9 NONE + search). A function still over the threshold at the ceiling — or a single oversized spec entry — surfaces as the new `pipeline-function-over-threshold` error diagnostic; the artifact is still emitted so downstream size guards print exact numbers.

## Measured on the live case

Regenerated the COS counterparty projection with the sacrificed filterability re-added, on this branch (defaults):

| file | bytes | % of 32,768 |
| --- | ---: | --- |
| unsplit `fn-prepare.js` (2.0.6) | 44,167 | **134.8% — undeployable** |
| `fn-prepare-query.js` | 24,106 | 73.6% |
| `fn-prepare-aggs.js` | 24,763 | 75.6% |
| `fn-search.js` | 1,473 | 4.5% |
| `resolver.js` (after-mapping, unchanged) | 19,286 | 58.9% |

All three functions pass `aws appsync evaluate-code` (APPSYNC_JS 1.0.0), and the consumer manifest wires unchanged (its construct already maps arbitrary `functions[]`).

## Tests

- Split shape: names/files/dataSources, every file within the threshold, AppSync-safe function names.
- **Behavioral equivalence**: the split pipeline's request handlers run sequentially against one shared ctx and the assembled OpenSearch body deep-equals the unsplit `prepare`'s (clauses compared as multisets — chunk order differs, bool filter context is commutative).
- Histogram budget divides by the request-wide selection across functions; alias fallback fires in every function's share.
- 10-function ceiling + `oversizedFunctions` diagnostics.
- Split output passes `@aws-appsync/eslint-plugin` recommended config.
- Threshold default keeps every existing fixture byte-identical (full suite green, 424 tests).