### PR TITLE
fix(graphql): tolerate index drift in the search response

### DIFF
--- a/src/emit-graphql-resolver.test.ts
+++ b/src/emit-graphql-resolver.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { describe, it } from "node:test";
 import type { Type } from "@typespec/compiler";
 import {
+	__test,
 	APPSYNC_FUNCTION_BYTE_LIMIT,
 	DEFAULT_AUTO_DATE_HISTOGRAM_BUCKETS,
 	emitGraphQLResolver,
@@ -388,10 +389,16 @@ describe("emitGraphQLResolver", () => {
 			],
 		});
 
-		const baseline = combinedContent(
+		// The request side only: an inert nested sub-projection still widens the
+		// response shape the after-mapping reconciles, and that is not what this
+		// test pins.
+		const requestSide = (result: EmitResult): string =>
+			result.functions.map((fn) => fn.content).join("\n");
+
+		const baseline = requestSide(
 			await emitGraphQLResolver(withoutNested, defaultOptions),
 		);
-		const actual = combinedContent(
+		const actual = requestSide(
 			await emitGraphQLResolver(withInertNested, defaultOptions),
 		);
 
@@ -1616,7 +1623,7 @@ describe("emitGraphQLResolver", () => {
 		);
 		assert.ok(
 			combinedContent(result).includes(
-				", hits: (b.hits?.hits?.hits ?? []).map((h) => h._source)",
+				", hits: (b.hits?.hits?.hits ?? []).map((h) => normalizeNode(h._source)).filter((h) => h != null)",
 			),
 			"terms response must unwrap hits.hits._source onto the bucket's hits field",
 		);
@@ -1648,7 +1655,7 @@ describe("emitGraphQLResolver", () => {
 		);
 		assert.ok(
 			combinedContent(result).includes(
-				", latestValidTo: b.latestValidTo?.value ?? null, hits: (b.hits?.hits?.hits ?? []).map((h) => h._source)",
+				", latestValidTo: b.latestValidTo?.value ?? null, hits: (b.hits?.hits?.hits ?? []).map((h) => normalizeNode(h._source)).filter((h) => h != null)",
 			),
 		);
 	});
@@ -4231,5 +4238,265 @@ describe("emitGraphQLResolver recursive pipeline split (issue #173)", () => {
 			canonical(monoBody.aggs),
 			"split aggs (with search-side budget division) must match the monolithic aggs",
 		);
+	});
+});
+
+describe("stale-document tolerance", () => {
+	const monolithicOptions = {
+		...defaultOptions,
+		monolithicThresholdBytes: 32_000,
+	};
+
+	function arrayOfModel(): Type {
+		return {
+			kind: "Model",
+			name: "Array",
+			indexer: { value: { kind: "Model" } },
+		} as unknown as Type;
+	}
+
+	function arrayOfString(): Type {
+		return {
+			kind: "Model",
+			name: "Array",
+			indexer: { value: { kind: "Scalar", name: "string" } },
+		} as unknown as Type;
+	}
+
+	function tradeProjection(): ResolvedProjection {
+		const volumeSubProjection = makeSubProjection("VolumeSearchDoc", [
+			makeField({ name: "volumeId", keyword: true }),
+		]);
+		const legSubProjection = makeSubProjection("LegSearchDoc", [
+			makeField({ name: "legId", keyword: true }),
+			makeField({
+				name: "volumes",
+				nested: true,
+				subProjection: volumeSubProjection,
+				type: arrayOfModel(),
+			}),
+		]);
+		return makeProjection({
+			name: "TradeSearchDoc",
+			indexName: "trades",
+			fields: [
+				makeField({ name: "tradeId", keyword: true }),
+				makeField({ name: "side", keyword: true, optional: true }),
+				makeField({
+					name: "legs",
+					nested: true,
+					subProjection: legSubProjection,
+					type: arrayOfModel(),
+				}),
+				makeField({
+					name: "legExternallyDefinedAttributes",
+					nested: true,
+					subProjection: makeSubProjection("LegAttributeSearchDoc", [
+						makeField({ name: "legId", keyword: true }),
+					]),
+					type: arrayOfModel(),
+				}),
+				makeField({
+					name: "aliases",
+					keyword: true,
+					optional: true,
+					type: arrayOfString(),
+				}),
+			],
+		});
+	}
+
+	function searchResult(sources: Record<string, unknown>[]): unknown {
+		return {
+			args: {},
+			result: {
+				hits: {
+					total: { value: sources.length },
+					hits: sources.map((source, index) => ({
+						_id: `doc-${index}`,
+						_source: source,
+						sort: [index],
+					})),
+				},
+			},
+		};
+	}
+
+	type Connection = {
+		edges: Array<{ node: Record<string, unknown> }>;
+		totalCount: number;
+	};
+
+	it("defaults an absent required list to an empty list", async () => {
+		const result = await emitGraphQLResolver(
+			tradeProjection(),
+			monolithicOptions,
+		);
+
+		const connection = evalResponse(
+			result.content,
+			searchResult([{ tradeId: "T-1", legs: [] }]),
+		) as Connection;
+
+		assert.equal(connection.edges.length, 1);
+		assert.deepEqual(
+			connection.edges[0].node.legExternallyDefinedAttributes,
+			[],
+		);
+	});
+
+	it("defaults an absent required list nested inside a sub-document", async () => {
+		const result = await emitGraphQLResolver(
+			tradeProjection(),
+			monolithicOptions,
+		);
+
+		const connection = evalResponse(
+			result.content,
+			searchResult([
+				{
+					tradeId: "T-1",
+					legs: [{ legId: "L-1" }],
+					legExternallyDefinedAttributes: [],
+				},
+			]),
+		) as Connection;
+
+		const legs = connection.edges[0].node.legs as Array<
+			Record<string, unknown>
+		>;
+		assert.deepEqual(legs[0].volumes, []);
+	});
+
+	it("leaves a present list untouched", async () => {
+		const result = await emitGraphQLResolver(
+			tradeProjection(),
+			monolithicOptions,
+		);
+
+		const connection = evalResponse(
+			result.content,
+			searchResult([
+				{
+					tradeId: "T-1",
+					legs: [],
+					legExternallyDefinedAttributes: [{ legId: "L-9" }],
+				},
+			]),
+		) as Connection;
+
+		assert.deepEqual(connection.edges[0].node.legExternallyDefinedAttributes, [
+			{ legId: "L-9" },
+		]);
+	});
+
+	it("invents nothing for absent optional fields", async () => {
+		const result = await emitGraphQLResolver(
+			tradeProjection(),
+			monolithicOptions,
+		);
+
+		const connection = evalResponse(
+			result.content,
+			searchResult([
+				{ tradeId: "T-1", legs: [], legExternallyDefinedAttributes: [] },
+			]),
+		) as Connection;
+
+		assert.ok(!("side" in connection.edges[0].node));
+		assert.ok(!("aliases" in connection.edges[0].node));
+	});
+
+	it("drops a document missing a required scalar and keeps its siblings", async () => {
+		const result = await emitGraphQLResolver(
+			tradeProjection(),
+			monolithicOptions,
+		);
+
+		const connection = evalResponse(
+			result.content,
+			searchResult([
+				{ legs: [], legExternallyDefinedAttributes: [] },
+				{ tradeId: "T-2", legs: [], legExternallyDefinedAttributes: [] },
+			]),
+		) as Connection;
+
+		assert.deepEqual(
+			connection.edges.map((edge) => edge.node.tradeId),
+			["T-2"],
+		);
+		assert.equal(connection.totalCount, 2);
+	});
+
+	it("drops a document whose sub-document is missing a required scalar", async () => {
+		const result = await emitGraphQLResolver(
+			tradeProjection(),
+			monolithicOptions,
+		);
+
+		const connection = evalResponse(
+			result.content,
+			searchResult([
+				{
+					tradeId: "T-1",
+					legs: [{ legId: "L-1", volumes: [] }, { volumes: [] }],
+					legExternallyDefinedAttributes: [],
+				},
+				{ tradeId: "T-2", legs: [], legExternallyDefinedAttributes: [] },
+			]),
+		) as Connection;
+
+		assert.deepEqual(
+			connection.edges.map((edge) => edge.node.tradeId),
+			["T-2"],
+		);
+	});
+
+	it("normalizes identically in the pipeline shape", async () => {
+		const result = await emitGraphQLResolver(tradeProjection(), defaultOptions);
+
+		assert.equal(result.mode, "pipeline");
+		const ctx = searchResult([{ tradeId: "T-1", legs: [] }]) as {
+			result: unknown;
+			args: unknown;
+		};
+		const connection = evalResponse(result.content, {
+			args: ctx.args,
+			prev: { result: ctx.result },
+		}) as Connection;
+
+		assert.deepEqual(
+			connection.edges[0].node.legExternallyDefinedAttributes,
+			[],
+		);
+	});
+
+	it("collects the non-null shape level by level", () => {
+		const spec = __test.collectDocumentSpec(tradeProjection());
+
+		assert.deepEqual(spec, [
+			{
+				path: [],
+				lists: ["legs", "legExternallyDefinedAttributes"],
+				values: ["tradeId"],
+			},
+			{ path: ["legs"], lists: ["volumes"], values: ["legId"] },
+			{ path: ["legs", "volumes"], lists: [], values: ["volumeId"] },
+			{
+				path: ["legExternallyDefinedAttributes"],
+				lists: [],
+				values: ["legId"],
+			},
+		]);
+	});
+
+	it("emits no walker for a projection with no non-null response fields", async () => {
+		const projection = makeProjection({
+			fields: [makeField({ name: "name", optional: true })],
+		});
+		const result = await emitGraphQLResolver(projection, monolithicOptions);
+
+		assert.ok(!result.content.includes("DOC_SPEC"));
+		assert.ok(result.content.includes("node: hit._source"));
 	});
 });

--- a/src/emit-graphql-resolver.test.ts
+++ b/src/emit-graphql-resolver.test.ts
@@ -4452,6 +4452,27 @@ describe("stale-document tolerance", () => {
 		);
 	});
 
+	it("advances the cursor past a page whose documents were all dropped", async () => {
+		const result = await emitGraphQLResolver(
+			tradeProjection(),
+			monolithicOptions,
+		);
+
+		const connection = evalResponse(
+			result.content,
+			searchResult([
+				{ legs: [], legExternallyDefinedAttributes: [] },
+				{ legs: [], legExternallyDefinedAttributes: [] },
+			]),
+		) as Connection & { pageInfo: { endCursor: string | null } };
+
+		assert.deepEqual(connection.edges, []);
+		assert.equal(
+			connection.pageInfo.endCursor,
+			Buffer.from("[1]", "utf8").toString("base64"),
+		);
+	});
+
 	it("normalizes identically in the pipeline shape", async () => {
 		const result = await emitGraphQLResolver(tradeProjection(), defaultOptions);
 

--- a/src/emit-graphql-resolver.ts
+++ b/src/emit-graphql-resolver.ts
@@ -810,8 +810,9 @@ function renderEdgesAssembly(levels: DocumentLevelSpec[]): string {
 	}));`;
 	}
 
-	return `	const edges = [];
-	for (const hit of hits.slice(0, size)) {
+	return `	const page = hits.slice(0, size);
+	const edges = [];
+	for (const hit of page) {
 		const node = ${NORMALIZE_NODE_HELPER}(hit._source);
 		if (node == null) {
 			console.log("dropping unrepresentable document", hit._id);
@@ -819,6 +820,20 @@ function renderEdgesAssembly(levels: DocumentLevelSpec[]): string {
 			edges.push({ node, cursor: util.base64Encode(JSON.stringify(hit.sort)) });
 		}
 	}`;
+}
+
+/**
+ * The `endCursor` expression. It marks a position in the index, not in the
+ * response, so it comes from the last hit on the page rather than the last
+ * surviving edge — a page whose documents were all dropped still advances the
+ * cursor instead of stranding the caller. Identical to the last edge's cursor
+ * whenever nothing was dropped.
+ */
+function renderEndCursor(levels: DocumentLevelSpec[]): string {
+	if (levels.length === 0) {
+		return "edges.length > 0 ? edges[edges.length - 1].cursor : null";
+	}
+	return "page.length > 0 ? util.base64Encode(JSON.stringify(page[page.length - 1].sort)) : null";
 }
 
 /**
@@ -1157,6 +1172,7 @@ function renderMonolithicResolver(
 	);
 	const normalizeNodeHelper = renderNormalizeNodeHelper(documentSpec);
 	const edgesAssembly = renderEdgesAssembly(documentSpec);
+	const endCursor = renderEndCursor(documentSpec);
 
 	return `import { util } from "@aws-appsync/utils";
 
@@ -1207,7 +1223,7 @@ ${responseAggregationsPreamble}
 		totalCount: totalHits,${responseAggregations}
 		pageInfo: {
 			hasNextPage,
-			endCursor: edges.length > 0 ? edges[edges.length - 1].cursor : null,
+			endCursor: ${endCursor},
 		},
 	};
 }
@@ -1272,6 +1288,7 @@ function renderResolver(
 	);
 	const normalizeNodeHelper = renderNormalizeNodeHelper(documentSpec);
 	const edgesAssembly = renderEdgesAssembly(documentSpec);
+	const endCursor = renderEndCursor(documentSpec);
 
 	return `import { util } from "@aws-appsync/utils";
 
@@ -1298,7 +1315,7 @@ ${responseAggregationsPreamble}
 		totalCount: totalHits,${responseAggregations}
 		pageInfo: {
 			hasNextPage,
-			endCursor: edges.length > 0 ? edges[edges.length - 1].cursor : null,
+			endCursor: ${endCursor},
 		},
 	};
 }

--- a/src/emit-graphql-resolver.ts
+++ b/src/emit-graphql-resolver.ts
@@ -150,6 +150,22 @@ const NESTED_TEXT_QUERY_HELPER = "NQ";
 // realistic SearchFilter shape; runtime util.error fires if exceeded.
 const FILTER_WORK_SLOT_COUNT = 256;
 
+/**
+ * Module-level helper that reconciles a hit's `_source` with the SDL before it
+ * becomes a response node. A search index is a derived projection and drifts
+ * behind the schema that reads it: a document written before a field existed
+ * carries no key for it, and the raw `_source` then hands GraphQL `null` for a
+ * non-null field.
+ *
+ * Absent state for a list is an empty list, so the helper fills those in and
+ * the document stays readable. An absent required scalar or object has no
+ * honest stand-in, so the helper rejects the document instead of inventing
+ * one; the resolver drops it from `edges` and the rest of the page still
+ * renders. Non-null propagation would otherwise turn one stale document into a
+ * null response for every sibling on the page.
+ */
+const NORMALIZE_NODE_HELPER = "normalizeNode";
+
 export async function emitGraphQLResolver(
 	projection: TopLevelProjection,
 	options: ResolverOptions,
@@ -184,6 +200,7 @@ export async function emitGraphQLResolver(
 
 	const aggregations = collectAggregations(projection);
 	const searchFilterShape = buildSearchFilterShape(projection);
+	const documentSpec = collectDocumentSpec(projection);
 
 	const threshold =
 		options.monolithicThresholdBytes ?? DEFAULT_MONOLITHIC_THRESHOLD_BYTES;
@@ -207,6 +224,7 @@ export async function emitGraphQLResolver(
 		aggregations,
 		searchFilterShape,
 		projection.indexName,
+		documentSpec,
 		options,
 	);
 	const monolithicBytes = Buffer.byteLength(monolithicContent, "utf-8");
@@ -223,7 +241,7 @@ export async function emitGraphQLResolver(
 
 	// Pipeline fallback. The resolver-level file holds the after-mapping;
 	// prepare runs on NONE, search on OPENSEARCH (issue #105).
-	const resolverContent = renderResolver(aggregations, options);
+	const resolverContent = renderResolver(aggregations, documentSpec, options);
 	const prepareContent = renderPrepareFunction(
 		textFields,
 		keywordFields,
@@ -647,6 +665,163 @@ function joinFieldPath(parent: string | undefined, segment: string): string {
 }
 
 /**
+ * The non-null fields of one document level, addressed by the segment path
+ * that reaches that level from the document root. Lists and values are split
+ * because they degrade differently: a list is fillable, a value is not.
+ */
+export interface DocumentLevelSpec {
+	path: string[];
+	lists: string[];
+	values: string[];
+}
+
+/**
+ * The non-null response shape the SDL declares, level by level. Only
+ * `searchable` fields reach the SDL, so filter-only and aggregatable-only
+ * fields are absent here too. Levels are collected outermost-first, so the
+ * emitted walker fills a parent list before descending into it.
+ */
+function collectDocumentSpec(
+	projection: ResolvedProjection,
+): DocumentLevelSpec[] {
+	const levels: DocumentLevelSpec[] = [];
+	collectDocumentSpecRecursive(projection, [], levels);
+	return levels.filter(
+		(level) => level.lists.length > 0 || level.values.length > 0,
+	);
+}
+
+function collectDocumentSpecRecursive(
+	projection: ResolvedProjection,
+	path: string[],
+	levels: DocumentLevelSpec[],
+): void {
+	if (!projection.fields) return;
+
+	const level: DocumentLevelSpec = { path, lists: [], values: [] };
+	levels.push(level);
+
+	const children: Array<{ projection: ResolvedProjection; path: string[] }> =
+		[];
+
+	for (const field of projection.fields) {
+		if (!field.searchable) continue;
+
+		const name = field.projectedName ?? field.name;
+
+		if (!field.optional) {
+			if (isArrayType(field.type)) {
+				level.lists.push(name);
+			} else {
+				level.values.push(name);
+			}
+		}
+
+		if (field.subProjection) {
+			children.push({ projection: field.subProjection, path: [...path, name] });
+		}
+	}
+
+	for (const child of children) {
+		collectDocumentSpecRecursive(child.projection, child.path, levels);
+	}
+}
+
+function isArrayType(type: ResolvedProjectionField["type"]): boolean {
+	return (
+		type.kind === "Model" &&
+		type.name === "Array" &&
+		type.indexer?.value !== undefined
+	);
+}
+
+/**
+ * Runtime walker declaration, emitted only when the projection declares a
+ * non-null response field. APPSYNC_JS rejects recursion, so the walker carries
+ * its own frontier of parent objects and steps one path segment at a time.
+ * Returns `null` for a document that cannot be made schema-valid; the caller
+ * drops it rather than letting non-null propagation null the whole page.
+ */
+function renderNormalizeNodeHelper(levels: DocumentLevelSpec[]): string {
+	if (levels.length === 0) return "";
+
+	const specLiteral = JSON.stringify(
+		levels.map((level) => [level.path, level.lists, level.values]),
+	);
+
+	return `
+const DOC_SPEC = ${specLiteral};
+
+function ${NORMALIZE_NODE_HELPER}(node) {
+	if (node == null) return null;
+	for (const level of DOC_SPEC) {
+		let containers = [node];
+		for (const segment of level[0]) {
+			const next = [];
+			for (const container of containers) {
+				const value = container[segment];
+				if (value != null) {
+					if (Array.isArray(value)) {
+						for (const item of value) {
+							if (item != null) next.push(item);
+						}
+					} else {
+						next.push(value);
+					}
+				}
+			}
+			containers = next;
+		}
+		for (const container of containers) {
+			for (const name of level[1]) {
+				if (container[name] == null) container[name] = [];
+			}
+			for (const name of level[2]) {
+				if (container[name] == null) return null;
+			}
+		}
+	}
+	return node;
+}
+`;
+}
+
+/**
+ * Reads `_source` through the walker when the projection has a non-null shape
+ * to reconcile, and raw otherwise.
+ */
+function renderNormalizedSource(
+	levels: DocumentLevelSpec[],
+	sourceExpression: string,
+): string {
+	if (levels.length === 0) return sourceExpression;
+	return `${NORMALIZE_NODE_HELPER}(${sourceExpression})`;
+}
+
+/**
+ * The `edges` assembly. With a non-null shape to reconcile it becomes a loop
+ * that skips the documents the walker rejects; `.map` cannot drop an element.
+ */
+function renderEdgesAssembly(levels: DocumentLevelSpec[]): string {
+	if (levels.length === 0) {
+		return `	const edges = hits.slice(0, size).map((hit) => ({
+		node: hit._source,
+		cursor: util.base64Encode(JSON.stringify(hit.sort)),
+	}));`;
+	}
+
+	return `	const edges = [];
+	for (const hit of hits.slice(0, size)) {
+		const node = ${NORMALIZE_NODE_HELPER}(hit._source);
+		if (node == null) {
+			console.log("dropping unrepresentable document", hit._id);
+		} else {
+			edges.push({ node, cursor: util.base64Encode(JSON.stringify(hit.sort)) });
+		}
+	}`;
+}
+
+/**
  * Declaration of the nested-query helper, emitted only when the projection has
  * nested text to search. `score_mode: "max"` scores a parent document by its
  * best-matching child rather than by a sum over children, so one strong hit
@@ -959,6 +1134,7 @@ function renderMonolithicResolver(
 	aggregations: AggregationEntry[],
 	searchFilterShape: SearchFilterShape | undefined,
 	indexName: string,
+	documentSpec: DocumentLevelSpec[],
 	options: ResolverOptions,
 ): string {
 	const textQueryPush = renderTextQueryPush(textFields);
@@ -975,7 +1151,12 @@ function renderMonolithicResolver(
 	const applyFilterSpecFunction = renderApplyFilterSpecFunction(slotsLiteral);
 	const responseAggregationsPreamble =
 		renderResponseAggregationsPreamble(aggregations);
-	const responseAggregations = renderResponseAggregations(aggregations);
+	const responseAggregations = renderResponseAggregations(
+		aggregations,
+		documentSpec,
+	);
+	const normalizeNodeHelper = renderNormalizeNodeHelper(documentSpec);
+	const edgesAssembly = renderEdgesAssembly(documentSpec);
 
 	return `import { util } from "@aws-appsync/utils";
 
@@ -1019,10 +1200,7 @@ ${renderSearchBodyGuard("parsedBody", "\t")}	const hits = parsedBody.hits.hits;
 	const size = Math.min(args.first || ${options.defaultPageSize}, ${options.maxPageSize});
 
 	const hasNextPage = hits.length > size;
-	const edges = hits.slice(0, size).map((hit) => ({
-		node: hit._source,
-		cursor: util.base64Encode(JSON.stringify(hit.sort)),
-	}));
+${edgesAssembly}
 ${responseAggregationsPreamble}
 	return {
 		edges,
@@ -1033,7 +1211,7 @@ ${responseAggregationsPreamble}
 		},
 	};
 }
-${buildAggsFunction}${textSpecDeclaration}${nestedTextHelper}
+${normalizeNodeHelper}${buildAggsFunction}${textSpecDeclaration}${nestedTextHelper}
 function buildQuery(queryText, filter, searchFilter) {
 	const musts = [];
 	const filters = [];
@@ -1083,11 +1261,17 @@ ${applyFilterSpecFunction}`;
  */
 function renderResolver(
 	aggregations: AggregationEntry[],
+	documentSpec: DocumentLevelSpec[],
 	options: ResolverOptions,
 ): string {
 	const responseAggregationsPreamble =
 		renderResponseAggregationsPreamble(aggregations);
-	const responseAggregations = renderResponseAggregations(aggregations);
+	const responseAggregations = renderResponseAggregations(
+		aggregations,
+		documentSpec,
+	);
+	const normalizeNodeHelper = renderNormalizeNodeHelper(documentSpec);
+	const edgesAssembly = renderEdgesAssembly(documentSpec);
 
 	return `import { util } from "@aws-appsync/utils";
 
@@ -1107,10 +1291,7 @@ ${renderSearchBodyGuard("parsedBody", "\t")}	const hits = parsedBody.hits.hits;
 	const size = Math.min(args.first || ${options.defaultPageSize}, ${options.maxPageSize});
 
 	const hasNextPage = hits.length > size;
-	const edges = hits.slice(0, size).map((hit) => ({
-		node: hit._source,
-		cursor: util.base64Encode(JSON.stringify(hit.sort)),
-	}));
+${edgesAssembly}
 ${responseAggregationsPreamble}
 	return {
 		edges,
@@ -1121,7 +1302,7 @@ ${responseAggregationsPreamble}
 		},
 	};
 }
-`;
+${normalizeNodeHelper}`;
 }
 
 /**
@@ -1924,7 +2105,10 @@ function renderResponseAggregationsPreamble(
 	return lines.join("\n");
 }
 
-function renderResponseAggregations(aggregations: AggregationEntry[]): string {
+function renderResponseAggregations(
+	aggregations: AggregationEntry[],
+	documentSpec: DocumentLevelSpec[],
+): string {
 	if (aggregations.length === 0) {
 		return "";
 	}
@@ -1935,13 +2119,16 @@ function renderResponseAggregations(aggregations: AggregationEntry[]): string {
 	for (const entry of aggregations) {
 		if (seen.has(entry.aggName)) continue;
 		seen.add(entry.aggName);
-		lines.push(renderResponseAggregationLine(entry));
+		lines.push(renderResponseAggregationLine(entry, documentSpec));
 	}
 
 	return `\n\t\taggregations: {\n${lines.join("\n")}\n\t\t},`;
 }
 
-function renderResponseAggregationLine(entry: AggregationEntry): string {
+function renderResponseAggregationLine(
+	entry: AggregationEntry,
+	documentSpec: DocumentLevelSpec[],
+): string {
 	const path = entry.nestedPath
 		? `_a${nestedAggGroupKey(entry.nestedPath)}.${entry.aggName}`
 		: `_a.${entry.aggName}`;
@@ -1960,7 +2147,7 @@ function renderResponseAggregationLine(entry: AggregationEntry): string {
 				.map(([name]) => `, ${name}: b.${name}?.value ?? null`)
 				.join("");
 			const hitsField = hasTopHits
-				? `, hits: (b.hits?.hits?.hits ?? []).map((h) => h._source)`
+				? `, hits: (b.hits?.hits?.hits ?? []).map((h) => ${renderNormalizedSource(documentSpec, "h._source")}).filter((h) => h != null)`
 				: "";
 			return `\t\t\t${entry.aggName}: (${path}?.buckets ?? []).map((b) => ({ key: b.key, count: b.doc_count${subFields}${hitsField} })),`;
 		}
@@ -2020,6 +2207,7 @@ export const __test = {
 	renderAggSpecLiteral,
 	renderBuildAggsFunction,
 	renderResponseAggregations,
+	collectDocumentSpec,
 	partitionAggregationsByTopPath,
 	DEFAULT_MONOLITHIC_THRESHOLD_BYTES,
 };

--- a/test/snapshots/opensearch-baseline/pet-public-search-doc-resolver.js
+++ b/test/snapshots/opensearch-baseline/pet-public-search-doc-resolver.js
@@ -26,8 +26,9 @@ export function response(ctx) {
 	const size = Math.min(args.first || 20, 100);
 
 	const hasNextPage = hits.length > size;
+	const page = hits.slice(0, size);
 	const edges = [];
-	for (const hit of hits.slice(0, size)) {
+	for (const hit of page) {
 		const node = normalizeNode(hit._source);
 		if (node == null) {
 			console.log("dropping unrepresentable document", hit._id);
@@ -47,7 +48,7 @@ export function response(ctx) {
 		},
 		pageInfo: {
 			hasNextPage,
-			endCursor: edges.length > 0 ? edges[edges.length - 1].cursor : null,
+			endCursor: page.length > 0 ? util.base64Encode(JSON.stringify(page[page.length - 1].sort)) : null,
 		},
 	};
 }

--- a/test/snapshots/opensearch-baseline/pet-public-search-doc-resolver.js
+++ b/test/snapshots/opensearch-baseline/pet-public-search-doc-resolver.js
@@ -26,10 +26,15 @@ export function response(ctx) {
 	const size = Math.min(args.first || 20, 100);
 
 	const hasNextPage = hits.length > size;
-	const edges = hits.slice(0, size).map((hit) => ({
-		node: hit._source,
-		cursor: util.base64Encode(JSON.stringify(hit.sort)),
-	}));
+	const edges = [];
+	for (const hit of hits.slice(0, size)) {
+		const node = normalizeNode(hit._source);
+		if (node == null) {
+			console.log("dropping unrepresentable document", hit._id);
+		} else {
+			edges.push({ node, cursor: util.base64Encode(JSON.stringify(hit.sort)) });
+		}
+	}
 	const _a = parsedBody.aggregations || {};
 	return {
 		edges,
@@ -45,4 +50,38 @@ export function response(ctx) {
 			endCursor: edges.length > 0 ? edges[edges.length - 1].cursor : null,
 		},
 	};
+}
+
+const DOC_SPEC = [[[],["tags","aliases","approvals","bankAccountApprovals"],["id","name","species","birthDate","createdAt","owner","rank","stock","score","active"]]];
+
+function normalizeNode(node) {
+	if (node == null) return null;
+	for (const level of DOC_SPEC) {
+		let containers = [node];
+		for (const segment of level[0]) {
+			const next = [];
+			for (const container of containers) {
+				const value = container[segment];
+				if (value != null) {
+					if (Array.isArray(value)) {
+						for (const item of value) {
+							if (item != null) next.push(item);
+						}
+					} else {
+						next.push(value);
+					}
+				}
+			}
+			containers = next;
+		}
+		for (const container of containers) {
+			for (const name of level[1]) {
+				if (container[name] == null) container[name] = [];
+			}
+			for (const name of level[2]) {
+				if (container[name] == null) return null;
+			}
+		}
+	}
+	return node;
 }

--- a/test/snapshots/opensearch-baseline/pet-search-doc-resolver.js
+++ b/test/snapshots/opensearch-baseline/pet-search-doc-resolver.js
@@ -26,8 +26,9 @@ export function response(ctx) {
 	const size = Math.min(args.first || 20, 100);
 
 	const hasNextPage = hits.length > size;
+	const page = hits.slice(0, size);
 	const edges = [];
-	for (const hit of hits.slice(0, size)) {
+	for (const hit of page) {
 		const node = normalizeNode(hit._source);
 		if (node == null) {
 			console.log("dropping unrepresentable document", hit._id);
@@ -51,7 +52,7 @@ export function response(ctx) {
 		},
 		pageInfo: {
 			hasNextPage,
-			endCursor: edges.length > 0 ? edges[edges.length - 1].cursor : null,
+			endCursor: page.length > 0 ? util.base64Encode(JSON.stringify(page[page.length - 1].sort)) : null,
 		},
 	};
 }

--- a/test/snapshots/opensearch-baseline/pet-search-doc-resolver.js
+++ b/test/snapshots/opensearch-baseline/pet-search-doc-resolver.js
@@ -26,10 +26,15 @@ export function response(ctx) {
 	const size = Math.min(args.first || 20, 100);
 
 	const hasNextPage = hits.length > size;
-	const edges = hits.slice(0, size).map((hit) => ({
-		node: hit._source,
-		cursor: util.base64Encode(JSON.stringify(hit.sort)),
-	}));
+	const edges = [];
+	for (const hit of hits.slice(0, size)) {
+		const node = normalizeNode(hit._source);
+		if (node == null) {
+			console.log("dropping unrepresentable document", hit._id);
+		} else {
+			edges.push({ node, cursor: util.base64Encode(JSON.stringify(hit.sort)) });
+		}
+	}
 	const _a = parsedBody.aggregations || {};
 	const _a_tags = _a._tags || {};
 	return {
@@ -49,4 +54,38 @@ export function response(ctx) {
 			endCursor: edges.length > 0 ? edges[edges.length - 1].cursor : null,
 		},
 	};
+}
+
+const DOC_SPEC = [[[],["tags","aliases","approvals","bankAccountApprovals"],["id","name","species","birthDate","createdAt","owner","rank","stock","score","active"]],[["tags"],[],["name"]],[["approvals"],[],["type","grantedBy"]],[["bankAccountApprovals"],[],["accountId","approvedBy"]]];
+
+function normalizeNode(node) {
+	if (node == null) return null;
+	for (const level of DOC_SPEC) {
+		let containers = [node];
+		for (const segment of level[0]) {
+			const next = [];
+			for (const container of containers) {
+				const value = container[segment];
+				if (value != null) {
+					if (Array.isArray(value)) {
+						for (const item of value) {
+							if (item != null) next.push(item);
+						}
+					} else {
+						next.push(value);
+					}
+				}
+			}
+			containers = next;
+		}
+		for (const container of containers) {
+			for (const name of level[1]) {
+				if (container[name] == null) container[name] = [];
+			}
+			for (const name of level[2]) {
+				if (container[name] == null) return null;
+			}
+		}
+	}
+	return node;
 }

--- a/test/snapshots/opensearch-baseline/tag-search-doc-resolver.js
+++ b/test/snapshots/opensearch-baseline/tag-search-doc-resolver.js
@@ -26,10 +26,15 @@ export function response(ctx) {
 	const size = Math.min(args.first || 20, 100);
 
 	const hasNextPage = hits.length > size;
-	const edges = hits.slice(0, size).map((hit) => ({
-		node: hit._source,
-		cursor: util.base64Encode(JSON.stringify(hit.sort)),
-	}));
+	const edges = [];
+	for (const hit of hits.slice(0, size)) {
+		const node = normalizeNode(hit._source);
+		if (node == null) {
+			console.log("dropping unrepresentable document", hit._id);
+		} else {
+			edges.push({ node, cursor: util.base64Encode(JSON.stringify(hit.sort)) });
+		}
+	}
 	const _a = parsedBody.aggregations || {};
 	return {
 		edges,
@@ -44,4 +49,38 @@ export function response(ctx) {
 			endCursor: edges.length > 0 ? edges[edges.length - 1].cursor : null,
 		},
 	};
+}
+
+const DOC_SPEC = [[[],[],["name"]]];
+
+function normalizeNode(node) {
+	if (node == null) return null;
+	for (const level of DOC_SPEC) {
+		let containers = [node];
+		for (const segment of level[0]) {
+			const next = [];
+			for (const container of containers) {
+				const value = container[segment];
+				if (value != null) {
+					if (Array.isArray(value)) {
+						for (const item of value) {
+							if (item != null) next.push(item);
+						}
+					} else {
+						next.push(value);
+					}
+				}
+			}
+			containers = next;
+		}
+		for (const container of containers) {
+			for (const name of level[1]) {
+				if (container[name] == null) container[name] = [];
+			}
+			for (const name of level[2]) {
+				if (container[name] == null) return null;
+			}
+		}
+	}
+	return node;
 }

--- a/test/snapshots/opensearch-baseline/tag-search-doc-resolver.js
+++ b/test/snapshots/opensearch-baseline/tag-search-doc-resolver.js
@@ -26,8 +26,9 @@ export function response(ctx) {
 	const size = Math.min(args.first || 20, 100);
 
 	const hasNextPage = hits.length > size;
+	const page = hits.slice(0, size);
 	const edges = [];
-	for (const hit of hits.slice(0, size)) {
+	for (const hit of page) {
 		const node = normalizeNode(hit._source);
 		if (node == null) {
 			console.log("dropping unrepresentable document", hit._id);
@@ -46,7 +47,7 @@ export function response(ctx) {
 		},
 		pageInfo: {
 			hasNextPage,
-			endCursor: edges.length > 0 ? edges[edges.length - 1].cursor : null,
+			endCursor: page.length > 0 ? util.base64Encode(JSON.stringify(page[page.length - 1].sort)) : null,
 		},
 	};
 }


### PR DESCRIPTION
A search index is a derived projection and is always potentially behind the schema that reads it. A document written before a field existed carries no key for it, so the raw `_source` hands GraphQL `null` for a non-null field — and non-null propagation turns that single stale document into a `null` response for every sibling on the page.

The emitted resolver now reconciles each hit against the non-null shape the SDL declares, at every document level including nested sub-documents:

- An absent non-null list becomes an empty list. Absent state for a list *is* the empty list, so the page renders and stays correct.
- A document with an absent required scalar or object is dropped from `edges` and logged. It cannot be represented honestly, and no value is invented for it — a fabricated `""` or `0` is wrong data displayed as real. Its siblings render.
- Optional fields are untouched. `totalCount` still reports what the index holds.

Projections that declare no non-null response field emit exactly as before.

Surfaced by a fully broken trades list in stxcommodities/core-services#3341, where one recently added list field emptied the whole result set. That issue is closed by consuming a released version of this package, not by this PR.