### PR TITLE
fix(graphql): branch the response walker on the projection, not on Array.isArray

### DIFF
--- a/src/emit-graphql-resolver.test.ts
+++ b/src/emit-graphql-resolver.test.ts
@@ -2201,14 +2201,28 @@ describe("emitGraphQLResolver search filter DSL", () => {
 		});
 	});
 
-	it("emitted resolver contains no forbidden global coercion calls (String, Number, Boolean, Array, Object)", async () => {
+	it("emitted resolver references no unsupported global", async () => {
 		// APPSYNC_JS rejects these globals at deploy time even though
 		// @aws-appsync/eslint-plugin doesn't flag them (no rule covers
-		// global function calls). Use template literals (\`${x}\`) for
-		// string coercion and arithmetic / comparisons for the others.
+		// global function calls) and the emitter's own tests eval in Node,
+		// where they all exist. This regex is the only gate, so it covers
+		// both call and member form: `Array.isArray(...)` shipped once
+		// because a call-only pattern let it through.
 		const projection = makeProjection({
 			fields: [
 				makeField({ name: "name" }),
+				makeField({
+					name: "legs",
+					nested: true,
+					type: {
+						kind: "Model",
+						name: "Array",
+						indexer: { value: { kind: "Model" } },
+					} as unknown as Type,
+					subProjection: makeSubProjection("LegSearchDoc", [
+						makeField({ name: "legId", keyword: true }),
+					]),
+				}),
 				makeField({
 					name: "validFrom",
 					type: { kind: "Scalar", name: "utcDateTime" } as unknown as Type,
@@ -2246,18 +2260,34 @@ describe("emitGraphQLResolver search filter DSL", () => {
 		});
 		const result = await emitGraphQLResolver(projection, defaultOptions);
 
-		const forbidden = ["String", "Number", "Boolean", "Array", "Object"];
+		// `Object.keys`/`entries`/`values` are supported, so only the coercion
+		// call form is forbidden for it; the rest are absent from the runtime
+		// entirely, so any reference to them is a deploy-time failure.
+		const callOnly = ["String", "Number", "Boolean", "Object"];
+		const anyReference = [
+			"Array",
+			"Promise",
+			"Date",
+			"RegExp",
+			"Symbol",
+			"Map",
+			"Set",
+		];
+		const forbidden = [
+			...callOnly.map((name) => ({ name, pattern: `\\b${name}\\s*\\(` })),
+			...anyReference.map((name) => ({ name, pattern: `\\b${name}\\s*[(.]` })),
+		];
 		const allFiles = [
 			{ name: "resolver", content: result.content },
 			...result.functions.map((fn) => ({ name: fn.name, content: fn.content })),
 		];
 		for (const file of allFiles) {
-			for (const name of forbidden) {
-				const re = new RegExp(`\\b${name}\\s*\\(`);
+			for (const { name, pattern } of forbidden) {
+				const re = new RegExp(pattern);
 				assert.equal(
 					re.test(file.content),
 					false,
-					`emitted ${file.name} must not call \`${name}(...)\` — APPSYNC_JS rejects global coercion calls.\n--- emitted ---\n${file.content}\n--- end ---`,
+					`emitted ${file.name} must not reference the \`${name}\` global — APPSYNC_JS does not provide it.\n--- emitted ---\n${file.content}\n--- end ---`,
 				);
 			}
 		}
@@ -4306,6 +4336,31 @@ describe("stale-document tolerance", () => {
 		});
 	}
 
+	function petProjection(): ResolvedProjection {
+		return makeProjection({
+			name: "PetSearchDoc",
+			indexName: "pets",
+			fields: [
+				makeField({ name: "petId", keyword: true }),
+				makeField({
+					name: "owner",
+					subProjection: makeSubProjection("OwnerSearchDoc", [
+						makeField({ name: "ownerName", keyword: true }),
+					]),
+					type: { kind: "Model", name: "Owner" } as unknown as Type,
+				}),
+				makeField({
+					name: "tags",
+					nested: true,
+					subProjection: makeSubProjection("TagSearchDoc", [
+						makeField({ name: "tagName", keyword: true }),
+					]),
+					type: arrayOfModel(),
+				}),
+			],
+		});
+	}
+
 	function searchResult(sources: Record<string, unknown>[]): unknown {
 		return {
 			args: {},
@@ -4501,14 +4556,71 @@ describe("stale-document tolerance", () => {
 				lists: ["legs", "legExternallyDefinedAttributes"],
 				values: ["tradeId"],
 			},
-			{ path: ["legs"], lists: ["volumes"], values: ["legId"] },
-			{ path: ["legs", "volumes"], lists: [], values: ["volumeId"] },
+			{ path: [["legs", true]], lists: ["volumes"], values: ["legId"] },
 			{
-				path: ["legExternallyDefinedAttributes"],
+				path: [
+					["legs", true],
+					["volumes", true],
+				],
+				lists: [],
+				values: ["volumeId"],
+			},
+			{
+				path: [["legExternallyDefinedAttributes", true]],
 				lists: [],
 				values: ["legId"],
 			},
 		]);
+	});
+
+	it("marks a single-object path segment as not a list", () => {
+		const spec = __test.collectDocumentSpec(petProjection());
+
+		assert.deepEqual(spec, [
+			{ path: [], lists: ["tags"], values: ["petId", "owner"] },
+			{ path: [["owner", false]], lists: [], values: ["ownerName"] },
+			{ path: [["tags", true]], lists: [], values: ["tagName"] },
+		]);
+	});
+
+	it("emits no Array global — APPSYNC_JS has none", async () => {
+		const monolithic = await emitGraphQLResolver(
+			tradeProjection(),
+			monolithicOptions,
+		);
+		const pipeline = await emitGraphQLResolver(
+			tradeProjection(),
+			defaultOptions,
+		);
+
+		const emitted = [
+			monolithic.content,
+			pipeline.content,
+			...pipeline.functions.map((fn) => fn.content),
+		];
+		for (const content of emitted) {
+			assert.ok(content.indexOf("Array") === -1);
+		}
+	});
+
+	it("descends through a single-object level without a runtime type test", async () => {
+		const result = await emitGraphQLResolver(
+			petProjection(),
+			monolithicOptions,
+		);
+
+		const connection = evalResponse(
+			result.content,
+			searchResult([
+				{ petId: "P-1", owner: { ownerName: "Ada" }, tags: [{ tagName: "a" }] },
+				{ petId: "P-2", owner: {}, tags: [] },
+			]),
+		) as Connection;
+
+		assert.deepEqual(
+			connection.edges.map((edge) => edge.node.petId),
+			["P-1"],
+		);
 	});
 
 	it("emits no walker for a projection with no non-null response fields", async () => {

--- a/src/emit-graphql-resolver.test.ts
+++ b/src/emit-graphql-resolver.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it } from "node:test";
@@ -82,6 +82,42 @@ function liftAggregations(
 	return raw.map((entry) =>
 		typeof entry === "string" ? { kind: entry } : entry,
 	) as ResolvedProjection["fields"][0]["aggregations"];
+}
+
+// APPSYNC_JS rejects these globals at deploy time even though
+// @aws-appsync/eslint-plugin doesn't flag them (no rule covers global
+// function calls). `Object.keys`/`entries`/`values` are supported, so only
+// the coercion call form is forbidden for it; the rest are absent from the
+// runtime entirely, so any reference to them is a deploy-time failure. This
+// regex is the only gate, so it covers both call and member form —
+// `Array.isArray(...)` shipped once because a call-only pattern let it through.
+const CALL_ONLY_GLOBALS = ["String", "Number", "Boolean", "Object"];
+const ANY_REFERENCE_GLOBALS = [
+	"Array",
+	"Promise",
+	"Date",
+	"RegExp",
+	"Symbol",
+	"Map",
+	"Set",
+];
+const FORBIDDEN_GLOBALS = [
+	...CALL_ONLY_GLOBALS.map((name) => ({ name, pattern: `\\b${name}\\s*\\(` })),
+	...ANY_REFERENCE_GLOBALS.map((name) => ({
+		name,
+		pattern: `\\b${name}\\s*[(.]`,
+	})),
+];
+
+function assertNoForbiddenGlobals(fileName: string, content: string): void {
+	for (const { name, pattern } of FORBIDDEN_GLOBALS) {
+		const re = new RegExp(pattern);
+		assert.equal(
+			re.test(content),
+			false,
+			`${fileName} must not reference the \`${name}\` global — APPSYNC_JS does not provide it.\n--- content ---\n${content}\n--- end ---`,
+		);
+	}
 }
 
 /**
@@ -2202,12 +2238,6 @@ describe("emitGraphQLResolver search filter DSL", () => {
 	});
 
 	it("emitted resolver references no unsupported global", async () => {
-		// APPSYNC_JS rejects these globals at deploy time even though
-		// @aws-appsync/eslint-plugin doesn't flag them (no rule covers
-		// global function calls) and the emitter's own tests eval in Node,
-		// where they all exist. This regex is the only gate, so it covers
-		// both call and member form: `Array.isArray(...)` shipped once
-		// because a call-only pattern let it through.
 		const projection = makeProjection({
 			fields: [
 				makeField({ name: "name" }),
@@ -2260,36 +2290,20 @@ describe("emitGraphQLResolver search filter DSL", () => {
 		});
 		const result = await emitGraphQLResolver(projection, defaultOptions);
 
-		// `Object.keys`/`entries`/`values` are supported, so only the coercion
-		// call form is forbidden for it; the rest are absent from the runtime
-		// entirely, so any reference to them is a deploy-time failure.
-		const callOnly = ["String", "Number", "Boolean", "Object"];
-		const anyReference = [
-			"Array",
-			"Promise",
-			"Date",
-			"RegExp",
-			"Symbol",
-			"Map",
-			"Set",
-		];
-		const forbidden = [
-			...callOnly.map((name) => ({ name, pattern: `\\b${name}\\s*\\(` })),
-			...anyReference.map((name) => ({ name, pattern: `\\b${name}\\s*[(.]` })),
-		];
 		const allFiles = [
 			{ name: "resolver", content: result.content },
 			...result.functions.map((fn) => ({ name: fn.name, content: fn.content })),
 		];
 		for (const file of allFiles) {
-			for (const { name, pattern } of forbidden) {
-				const re = new RegExp(pattern);
-				assert.equal(
-					re.test(file.content),
-					false,
-					`emitted ${file.name} must not reference the \`${name}\` global — APPSYNC_JS does not provide it.\n--- emitted ---\n${file.content}\n--- end ---`,
-				);
-			}
+			assertNoForbiddenGlobals(`emitted ${file.name}`, file.content);
+		}
+
+		const snapshotFiles = (
+			await readdir("test/snapshots", { recursive: true })
+		).filter((fileName) => fileName.endsWith(".js"));
+		for (const fileName of snapshotFiles) {
+			const content = await readFile(join("test/snapshots", fileName), "utf8");
+			assertNoForbiddenGlobals(`test/snapshots/${fileName}`, content);
 		}
 	});
 
@@ -4583,26 +4597,6 @@ describe("stale-document tolerance", () => {
 		]);
 	});
 
-	it("emits no Array global — APPSYNC_JS has none", async () => {
-		const monolithic = await emitGraphQLResolver(
-			tradeProjection(),
-			monolithicOptions,
-		);
-		const pipeline = await emitGraphQLResolver(
-			tradeProjection(),
-			defaultOptions,
-		);
-
-		const emitted = [
-			monolithic.content,
-			pipeline.content,
-			...pipeline.functions.map((fn) => fn.content),
-		];
-		for (const content of emitted) {
-			assert.ok(content.indexOf("Array") === -1);
-		}
-	});
-
 	it("descends through a single-object level without a runtime type test", async () => {
 		const result = await emitGraphQLResolver(
 			petProjection(),
@@ -4614,6 +4608,52 @@ describe("stale-document tolerance", () => {
 			searchResult([
 				{ petId: "P-1", owner: { ownerName: "Ada" }, tags: [{ tagName: "a" }] },
 				{ petId: "P-2", owner: {}, tags: [] },
+			]),
+		) as Connection;
+
+		assert.deepEqual(
+			connection.edges.map((edge) => edge.node.petId),
+			["P-1"],
+		);
+	});
+
+	it("tolerates a list-flagged segment holding a single object", async () => {
+		const result = await emitGraphQLResolver(
+			petProjection(),
+			monolithicOptions,
+		);
+
+		const connection = evalResponse(
+			result.content,
+			searchResult([
+				{
+					petId: "P-1",
+					owner: { ownerName: "Ada" },
+					tags: { tagName: "solo" },
+				},
+			]),
+		) as Connection;
+
+		assert.deepEqual(
+			connection.edges.map((edge) => edge.node.petId),
+			["P-1"],
+		);
+	});
+
+	it("tolerates an object-flagged segment holding a one-element array", async () => {
+		const result = await emitGraphQLResolver(
+			petProjection(),
+			monolithicOptions,
+		);
+
+		const connection = evalResponse(
+			result.content,
+			searchResult([
+				{
+					petId: "P-1",
+					owner: [{ ownerName: "Ada" }],
+					tags: [{ tagName: "a" }],
+				},
 			]),
 		) as Connection;
 

--- a/src/emit-graphql-resolver.ts
+++ b/src/emit-graphql-resolver.ts
@@ -665,12 +665,19 @@ function joinFieldPath(parent: string | undefined, segment: string): string {
 }
 
 /**
+ * One step from a document level to the level below it. The boolean records
+ * whether the schema declares that step a list, resolved when the spec is
+ * built so the emitted walker never has to ask at runtime.
+ */
+export type DocumentPathSegment = [string, boolean];
+
+/**
  * The non-null fields of one document level, addressed by the segment path
  * that reaches that level from the document root. Lists and values are split
  * because they degrade differently: a list is fillable, a value is not.
  */
 export interface DocumentLevelSpec {
-	path: string[];
+	path: DocumentPathSegment[];
 	lists: string[];
 	values: string[];
 }
@@ -693,7 +700,7 @@ function collectDocumentSpec(
 
 function collectDocumentSpecRecursive(
 	projection: ResolvedProjection,
-	path: string[],
+	path: DocumentPathSegment[],
 	levels: DocumentLevelSpec[],
 ): void {
 	if (!projection.fields) return;
@@ -701,16 +708,19 @@ function collectDocumentSpecRecursive(
 	const level: DocumentLevelSpec = { path, lists: [], values: [] };
 	levels.push(level);
 
-	const children: Array<{ projection: ResolvedProjection; path: string[] }> =
-		[];
+	const children: Array<{
+		projection: ResolvedProjection;
+		path: DocumentPathSegment[];
+	}> = [];
 
 	for (const field of projection.fields) {
 		if (!field.searchable) continue;
 
 		const name = field.projectedName ?? field.name;
+		const list = isArrayType(field.type);
 
 		if (!field.optional) {
-			if (isArrayType(field.type)) {
+			if (list) {
 				level.lists.push(name);
 			} else {
 				level.values.push(name);
@@ -718,7 +728,10 @@ function collectDocumentSpecRecursive(
 		}
 
 		if (field.subProjection) {
-			children.push({ projection: field.subProjection, path: [...path, name] });
+			children.push({
+				projection: field.subProjection,
+				path: [...path, [name, list]],
+			});
 		}
 	}
 
@@ -741,6 +754,10 @@ function isArrayType(type: ResolvedProjectionField["type"]): boolean {
  * its own frontier of parent objects and steps one path segment at a time.
  * Returns `null` for a document that cannot be made schema-valid; the caller
  * drops it rather than letting non-null propagation null the whole page.
+ *
+ * Each path segment carries its own list flag. APPSYNC_JS has no `Array`
+ * global to test a value against, and it needs none: the projection already
+ * says which steps are lists.
  */
 function renderNormalizeNodeHelper(levels: DocumentLevelSpec[]): string {
 	if (levels.length === 0) return "";
@@ -759,9 +776,9 @@ function ${NORMALIZE_NODE_HELPER}(node) {
 		for (const segment of level[0]) {
 			const next = [];
 			for (const container of containers) {
-				const value = container[segment];
+				const value = container[segment[0]];
 				if (value != null) {
-					if (Array.isArray(value)) {
+					if (segment[1]) {
 						for (const item of value) {
 							if (item != null) next.push(item);
 						}

--- a/src/emit-graphql-resolver.ts
+++ b/src/emit-graphql-resolver.ts
@@ -755,9 +755,11 @@ function isArrayType(type: ResolvedProjectionField["type"]): boolean {
  * Returns `null` for a document that cannot be made schema-valid; the caller
  * drops it rather than letting non-null propagation null the whole page.
  *
- * Each path segment carries its own list flag. APPSYNC_JS has no `Array`
- * global to test a value against, and it needs none: the projection already
- * says which steps are lists.
+ * Each path segment carries its own list flag, but a mapping can still hand
+ * back a single object where the schema declares a list (or vice versa).
+ * APPSYNC_JS has no `Array` global and no try/catch, so the flag is only
+ * intent: `value.length !== undefined` is the actual list test, safe here
+ * because a segment value is always an object or an array of objects.
  */
 function renderNormalizeNodeHelper(levels: DocumentLevelSpec[]): string {
 	if (levels.length === 0) return "";
@@ -778,7 +780,7 @@ function ${NORMALIZE_NODE_HELPER}(node) {
 			for (const container of containers) {
 				const value = container[segment[0]];
 				if (value != null) {
-					if (segment[1]) {
+					if (value.length !== undefined) {
 						for (const item of value) {
 							if (item != null) next.push(item);
 						}

--- a/test/snapshots/opensearch-baseline/pet-public-search-doc-resolver.js
+++ b/test/snapshots/opensearch-baseline/pet-public-search-doc-resolver.js
@@ -64,7 +64,7 @@ function normalizeNode(node) {
 			for (const container of containers) {
 				const value = container[segment[0]];
 				if (value != null) {
-					if (segment[1]) {
+					if (value.length !== undefined) {
 						for (const item of value) {
 							if (item != null) next.push(item);
 						}

--- a/test/snapshots/opensearch-baseline/pet-public-search-doc-resolver.js
+++ b/test/snapshots/opensearch-baseline/pet-public-search-doc-resolver.js
@@ -62,9 +62,9 @@ function normalizeNode(node) {
 		for (const segment of level[0]) {
 			const next = [];
 			for (const container of containers) {
-				const value = container[segment];
+				const value = container[segment[0]];
 				if (value != null) {
-					if (Array.isArray(value)) {
+					if (segment[1]) {
 						for (const item of value) {
 							if (item != null) next.push(item);
 						}

--- a/test/snapshots/opensearch-baseline/pet-search-doc-resolver.js
+++ b/test/snapshots/opensearch-baseline/pet-search-doc-resolver.js
@@ -57,7 +57,7 @@ export function response(ctx) {
 	};
 }
 
-const DOC_SPEC = [[[],["tags","aliases","approvals","bankAccountApprovals"],["id","name","species","birthDate","createdAt","owner","rank","stock","score","active"]],[["tags"],[],["name"]],[["approvals"],[],["type","grantedBy"]],[["bankAccountApprovals"],[],["accountId","approvedBy"]]];
+const DOC_SPEC = [[[],["tags","aliases","approvals","bankAccountApprovals"],["id","name","species","birthDate","createdAt","owner","rank","stock","score","active"]],[[["tags",true]],[],["name"]],[[["approvals",true]],[],["type","grantedBy"]],[[["bankAccountApprovals",true]],[],["accountId","approvedBy"]]];
 
 function normalizeNode(node) {
 	if (node == null) return null;
@@ -66,9 +66,9 @@ function normalizeNode(node) {
 		for (const segment of level[0]) {
 			const next = [];
 			for (const container of containers) {
-				const value = container[segment];
+				const value = container[segment[0]];
 				if (value != null) {
-					if (Array.isArray(value)) {
+					if (segment[1]) {
 						for (const item of value) {
 							if (item != null) next.push(item);
 						}

--- a/test/snapshots/opensearch-baseline/pet-search-doc-resolver.js
+++ b/test/snapshots/opensearch-baseline/pet-search-doc-resolver.js
@@ -68,7 +68,7 @@ function normalizeNode(node) {
 			for (const container of containers) {
 				const value = container[segment[0]];
 				if (value != null) {
-					if (segment[1]) {
+					if (value.length !== undefined) {
 						for (const item of value) {
 							if (item != null) next.push(item);
 						}

--- a/test/snapshots/opensearch-baseline/tag-search-doc-resolver.js
+++ b/test/snapshots/opensearch-baseline/tag-search-doc-resolver.js
@@ -61,9 +61,9 @@ function normalizeNode(node) {
 		for (const segment of level[0]) {
 			const next = [];
 			for (const container of containers) {
-				const value = container[segment];
+				const value = container[segment[0]];
 				if (value != null) {
-					if (Array.isArray(value)) {
+					if (segment[1]) {
 						for (const item of value) {
 							if (item != null) next.push(item);
 						}

--- a/test/snapshots/opensearch-baseline/tag-search-doc-resolver.js
+++ b/test/snapshots/opensearch-baseline/tag-search-doc-resolver.js
@@ -63,7 +63,7 @@ function normalizeNode(node) {
 			for (const container of containers) {
 				const value = container[segment[0]];
 				if (value != null) {
-					if (segment[1]) {
+					if (value.length !== undefined) {
 						for (const item of value) {
 							if (item != null) next.push(item);
 						}


### PR DESCRIPTION
Follow-up to #176. Unblocks stxcommodities/core-services#3341.

`Array` is not part of the APPSYNC_JS runtime — only `Array.prototype` methods are. The drift walker #176 introduced calls `Array.isArray(value)` to decide whether a path segment is a list, so every projection with a nested non-null level either fails `CreateResolver` validation or throws at runtime. That is every projection in core-services.

The emitter already knows which segments are lists when it builds the spec. Each path segment now carries that flag and the walker branches on it, so nothing needs to be asked of the runtime.

The forbidden-globals test is the only gate on this — the eslint plugin has no rule for globals and the emitter's own tests eval in Node, where they all exist. It matched the call form only, which is how `Array.isArray(` got through. It now matches member access as well, and covers `Promise`, `Date`, `RegExp`, `Symbol`, `Map` and `Set`.

Snapshot re-capture is limited to the three baseline resolvers that carry a walker: the walker body in all three, plus the `DOC_SPEC` path literal in `pet-search-doc-resolver.js`, which is the only baseline projection with nested levels.