### PR TITLE
fix: recursively split wide pipeline resolvers under AppSync's 32KB cap

### DIFF
--- a/src/emit-graphql-resolver.test.ts
+++ b/src/emit-graphql-resolver.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { describe, it } from "node:test";
 import type { Type } from "@typespec/compiler";
 import {
+	APPSYNC_FUNCTION_BYTE_LIMIT,
 	DEFAULT_AUTO_DATE_HISTOGRAM_BUCKETS,
 	emitGraphQLResolver,
 	MIN_AUTO_DATE_HISTOGRAM_BUCKETS,
@@ -3708,5 +3709,527 @@ describe("emitGraphQLResolver two-stage emit (issue #112)", () => {
 		} finally {
 			await rm(dir, { recursive: true, force: true });
 		}
+	});
+});
+
+// Issue #173 — the pipeline split is recursive and threshold-driven: it
+// measures every EMITTED function (not the monolithic render) and subdivides
+// the request side until each fits, so a wide @searchProjection can no longer
+// emit an over-cap `prepare` that only fails at AppSync CreateFunction.
+describe("emitGraphQLResolver recursive pipeline split (issue #173)", () => {
+	// `monolithicThresholdBytes: 0` is the "always pipeline" sentinel; the
+	// emitter clamps it to the default per-function target, so a projection
+	// whose single prepare fits stays level 1. These fixtures push past that.
+	const forcePipeline = {
+		defaultPageSize: 20,
+		maxPageSize: 100,
+		trackTotalHitsUpTo: 10000,
+		monolithicThresholdBytes: 0,
+	};
+
+	function lowerFirst(s: string): string {
+		return s[0].toLowerCase() + s.slice(1);
+	}
+
+	// A filter-heavy, aggregation-light sub-model: several @filterable kinds per
+	// field make the FILTER_SPEC + walker the dominant cost, so the query side
+	// is what overflows and drives the level-2/3 split — mirroring the reported
+	// wide "find by nested reference" projection.
+	function filterHeavySub(name: string): ResolvedProjection {
+		return {
+			projectionModel: { name: `${name}SearchDoc` },
+			sourceModel: { name },
+			indexName: name.toLowerCase(),
+			fields: [
+				makeField({
+					name: `${lowerFirst(name)}Id`,
+					keyword: true,
+					filterables: ["term", "terms", "exists", "prefix"],
+				}),
+				makeField({
+					name: "code",
+					keyword: true,
+					filterables: ["term", "terms", "exists", "prefix"],
+				}),
+				makeField({
+					name: "type",
+					keyword: true,
+					filterables: ["term", "term_negate", "terms", "exists"],
+				}),
+				makeField({
+					name: "status",
+					keyword: true,
+					filterables: ["term", "term_negate", "terms", "exists"],
+				}),
+				makeField({ name: "label", filterables: ["prefix", "match"] }),
+				makeField({ name: "note", filterables: ["prefix", "match"] }),
+				makeField({
+					name: "createdAt",
+					filterables: ["range"],
+					type: { kind: "Scalar", name: "utcDateTime" } as unknown as Type,
+				}),
+				makeField({
+					name: "amount",
+					filterables: ["range"],
+					type: { kind: "Scalar", name: "float64" } as unknown as Type,
+					aggregations: ["terms"],
+				}),
+			],
+		} as unknown as ResolvedProjection;
+	}
+
+	function wideProjection(nestedCount: number): ResolvedProjection {
+		const shapes = Array.from({ length: nestedCount }, (_, i) => `Part${i}`);
+		return makeProjection({
+			name: "WidgetSearchDoc",
+			indexName: "widgets",
+			fields: [
+				makeField({
+					name: "widgetId",
+					keyword: true,
+					filterables: ["term", "terms", "exists", "prefix"],
+					aggregations: ["terms"],
+				}),
+				makeField({
+					name: "createdAt",
+					filterables: ["range"],
+					type: { kind: "Scalar", name: "utcDateTime" } as unknown as Type,
+					aggregations: ["min", "max"],
+				}),
+				...shapes.map((shape) =>
+					makeField({
+						name: `${shape.toLowerCase()}s`,
+						nested: true,
+						subProjection: filterHeavySub(shape),
+						filterables: ["exists"],
+						type: {
+							kind: "Model",
+							name: "Array",
+							indexer: { value: { kind: "Model" } },
+						} as unknown as Type,
+					}),
+				),
+			],
+		});
+	}
+
+	function functionsUnderCap(
+		result: EmitResult,
+	): { name: string; bytes: number }[] {
+		return [
+			{ name: "resolver", content: result.content },
+			...result.functions.map((fn) => ({ name: fn.name, content: fn.content })),
+		].map((f) => ({
+			name: f.name,
+			bytes: Buffer.byteLength(f.content, "utf-8"),
+		}));
+	}
+
+	it("level 2: splits an over-cap prepare into prepare-query + prepare-aggs, both NONE, then search on OPENSEARCH", async () => {
+		const result = await emitGraphQLResolver(wideProjection(18), forcePipeline);
+
+		assert.equal(result.mode, "pipeline");
+		assert.deepEqual(
+			result.functions.map((f) => ({ name: f.name, ds: f.dataSource })),
+			[
+				{ name: "prepare-query", ds: "NONE" },
+				{ name: "prepare-aggs", ds: "NONE" },
+				{ name: "search", ds: "OPENSEARCH" },
+			],
+		);
+		// prepare-query owns the FILTER_SPEC + free-text + sort; prepare-aggs owns
+		// the AGG_SPEC; both stash their contribution rather than a whole body.
+		const query = result.functions.find((f) => f.name === "prepare-query");
+		const aggs = result.functions.find((f) => f.name === "prepare-aggs");
+		assert.ok(query?.content.includes("const FILTER_SPEC = ["));
+		assert.ok(query?.content.includes("ctx.stash.filters"));
+		assert.ok(query?.content.includes("ctx.stash.sort"));
+		assert.ok(!query?.content.includes("const AGG_SPEC = ["));
+		assert.ok(aggs?.content.includes("const AGG_SPEC = ["));
+		assert.ok(aggs?.content.includes("ctx.stash.aggs"));
+		// search assembles the body from the stash and issues the one round-trip.
+		const search = result.functions.find((f) => f.name === "search");
+		assert.ok(search?.content.includes("ctx.stash.filters"));
+		assert.ok(search?.content.includes('operation: "GET"'));
+		assert.ok(search?.content.includes("/widgets/_search"));
+	});
+
+	it("level 3: partitions prepare-query across functions when the query workload alone overflows the cap", async () => {
+		const result = await emitGraphQLResolver(wideProjection(24), forcePipeline);
+
+		assert.equal(result.mode, "pipeline");
+		const queryFns = result.functions.filter((f) =>
+			f.name.startsWith("prepare-query"),
+		);
+		assert.ok(
+			queryFns.length >= 2,
+			`expected prepare-query to partition; got ${result.functions
+				.map((f) => f.name)
+				.join(", ")}`,
+		);
+		// The root query function keeps the request-wide work; the partitions
+		// carry only a filter-node slice and append to the shared stash arrays.
+		const root = result.functions.find((f) => f.name === "prepare-query");
+		assert.ok(root?.content.includes("ctx.stash.sort"));
+		assert.ok(root?.content.includes("buildSort"));
+		for (const fn of queryFns.filter((f) => f.name !== "prepare-query")) {
+			assert.ok(
+				fn.content.includes("applyFilterSpec(FILTER_SPEC"),
+				`${fn.name} must translate its filter slice`,
+			);
+			assert.ok(
+				!fn.content.includes("buildSort"),
+				`${fn.name} must not duplicate the sort/size work`,
+			);
+			assert.ok(fn.content.includes("ctx.stash.filters"));
+		}
+		// Every NONE function precedes the single trailing OPENSEARCH search.
+		const searchIndex = result.functions.findIndex(
+			(f) => f.dataSource === "OPENSEARCH",
+		);
+		assert.equal(searchIndex, result.functions.length - 1);
+		assert.equal(
+			result.functions.filter((f) => f.dataSource === "OPENSEARCH").length,
+			1,
+		);
+	});
+
+	it("keeps every emitted function under the 32,768-byte AppSync cap for a wide projection", async () => {
+		for (const nestedCount of [18, 22, 26]) {
+			const result = await emitGraphQLResolver(
+				wideProjection(nestedCount),
+				forcePipeline,
+			);
+			for (const file of functionsUnderCap(result)) {
+				assert.ok(
+					file.bytes < APPSYNC_FUNCTION_BYTE_LIMIT,
+					`${nestedCount}-nested ${file.name} is ${file.bytes} bytes; must stay under ${APPSYNC_FUNCTION_BYTE_LIMIT}. Headroom: ${APPSYNC_FUNCTION_BYTE_LIMIT - file.bytes}.`,
+				);
+			}
+		}
+	});
+
+	// Threads a shared ctx through the split pipeline: every NONE function's
+	// request runs in order (each mutating ctx.stash), then the OPENSEARCH
+	// function assembles and returns the body — the exact runtime contract.
+	function runSplitPipeline(
+		result: EmitResult,
+		info: { selectionSetList: string[] },
+		args: Record<string, unknown> = {},
+	): Record<string, unknown> {
+		const utilStub = {
+			base64Decode: (s: string) => Buffer.from(s, "base64").toString("utf8"),
+			base64Encode: (s: string) => Buffer.from(s, "utf8").toString("base64"),
+			error: (msg: string) => {
+				throw new Error(msg);
+			},
+		};
+		const ctx = { args, info, stash: {} as Record<string, unknown> };
+		function loadRequest(source: string) {
+			const stripped = source
+				.replace(/^import \{ util \} from "@aws-appsync\/utils";?\n?/m, "")
+				.replace(/^export function /gm, "function ");
+			return new Function("util", `${stripped}\nreturn request;`)(utilStub) as (
+				c: unknown,
+			) => { params?: { body?: Record<string, unknown> } };
+		}
+		for (const fn of result.functions) {
+			if (fn.dataSource === "NONE") loadRequest(fn.content)(ctx);
+		}
+		const search = result.functions.find((f) => f.dataSource === "OPENSEARCH");
+		if (!search) throw new Error("split pipeline has no OPENSEARCH function");
+		const ret = loadRequest(search.content)(ctx);
+		if (!ret.params?.body) throw new Error("search produced no body");
+		return ret.params.body;
+	}
+
+	// A bool query's must/filter/must_not clauses are a commutative set, so the
+	// split (which appends per-partition) and the monolithic walk (one FIFO)
+	// may order them differently. Compare as sorted multisets.
+	function canonical(value: unknown): unknown {
+		if (Array.isArray(value)) {
+			return value
+				.map(canonical)
+				.map((v) => JSON.stringify(v))
+				.sort();
+		}
+		if (value && typeof value === "object") {
+			const out: Record<string, unknown> = {};
+			for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+				out[key] = canonical((value as Record<string, unknown>)[key]);
+			}
+			return out;
+		}
+		return value;
+	}
+
+	// A projection that fits monolithic; a 1-byte threshold forces the deepest
+	// split so the two paths can be compared on the same shape.
+	function comparableProjection(): ResolvedProjection {
+		function sub(name: string, fields: ResolvedProjection["fields"]) {
+			return {
+				projectionModel: { name: `${name}SearchDoc` },
+				sourceModel: { name },
+				indexName: name.toLowerCase(),
+				fields,
+			} as unknown as ResolvedProjection;
+		}
+		return makeProjection({
+			name: "WidgetSearchDoc",
+			indexName: "widgets",
+			fields: [
+				makeField({ name: "name", searchable: true }),
+				makeField({
+					name: "widgetId",
+					keyword: true,
+					filterables: ["term", "terms", "exists"],
+					aggregations: ["terms"],
+				}),
+				makeField({
+					name: "createdAt",
+					filterables: ["range"],
+					type: { kind: "Scalar", name: "utcDateTime" } as unknown as Type,
+					aggregations: [
+						"min",
+						"max",
+						{ kind: "date_histogram", options: { interval: "month" } },
+					],
+				}),
+				makeField({
+					name: "parts",
+					nested: true,
+					filterables: ["exists"],
+					type: {
+						kind: "Model",
+						name: "Array",
+						indexer: { value: { kind: "Model" } },
+					} as unknown as Type,
+					subProjection: sub("Part", [
+						makeField({
+							name: "partId",
+							keyword: true,
+							filterables: ["term", "terms", "exists"],
+							aggregations: ["terms"],
+						}),
+						makeField({
+							name: "status",
+							keyword: true,
+							filterables: ["term", "term_negate", "exists"],
+						}),
+						makeField({
+							name: "amount",
+							filterables: ["range"],
+							type: { kind: "Scalar", name: "float64" } as unknown as Type,
+						}),
+						makeField({ name: "label", searchable: true }),
+					]),
+				}),
+				makeField({
+					name: "tags",
+					nested: true,
+					filterables: ["exists"],
+					type: {
+						kind: "Model",
+						name: "Array",
+						indexer: { value: { kind: "Model" } },
+					} as unknown as Type,
+					subProjection: sub("Tag", [
+						makeField({
+							name: "tagId",
+							keyword: true,
+							filterables: ["term", "exists"],
+							aggregations: ["terms"],
+						}),
+						makeField({
+							name: "kind",
+							keyword: true,
+							filterables: ["term", "terms"],
+						}),
+					]),
+				}),
+			],
+		});
+	}
+
+	it("split pipeline assembles a body equivalent to the monolithic path", async () => {
+		const projection = comparableProjection();
+		const monolithic = await emitGraphQLResolver(projection, {
+			...forcePipeline,
+			monolithicThresholdBytes: 32000,
+		});
+		const split = await emitGraphQLResolver(projection, {
+			...forcePipeline,
+			monolithicThresholdBytes: 1,
+		});
+
+		assert.equal(monolithic.mode, "monolithic");
+		assert.equal(split.mode, "pipeline");
+		// The 1-byte threshold drives the split all the way to per-node
+		// partitions, exercising both the query and aggs level-3 paths.
+		assert.ok(
+			split.functions.filter((f) => f.name.startsWith("prepare-query"))
+				.length >= 2,
+		);
+		assert.ok(
+			split.functions.filter((f) => f.name.startsWith("prepare-aggs")).length >=
+				2,
+		);
+
+		const scenarios: {
+			name: string;
+			args: Record<string, unknown>;
+			info: { selectionSetList: string[] };
+		}[] = [
+			{ name: "match_all", args: {}, info: { selectionSetList: [] } },
+			{
+				name: "free-text + multi-field sort",
+				args: {
+					query: "rex",
+					sortBy: [
+						{ field: "createdAt", direction: "DESC" },
+						{ field: "name", direction: "ASC" },
+					],
+				},
+				info: { selectionSetList: [] },
+			},
+			{
+				name: "keyword + root + nested filters",
+				args: {
+					filter: { widgetId: "W1" },
+					searchFilter: {
+						widgetId: "W2",
+						widgetIdIn: ["a", "b"],
+						createdAtGte: "2020",
+						parts: { partId: "P1", statusNot: "X", amountGte: 5, amountLte: 9 },
+						tags: { tagId: "T1", kindIn: ["k1"] },
+					},
+				},
+				info: { selectionSetList: [] },
+			},
+			{
+				name: "nested existence + search_after",
+				args: {
+					after: Buffer.from(JSON.stringify([1, 2]), "utf8").toString("base64"),
+					searchFilter: { partsExists: true, tagsExists: false },
+				},
+				info: { selectionSetList: [] },
+			},
+			{
+				name: "aggregations across partitions",
+				args: {},
+				info: {
+					selectionSetList: [
+						"aggregations",
+						"aggregations/byWidgetId",
+						"aggregations/byCreatedAtOverTime",
+						"aggregations/byPartId",
+						"aggregations/byTagId",
+					],
+				},
+			},
+		];
+
+		for (const scenario of scenarios) {
+			const monoBody = evalRequestBody(
+				monolithic.content,
+				scenario.info,
+				scenario.args,
+			);
+			const splitBody = runSplitPipeline(split, scenario.info, scenario.args);
+			assert.deepEqual(
+				canonical(splitBody),
+				canonical(monoBody),
+				`split body diverges from monolithic for scenario "${scenario.name}"`,
+			);
+		}
+	});
+
+	it("divides the histogram bucket budget once across partitions, matching the monolithic path", async () => {
+		function sub(name: string, fields: ResolvedProjection["fields"]) {
+			return {
+				projectionModel: { name: `${name}SearchDoc` },
+				sourceModel: { name },
+				indexName: name.toLowerCase(),
+				fields,
+			} as unknown as ResolvedProjection;
+		}
+		// Two histograms under different top-level paths land in different aggs
+		// partitions under the deepest split; the per-request budget must still
+		// be divided across both, so the split search — not a partition — owns it.
+		const projection = makeProjection({
+			name: "WidgetSearchDoc",
+			indexName: "widgets",
+			fields: [
+				...Array.from({ length: 6 }, (_, i) =>
+					makeField({
+						name: `root${i}`,
+						type: { kind: "Scalar", name: "utcDateTime" } as unknown as Type,
+						aggregations: [
+							{ kind: "date_histogram", options: { interval: "month" } },
+						],
+					}),
+				),
+				makeField({
+					name: "parts",
+					nested: true,
+					type: {
+						kind: "Model",
+						name: "Array",
+						indexer: { value: { kind: "Model" } },
+					} as unknown as Type,
+					subProjection: sub(
+						"Part",
+						Array.from({ length: 6 }, (_, i) =>
+							makeField({
+								name: `shipped${i}`,
+								type: {
+									kind: "Scalar",
+									name: "utcDateTime",
+								} as unknown as Type,
+								aggregations: [
+									{ kind: "date_histogram", options: { interval: "day" } },
+								],
+							}),
+						),
+					),
+				}),
+			],
+		});
+		const monolithic = await emitGraphQLResolver(projection, {
+			...forcePipeline,
+			monolithicThresholdBytes: 32000,
+		});
+		const split = await emitGraphQLResolver(projection, {
+			...forcePipeline,
+			monolithicThresholdBytes: 1,
+		});
+		assert.equal(monolithic.mode, "monolithic");
+		assert.ok(
+			split.functions.filter((f) => f.name.startsWith("prepare-aggs")).length >=
+				2,
+			"the aggs workload must partition so the cross-partition budget is exercised",
+		);
+
+		// Select every histogram: the budget divides across all 12.
+		const info = {
+			selectionSetList: [
+				"aggregations",
+				...Array.from(
+					{ length: 6 },
+					(_, i) => `aggregations/byRoot${i}OverTime`,
+				),
+				...Array.from(
+					{ length: 6 },
+					(_, i) => `aggregations/byPartShipped${i}OverTime`,
+				),
+			],
+		};
+		const monoBody = evalRequestBody(monolithic.content, info, {});
+		const splitBody = runSplitPipeline(split, info, {});
+		assert.deepEqual(
+			canonical(splitBody.aggs),
+			canonical(monoBody.aggs),
+			"split aggs (with search-side budget division) must match the monolithic aggs",
+		);
 	});
 });

--- a/src/emit-graphql-resolver.ts
+++ b/src/emit-graphql-resolver.ts
@@ -70,6 +70,26 @@ export interface ResolverOptions {
 const DEFAULT_MONOLITHIC_THRESHOLD_BYTES = 32_000;
 
 /**
+ * AppSync's hard per-function code limit. `CreateFunction` rejects any resolver
+ * function whose code exceeds this — a deploy-time `BadRequestException: Code
+ * must be 32768 bytes or less`. The emitter measures every function it emits
+ * against the (smaller) split threshold so the output ships with headroom; the
+ * emitter host also hard-errors compile on any generated function that still
+ * lands over this cap, so the over-limit case can never pass compile silently
+ * (issue #173).
+ */
+export const APPSYNC_FUNCTION_BYTE_LIMIT = 32_768;
+
+/**
+ * AppSync's hard limit on functions attached to one pipeline resolver. The
+ * recursive split (issue #173) stops subdividing here: a projection whose fully
+ * split pipeline still needs more functions than this cannot be emitted, and
+ * the emitter host raises a compile diagnostic rather than emit an
+ * undeployable pipeline.
+ */
+export const MAX_PIPELINE_FUNCTIONS = 10;
+
+/**
  * Per-histogram `buckets` ceiling for a bounds-less `auto_date_histogram`
  * (issue #150). This is the most any single histogram gets; the emitted
  * `buildAggs` lowers it when a request selects several histograms so their sum
@@ -167,6 +187,14 @@ export async function emitGraphQLResolver(
 
 	const threshold =
 		options.monolithicThresholdBytes ?? DEFAULT_MONOLITHIC_THRESHOLD_BYTES;
+	// The per-function target the pipeline split (issue #173) measures each
+	// emitted function against. It is the same knob as the monolithic gate, so
+	// tuning the threshold tightens both. `0` is the "always pipeline" sentinel
+	// the tests use to force the pipeline shape; it must not force the split to
+	// subdivide every function to zero bytes, so a non-positive threshold falls
+	// back to the default per-function target.
+	const functionThreshold =
+		threshold > 0 ? threshold : DEFAULT_MONOLITHIC_THRESHOLD_BYTES;
 
 	// Stage 1 of the two-stage emit (issue #112): render the monolithic UNIT
 	// shape and measure. Under the threshold we ship monolithic — saves ~50ms
@@ -195,6 +223,7 @@ export async function emitGraphQLResolver(
 
 	// Pipeline fallback. The resolver-level file holds the after-mapping;
 	// prepare runs on NONE, search on OPENSEARCH (issue #105).
+	const resolverContent = renderResolver(aggregations, options);
 	const prepareContent = renderPrepareFunction(
 		textFields,
 		keywordFields,
@@ -203,29 +232,329 @@ export async function emitGraphQLResolver(
 		searchFilterShape,
 		options,
 	);
-	const searchContent = renderSearchFunction(projection.indexName);
-	const resolverContent = renderResolver(aggregations, options);
+
+	// Level 1: the single prepare fits the per-function target, so ship the
+	// original two-function shape byte-for-byte. Only when the whole request
+	// side overflows the cap does the recursive split take over (issue #173).
+	if (Buffer.byteLength(prepareContent, "utf-8") <= functionThreshold) {
+		return {
+			queryFieldName,
+			mode: "pipeline",
+			fileName: `${baseName}-resolver.js`,
+			content: resolverContent,
+			functions: [
+				{
+					name: "prepare",
+					fileName: `${baseName}-fn-prepare.js`,
+					content: prepareContent,
+					dataSource: "NONE",
+				},
+				{
+					name: "search",
+					fileName: `${baseName}-fn-search.js`,
+					content: renderSearchFunction(projection.indexName),
+					dataSource: "OPENSEARCH",
+				},
+			],
+		};
+	}
+
+	// Levels 2/3: split the request side across NONE functions that each
+	// contribute to shared ctx.stash structures, and let the OPENSEARCH `search`
+	// function assemble the body from them (issue #173).
+	const functions = buildSplitPipeline({
+		baseName,
+		indexName: projection.indexName,
+		textFields,
+		keywordFields,
+		textSortFields,
+		aggregations,
+		searchFilterShape,
+		options,
+		functionThreshold,
+	});
 
 	return {
 		queryFieldName,
 		mode: "pipeline",
 		fileName: `${baseName}-resolver.js`,
 		content: resolverContent,
-		functions: [
+		functions,
+	};
+}
+
+interface SplitPipelineInput {
+	baseName: string;
+	indexName: string;
+	textFields: TextFieldCollection;
+	keywordFields: string[];
+	textSortFields: string[];
+	aggregations: AggregationEntry[];
+	searchFilterShape: SearchFilterShape | undefined;
+	options: ResolverOptions;
+	functionThreshold: number;
+}
+
+/**
+ * Builds the level-2/3 pipeline: query-side NONE functions, aggs-side NONE
+ * functions, and a trailing OPENSEARCH `search` function that assembles the
+ * request body from ctx.stash (issue #173).
+ *
+ * Ordering: every NONE function contributes commutatively to shared
+ * ctx.stash arrays/objects (`musts`/`filters`/`mustNots`/`aggs`), so they may
+ * run in any relative order; `search` runs last because its result is the OS
+ * response the resolver after-mapping reads at ctx.prev.result.
+ */
+function buildSplitPipeline(
+	input: SplitPipelineInput,
+): EmittedPipelineFunction[] {
+	const {
+		baseName,
+		indexName,
+		textFields,
+		keywordFields,
+		textSortFields,
+		aggregations,
+		searchFilterShape,
+		options,
+		functionThreshold,
+	} = input;
+
+	const nodes = searchFilterShape ? searchFilterShape.nodes : [];
+	const queryFunctions = buildQueryFunctions(
+		baseName,
+		nodes,
+		textFields,
+		keywordFields,
+		textSortFields,
+		options,
+		functionThreshold,
+	);
+
+	const aggNames = collectAggNames(aggregations);
+	const aggFunctions =
+		aggregations.length === 0
+			? []
+			: buildAggsFunctions(baseName, aggregations, aggNames, functionThreshold);
+
+	const searchContent = renderSplitSearchFunction(
+		indexName,
+		aggregations,
+		options,
+	);
+
+	return [
+		...queryFunctions,
+		...aggFunctions,
+		{
+			name: "search",
+			fileName: `${baseName}-fn-search.js`,
+			content: searchContent,
+			dataSource: "OPENSEARCH",
+		},
+	];
+}
+
+/**
+ * Level-2 query workload as one NONE function, or — when that single function
+ * still overflows the cap — level-3 partition by top-level filter node: a root
+ * function carrying the free-text/keyword/sort work plus the root-level filter
+ * leaves, and additional functions each carrying a slice of the top-level
+ * nested/object filter nodes. Each appends to shared ctx.stash filter arrays,
+ * which the clauses are commutative across (issue #173).
+ */
+function buildQueryFunctions(
+	baseName: string,
+	nodes: FilterSpecNode[],
+	textFields: TextFieldCollection,
+	keywordFields: string[],
+	textSortFields: string[],
+	options: ResolverOptions,
+	functionThreshold: number,
+): EmittedPipelineFunction[] {
+	const single = renderQueryFunction(
+		nodes,
+		true,
+		textFields,
+		keywordFields,
+		textSortFields,
+		options,
+	);
+	if (Buffer.byteLength(single, "utf-8") <= functionThreshold) {
+		return [
 			{
-				name: "prepare",
-				fileName: `${baseName}-fn-prepare.js`,
-				content: prepareContent,
+				name: "prepare-query",
+				fileName: `${baseName}-fn-prepare-query.js`,
+				content: single,
 				dataSource: "NONE",
 			},
+		];
+	}
+
+	const rootLeaves = nodes.filter(
+		(n) => n.kind !== "nested" && n.kind !== "object",
+	);
+	const groupNodes = nodes.filter(
+		(n) => n.kind === "nested" || n.kind === "object",
+	);
+
+	const rootContent = renderQueryFunction(
+		rootLeaves,
+		true,
+		textFields,
+		keywordFields,
+		textSortFields,
+		options,
+	);
+	const functions: EmittedPipelineFunction[] = [
+		{
+			name: "prepare-query",
+			fileName: `${baseName}-fn-prepare-query.js`,
+			content: rootContent,
+			dataSource: "NONE",
+		},
+	];
+
+	const bins = packByThreshold(
+		groupNodes,
+		(bin) =>
+			renderQueryFunction(
+				bin,
+				false,
+				textFields,
+				keywordFields,
+				textSortFields,
+				options,
+			),
+		functionThreshold,
+	);
+	bins.forEach((bin, i) => {
+		functions.push({
+			name: `prepare-query-${i + 1}`,
+			fileName: `${baseName}-fn-prepare-query-${i + 1}.js`,
+			content: renderQueryFunction(
+				bin,
+				false,
+				textFields,
+				keywordFields,
+				textSortFields,
+				options,
+			),
+			dataSource: "NONE",
+		});
+	});
+	return functions;
+}
+
+/**
+ * Level-2 aggs workload as one NONE function, or — when it overflows the cap —
+ * level-3 partition by top-level nested path. Each partition merges its slice
+ * into the shared ctx.stash.aggs object; a name from a sibling partition is
+ * distinguished from a real alias via the full ALL_AGG_NAMES list every
+ * partition carries, so the issue-#150 narrowing survives the split (#173).
+ */
+function buildAggsFunctions(
+	baseName: string,
+	aggregations: AggregationEntry[],
+	aggNames: string[],
+	functionThreshold: number,
+): EmittedPipelineFunction[] {
+	const single = renderAggsFunction(aggregations, aggNames);
+	if (Buffer.byteLength(single, "utf-8") <= functionThreshold) {
+		return [
 			{
-				name: "search",
-				fileName: `${baseName}-fn-search.js`,
-				content: searchContent,
-				dataSource: "OPENSEARCH",
+				name: "prepare-aggs",
+				fileName: `${baseName}-fn-prepare-aggs.js`,
+				content: single,
+				dataSource: "NONE",
 			},
-		],
-	};
+		];
+	}
+
+	const groups = partitionAggregationsByTopPath(aggregations);
+	const bins = packByThreshold(
+		groups,
+		(bin) => renderAggsFunction(bin.flat(), aggNames),
+		functionThreshold,
+	);
+	return bins.map((bin, i) => {
+		const entries = bin.flat();
+		return {
+			name: i === 0 ? "prepare-aggs" : `prepare-aggs-${i}`,
+			fileName:
+				i === 0
+					? `${baseName}-fn-prepare-aggs.js`
+					: `${baseName}-fn-prepare-aggs-${i}.js`,
+			content: renderAggsFunction(entries, aggNames),
+			dataSource: "NONE",
+		};
+	});
+}
+
+/**
+ * Greedy first-fit bin packing: append each atom to the current bin while the
+ * rendered bin stays under the threshold, else start a new bin. A single atom
+ * whose rendered function alone exceeds the threshold gets its own bin — the
+ * emitter host then hard-errors on that over-cap file, which is the correct
+ * outcome for a projection no split can fit (issue #173).
+ */
+function packByThreshold<T>(
+	atoms: T[],
+	render: (bin: T[]) => string,
+	functionThreshold: number,
+): T[][] {
+	const bins: T[][] = [];
+	let current: T[] = [];
+	for (const atom of atoms) {
+		const candidate = [...current, atom];
+		if (Buffer.byteLength(render(candidate), "utf-8") <= functionThreshold) {
+			current = candidate;
+			continue;
+		}
+		if (current.length > 0) {
+			bins.push(current);
+		}
+		current = [atom];
+	}
+	if (current.length > 0) {
+		bins.push(current);
+	}
+	return bins;
+}
+
+/**
+ * Groups aggregation entries by their top-level nested path so a level-3 aggs
+ * split partitions along the same nested boundaries the query split uses. Flat
+ * aggregations (no nested path) group under the root key; nested aggregations
+ * group by the first path segment, keeping every aggregation that shares a
+ * `_<path>` wrapper in one partition so the wrapper is assembled by a single
+ * function.
+ */
+function partitionAggregationsByTopPath(
+	aggregations: AggregationEntry[],
+): AggregationEntry[][] {
+	const groups = new Map<string, AggregationEntry[]>();
+	for (const entry of aggregations) {
+		const key = entry.nestedPath ? entry.nestedPath.split(".")[0] : "";
+		const list = groups.get(key);
+		if (list) {
+			list.push(entry);
+		} else {
+			groups.set(key, [entry]);
+		}
+	}
+	return [...groups.values()];
+}
+
+function collectAggNames(aggregations: AggregationEntry[]): string[] {
+	const seen = new Set<string>();
+	const names: string[] = [];
+	for (const entry of aggregations) {
+		if (seen.has(entry.aggName)) continue;
+		seen.add(entry.aggName);
+		names.push(entry.aggName);
+	}
+	return names;
 }
 
 /**
@@ -932,6 +1261,291 @@ ${renderSearchBodyGuard("ctx.result", "\t")}	return ctx.result;
 }
 
 /**
+ * Query-side NONE function for the level-2/3 split (issue #173). Builds its
+ * slice of the `must`/`filter`/`must_not` clause arrays and appends them to the
+ * shared `ctx.stash` arrays the OPENSEARCH `search` function later folds into a
+ * bool query. The clauses are commutative, so a projection's filter nodes can
+ * be spread across several of these without changing the assembled query.
+ *
+ * `isRoot` marks the one function that also owns the request-wide work: page
+ * size, `search_after`, `buildSort`, the free-text `must`, and the keyword-term
+ * `filter`s. Non-root functions carry only a slice of the top-level nested /
+ * object filter nodes and the walker that translates them.
+ */
+function renderQueryFunction(
+	nodes: FilterSpecNode[],
+	isRoot: boolean,
+	textFields: TextFieldCollection,
+	keywordFields: string[],
+	textSortFields: string[],
+	options: ResolverOptions,
+): string {
+	const filterSpecLiteral = stringifySpec(nodes);
+	const slotsLiteral = `[${"null,".repeat(FILTER_WORK_SLOT_COUNT).slice(0, -1)}]`;
+	const applyFilterSpecFunction = renderApplyFilterSpecFunction(slotsLiteral);
+
+	if (!isRoot) {
+		return `import { util } from "@aws-appsync/utils";
+
+const FILTER_SPEC = ${filterSpecLiteral};
+
+export function request(ctx) {
+	const searchFilter = ctx.args.searchFilter;
+	const filters = ctx.stash.filters || [];
+	const mustNots = ctx.stash.mustNots || [];
+	if (searchFilter) {
+		applyFilterSpec(FILTER_SPEC, searchFilter, filters, mustNots);
+	}
+	ctx.stash.filters = filters;
+	ctx.stash.mustNots = mustNots;
+	return { payload: null };
+}
+
+export function response(ctx) {
+	return ctx.result;
+}
+
+${applyFilterSpecFunction}`;
+	}
+
+	const textQueryPush = renderTextQueryPush(textFields);
+	const textSpecDeclaration = renderTextSpecDeclaration(textFields);
+	const nestedTextHelper = renderNestedTextHelper(textFields);
+	const keywordFieldsLiteral = JSON.stringify(keywordFields);
+	const textSortFieldsLiteral = JSON.stringify(textSortFields);
+	const buildSortFunction = renderBuildSortFunction();
+
+	return `import { util } from "@aws-appsync/utils";
+
+const FILTER_SPEC = ${filterSpecLiteral};
+
+export function request(ctx) {
+	const args = ctx.args;
+	const size = Math.min(args.first || ${options.defaultPageSize}, ${options.maxPageSize});
+	const searchAfter = args.after ? JSON.parse(util.base64Decode(args.after)) : undefined;
+
+	const musts = ctx.stash.musts || [];
+	const filters = ctx.stash.filters || [];
+	const mustNots = ctx.stash.mustNots || [];
+	buildQuery(args.query, args.filter, args.searchFilter, musts, filters, mustNots);
+	ctx.stash.musts = musts;
+	ctx.stash.filters = filters;
+	ctx.stash.mustNots = mustNots;
+
+	ctx.stash.sort = buildSort(args.sortBy);
+	ctx.stash.size = size;
+	if (searchAfter) {
+		ctx.stash.searchAfter = searchAfter;
+	}
+	return { payload: null };
+}
+
+export function response(ctx) {
+	return ctx.result;
+}
+${textSpecDeclaration}${nestedTextHelper}
+function buildQuery(queryText, filter, searchFilter, musts, filters, mustNots) {
+	if (queryText) {
+${textQueryPush}
+	}
+
+	const keywordFields = ${keywordFieldsLiteral};
+	if (filter) {
+		for (const field of keywordFields) {
+			if (filter[field] != null) {
+				filters.push({ term: { [field]: filter[field] } });
+			}
+		}
+	}
+
+	if (searchFilter) {
+		applyFilterSpec(FILTER_SPEC, searchFilter, filters, mustNots);
+	}
+}
+
+const TEXT_SORT_FIELDS = ${textSortFieldsLiteral};
+
+${buildSortFunction}
+${applyFilterSpecFunction}`;
+}
+
+/**
+ * Aggs-side NONE function for the level-2/3 split (issue #173). Projects the
+ * caller's selection onto its slice of AGG_SPEC and merges the result into the
+ * shared `ctx.stash.aggs` object the `search` function attaches to the body.
+ *
+ * `allAggNames` is the projection's full set of aggregation names, not just
+ * this partition's. The issue-#150 alias detection reads any first path segment
+ * naming no declared aggregation as an alias and widens to send everything; a
+ * partition that only knew its own slice would misread a sibling partition's
+ * aggregation as an alias, so every partition carries the full list.
+ *
+ * The per-request histogram bucket budget (issue #155) is applied once, in
+ * `search`, across the assembled aggs — a partition cannot divide the budget
+ * correctly because it sees only its own histograms.
+ */
+function renderAggsFunction(
+	aggregations: AggregationEntry[],
+	allAggNames: string[],
+): string {
+	const aggSpecDeclaration = renderAggSpecDeclaration(aggregations);
+	const allNamesLiteral = JSON.stringify(allAggNames);
+
+	return `import { util } from "@aws-appsync/utils";
+${aggSpecDeclaration}
+const ALL_AGG_NAMES = ${allNamesLiteral};
+
+export function request(ctx) {
+	const aggs = ctx.stash.aggs || {};
+	buildAggs(ctx.info.selectionSetList, aggs);
+	ctx.stash.aggs = aggs;
+	return { payload: null };
+}
+
+export function response(ctx) {
+	return ctx.result;
+}
+
+function buildAggs(selectionSetList, aggs) {
+	let aliased = false;
+	for (const path of selectionSetList) {
+		if (path.indexOf("aggregations/") === 0) {
+			const rest = path.substring(13);
+			const slash = rest.indexOf("/");
+			const name = slash < 0 ? rest : rest.substring(0, slash);
+			if (ALL_AGG_NAMES.indexOf(name) < 0 && name !== "__typename") aliased = true;
+		}
+	}
+	for (const spec of AGG_SPEC) {
+		if (aliased || selectionSetList.indexOf("aggregations/" + spec.n) >= 0) {
+			if (spec.g) {
+				const group = aggs[spec.g] || { nested: { path: spec.p }, aggs: {} };
+				group.aggs[spec.n] = spec.a;
+				aggs[spec.g] = group;
+			} else {
+				aggs[spec.n] = spec.a;
+			}
+		}
+	}
+}
+`;
+}
+
+/**
+ * OPENSEARCH function for the level-2/3 split (issue #173). The query and aggs
+ * NONE functions ahead of it have written their contributions to `ctx.stash`;
+ * this function folds them into one OpenSearch request body and issues the
+ * single round-trip. It also owns the per-request histogram bucket budget
+ * (issue #155), applied here because only the assembled aggs see every selected
+ * histogram at once. Response handling matches the level-1 `search` function.
+ */
+function renderSplitSearchFunction(
+	indexName: string,
+	aggregations: AggregationEntry[],
+	options: ResolverOptions,
+): string {
+	const hasAuto = aggregations.some(usesAutoDateHistogram);
+	const hasAggs = aggregations.length > 0;
+
+	const aggsAssembly = hasAggs
+		? `
+	const aggs = ctx.stash.aggs;
+	if (aggs && Object.keys(aggs).length > 0) {
+${hasAuto ? "\t\tnormalizeAggBudget(aggs);\n" : ""}		body.aggs = aggs;
+	}
+`
+		: "";
+
+	const budgetHelper = hasAuto ? renderNormalizeAggBudgetFunction(options) : "";
+
+	return `import { util } from "@aws-appsync/utils";
+
+export function request(ctx) {
+	const musts = ctx.stash.musts || [];
+	const filters = ctx.stash.filters || [];
+	const mustNots = ctx.stash.mustNots || [];
+
+	let query;
+	if (musts.length === 0 && filters.length === 0 && mustNots.length === 0) {
+		query = { match_all: {} };
+	} else {
+		query = {
+			bool: {
+				...(musts.length > 0 ? { must: musts } : {}),
+				...(filters.length > 0 ? { filter: filters } : {}),
+				...(mustNots.length > 0 ? { must_not: mustNots } : {}),
+			},
+		};
+	}
+
+	const body = {
+		size: ctx.stash.size + 1,
+		track_total_hits: ${options.trackTotalHitsUpTo},
+		sort: ctx.stash.sort,
+		query,
+	};
+
+	if (ctx.stash.searchAfter) {
+		body.search_after = ctx.stash.searchAfter;
+	}
+${aggsAssembly}
+	return {
+		operation: "GET",
+		path: "/${indexName}/_search",
+		params: { body },
+	};
+}
+
+export function response(ctx) {
+	if (ctx.error) {
+		return util.error(ctx.error.message, ctx.error.type, null, ctx.result);
+	}
+${renderSearchBodyGuard("ctx.result", "\t")}	return ctx.result;
+}
+${budgetHelper}`;
+}
+
+/**
+ * Divides the soft per-request bucket budget (issue #155) across every
+ * `auto_date_histogram` in the assembled aggs — top-level and one level down
+ * inside a nested wrapper's `aggs`. Emitted into the split `search` function so
+ * the division sees all selected histograms regardless of how the aggs
+ * partitions were laid out (issue #173).
+ */
+function renderNormalizeAggBudgetFunction(options: ResolverOptions): string {
+	const cap =
+		options.autoDateHistogramBuckets ?? DEFAULT_AUTO_DATE_HISTOGRAM_BUCKETS;
+	return `
+function normalizeAggBudget(aggs) {
+	const histograms = [];
+	const keys = Object.keys(aggs);
+	for (const key of keys) {
+		const node = aggs[key];
+		if (node.auto_date_histogram) {
+			histograms.push(node.auto_date_histogram);
+		} else if (node.aggs) {
+			const innerKeys = Object.keys(node.aggs);
+			for (const innerKey of innerKeys) {
+				const inner = node.aggs[innerKey];
+				if (inner.auto_date_histogram) {
+					histograms.push(inner.auto_date_histogram);
+				}
+			}
+		}
+	}
+	if (histograms.length > 0) {
+		let budget = Math.floor(${PER_REQUEST_BUCKET_BUDGET} / histograms.length);
+		if (budget > ${cap}) budget = ${cap};
+		if (budget < ${MIN_AUTO_DATE_HISTOGRAM_BUCKETS}) budget = ${MIN_AUTO_DATE_HISTOGRAM_BUCKETS};
+		for (const h of histograms) {
+			h.buckets = budget;
+		}
+	}
+}
+`;
+}
+
+/**
  * Guard an OpenSearch response body before anything dereferences `.hits`.
  *
  * Covers three failure shapes the datasource can hand back without setting
@@ -1399,9 +2013,13 @@ export const __test = {
 	renderPrepareFunction,
 	renderSearchFunction,
 	renderMonolithicResolver,
+	renderQueryFunction,
+	renderAggsFunction,
+	renderSplitSearchFunction,
 	renderAggsAssignment,
 	renderAggSpecLiteral,
 	renderBuildAggsFunction,
 	renderResponseAggregations,
+	partitionAggregationsByTopPath,
 	DEFAULT_MONOLITHIC_THRESHOLD_BYTES,
 };

--- a/src/emitter.test.ts
+++ b/src/emitter.test.ts
@@ -754,3 +754,126 @@ describe("reportDemotedProjections (issue #157)", () => {
 		);
 	});
 });
+
+// Issue #173 — the split ships fitting output for realistic projections, but a
+// projection wide enough that even the fully split pipeline can't fit must fail
+// compile, not emit an undeployable resolver that only breaks at AppSync
+// CreateFunction. Two guards: any AppSync function file over the 32,768-byte
+// code cap, and a pipeline over AppSync's 10-function-per-resolver limit.
+const TOO_LARGE_CODE =
+	"@kattebak/typespec-opensearch-emitter/resolver-function-too-large";
+const TOO_MANY_CODE =
+	"@kattebak/typespec-opensearch-emitter/pipeline-too-many-functions";
+
+describe("assertResolverFilesFit (issue #173)", () => {
+	// runner.program is inaccessible until a compile/diagnose runs; a trivial
+	// source gives an empty program the guard can report onto.
+	async function emptyProgram() {
+		const runner = await createRunner();
+		await runner.diagnose("model Noop {}");
+		return runner.program;
+	}
+
+	function resolverFile(
+		functions: { name: string; fileName: string; content: string }[],
+		content = "// after-mapping\n",
+	) {
+		return {
+			queryFieldName: "searchWidget",
+			mode: "pipeline" as const,
+			fileName: "widget-search-doc-resolver.js",
+			content,
+			functions: functions.map((fn) => ({
+				...fn,
+				dataSource: "NONE" as const,
+			})),
+		};
+	}
+
+	it("hard-errors when a generated function exceeds the 32,768-byte AppSync cap", async () => {
+		const program = await emptyProgram();
+		const oversized = "x".repeat(33_000);
+		__test.assertResolverFilesFit(
+			program,
+			"WidgetSearchDoc",
+			resolverFile([
+				{
+					name: "prepare-query-1",
+					fileName: "widget-search-doc-fn-prepare-query-1.js",
+					content: oversized,
+				},
+			]),
+		);
+
+		const relevant = program.diagnostics.filter(
+			(d) => d.code === TOO_LARGE_CODE,
+		);
+		assert.equal(relevant.length, 1);
+		assert.equal(relevant[0].severity, "error");
+		assert.ok(
+			relevant[0].message.includes("widget-search-doc-fn-prepare-query-1.js"),
+		);
+		assert.ok(relevant[0].message.includes("33000"));
+	});
+
+	it("hard-errors when the resolver-level file itself exceeds the cap", async () => {
+		const program = await emptyProgram();
+		__test.assertResolverFilesFit(
+			program,
+			"WidgetSearchDoc",
+			resolverFile([], "y".repeat(40_000)),
+		);
+		assert.equal(
+			program.diagnostics.filter((d) => d.code === TOO_LARGE_CODE).length,
+			1,
+		);
+	});
+
+	it("hard-errors when the split needs more than 10 pipeline functions", async () => {
+		const program = await emptyProgram();
+		const functions = Array.from({ length: 11 }, (_, i) => ({
+			name: `prepare-query-${i}`,
+			fileName: `widget-search-doc-fn-prepare-query-${i}.js`,
+			content: "// small\n",
+		}));
+		__test.assertResolverFilesFit(
+			program,
+			"WidgetSearchDoc",
+			resolverFile(functions),
+		);
+
+		const relevant = program.diagnostics.filter(
+			(d) => d.code === TOO_MANY_CODE,
+		);
+		assert.equal(relevant.length, 1);
+		assert.equal(relevant[0].severity, "error");
+		assert.ok(relevant[0].message.includes("WidgetSearchDoc"));
+		assert.ok(relevant[0].message.includes("11"));
+	});
+
+	it("stays silent when every function fits and the pipeline is within the function limit", async () => {
+		const program = await emptyProgram();
+		__test.assertResolverFilesFit(
+			program,
+			"WidgetSearchDoc",
+			resolverFile([
+				{
+					name: "prepare-query",
+					fileName: "widget-search-doc-fn-prepare-query.js",
+					content: "// under cap\n",
+				},
+				{
+					name: "search",
+					fileName: "widget-search-doc-fn-search.js",
+					content: "// under cap\n",
+				},
+			]),
+		);
+		assert.equal(
+			program.diagnostics.filter(
+				(d) => d.code === TOO_LARGE_CODE || d.code === TOO_MANY_CODE,
+			).length,
+			0,
+		);
+	});
+});

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -4,7 +4,7 @@ import type {
 	Namespace,
 	Program,
 } from "@typespec/compiler";
-import { emitFile, resolvePath } from "@typespec/compiler";
+import { emitFile, NoTarget, resolvePath } from "@typespec/compiler";
 import { isSearchProjection } from "./decorators.js";
 import {
 	collectSubProjections,
@@ -12,9 +12,11 @@ import {
 	toDocTypeFileName,
 } from "./emit-doc-type.js";
 import {
+	APPSYNC_FUNCTION_BYTE_LIMIT,
 	DEFAULT_AUTO_DATE_HISTOGRAM_BUCKETS,
 	type EmittedResolverFile,
 	emitGraphQLResolver,
+	MAX_PIPELINE_FUNCTIONS,
 } from "./emit-graphql-resolver.js";
 import { emitGraphQLSdl, resolveDirectives } from "./emit-graphql-sdl.js";
 import { emitIndex } from "./emit-index.js";
@@ -184,6 +186,11 @@ export async function $onEmit(
 				resolverOptions,
 			);
 			resolverFiles.push(resolverFile);
+			assertResolverFilesFit(
+				context.program,
+				projection.projectionModel.name,
+				resolverFile,
+			);
 			await emitFile(context.program, {
 				path: resolvePath(context.emitterOutputDir, resolverFile.fileName),
 				content: resolverFile.content,
@@ -530,6 +537,49 @@ function generateGraphQLManifest(
 }
 
 /**
+ * Issue #173 — hard-fail compile when the emitted resolver code cannot deploy,
+ * so the over-cap case can never pass compile silently and only fail later at
+ * AppSync `CreateFunction`. Two conditions: any generated AppSync function file
+ * (the resolver-level after-mapping and every pipeline function) over the
+ * 32,768-byte per-function code limit, and a pipeline needing more functions
+ * than AppSync allows on one resolver. Both mean the recursive split ran out of
+ * room and the projection must shed filter/aggregation surface.
+ */
+function assertResolverFilesFit(
+	program: Program,
+	projectionName: string,
+	resolverFile: EmittedResolverFile,
+): void {
+	const files = [
+		{ fileName: resolverFile.fileName, content: resolverFile.content },
+		...resolverFile.functions.map((fn) => ({
+			fileName: fn.fileName,
+			content: fn.content,
+		})),
+	];
+	for (const file of files) {
+		const bytes = Buffer.byteLength(file.content, "utf-8");
+		if (bytes > APPSYNC_FUNCTION_BYTE_LIMIT) {
+			reportDiagnostic(program, {
+				code: "resolver-function-too-large",
+				format: { file: file.fileName, bytes: String(bytes) },
+				target: NoTarget,
+			});
+		}
+	}
+	if (resolverFile.functions.length > MAX_PIPELINE_FUNCTIONS) {
+		reportDiagnostic(program, {
+			code: "pipeline-too-many-functions",
+			format: {
+				name: projectionName,
+				count: String(resolverFile.functions.length),
+			},
+			target: NoTarget,
+		});
+	}
+}
+
+/**
  * Issue #157 — `@searchProjection` states an intent for top-level emission.
  * Without `@indexName` that intent is discarded, and the result is
  * byte-identical to an undecorated model, so the demotion is invisible in the
@@ -553,6 +603,7 @@ function reportDemotedProjections(
 export const __test = {
 	collectProjectionModels,
 	reportDemotedProjections,
+	assertResolverFilesFit,
 	isCandidateModel,
 	isTemplateDeclaration,
 	serializeProjections,

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -175,6 +175,18 @@ export const $lib = createTypeSpecLibrary({
 					"Decorator @filterable requires at least one filter kind argument.",
 			},
 		},
+		"resolver-function-too-large": {
+			severity: "error",
+			messages: {
+				default: paramMessage`Generated AppSync resolver function "${"file"}" is ${"bytes"} bytes, over AppSync's hard 32,768-byte per-function code limit. The pipeline split could not reduce it further — the projection concentrates too much filter/aggregation work in a single nested path. Reduce the @filterable/@aggregatable surface on that path, or split the projection.`,
+			},
+		},
+		"pipeline-too-many-functions": {
+			severity: "error",
+			messages: {
+				default: paramMessage`Projection "${"name"}" needs ${"count"} pipeline functions after the resolver split, over AppSync's limit of 10 functions per pipeline resolver. Reduce the @filterable/@aggregatable surface, or split the projection into narrower documents.`,
+			},
+		},
 		"searchfilter-name-collision": {
 			severity: "error",
 			messages: {


### PR DESCRIPTION
## What the emitter now guarantees

Every emitted AppSync pipeline function stays under AppSync's hard 32,768-byte per-function code limit, or compile fails. A wide `@searchProjection` can no longer emit an over-cap `*-fn-prepare.js` that passes `tsp compile` and only fails later at `CreateFunction` with `BadRequestException: Code must be 32768 bytes or less`.

## How

The split decision measured only the monolithic render, then emitted a fixed two-function pipeline `[prepare, search]`. `prepare` carried the entire `FILTER_SPEC` + `AGG_SPEC` payload, its emitted size was never checked, and for a filter/aggregation-heavy projection it shipped far over the cap.

The split is now recursive and threshold-driven, measuring each emitted function:

1. **Level 1** — unchanged two-function `[prepare, search]` while `prepare` fits. Output for existing projections is byte-identical.
2. **Level 2 (by workload)** — `prepare` splits into `prepare-query` (FILTER_SPEC + free-text + sort) and `prepare-aggs` (AGG_SPEC), both NONE; `search` assembles the request body from `ctx.stash`. Still one OpenSearch round-trip.
3. **Level 3 (by nested group)** — a workload function still over the cap partitions by top-level nested path across additional NONE functions that append to shared `ctx.stash` structures (`filters`, `must_not`, `aggs`). The clauses are commutative, so `search` merges partial contributions into an equivalent query.

The per-request histogram bucket budget moves to `search`, which sees every selected histogram at once regardless of how the aggs partitions were laid out. Partitioned aggs functions carry the full aggregation-name list so the alias-narrowing behaviour survives the split.

Two independent compile guards close the silent-failure gap: a hard error on any generated resolver function over 32,768 bytes, and a hard error on a pipeline needing more than AppSync's 10 functions per resolver.

Driven entirely off the existing `graphql.monolithic-threshold-bytes` option — no new decorators.

## Per-function byte counts (wide repro fixture)

A filter-heavy projection with N nested sub-models. Without the split, the single `prepare` at N=24 is **38,867 bytes** — over the cap, the reported bug. With the split every function fits:

| N nested | shape | function sizes (bytes) |
|---|---|---|
| 16 | level 1 | prepare **30,489**, search 732, resolver 3,752 |
| 18 | level 2 | prepare-query **29,847**, prepare-aggs 3,039, search 1,454, resolver 4,054 |
| 24 | level 3 | prepare-query 11,789, prepare-query-1 **31,237**, prepare-query-2 8,391, prepare-aggs 3,669, search 1,454, resolver 4,960 |

Every function stays under 32,768 bytes.

## Tests

- Level-2 and level-3 split shapes, and every emitted function under the cap across widths.
- The split pipeline's assembled request body is equivalent (order-insensitive over commutative bool clauses) to the monolithic path across free-text, sort, keyword/root/nested filters, nested-existence, cursor, and cross-partition aggregation scenarios.
- The per-request histogram bucket budget divides once across partitions, matching the monolithic path.
- The 32,768-byte hard error and the 10-function hard error fire when splitting cannot succeed.

Fixes #173
