### PR TITLE
fix(graphql): unroll the normalizeNode walker so AppSync's checker can index it

### DIFF
--- a/src/emit-graphql-resolver.test.ts
+++ b/src/emit-graphql-resolver.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it } from "node:test";
 import type { Type } from "@typespec/compiler";
+import ts from "typescript";
 import {
 	__test,
 	APPSYNC_FUNCTION_BYTE_LIMIT,
@@ -116,6 +117,86 @@ function assertNoForbiddenGlobals(fileName: string, content: string): void {
 			re.test(content),
 			false,
 			`${fileName} must not reference the \`${name}\` global — APPSYNC_JS does not provide it.\n--- content ---\n${content}\n--- end ---`,
+		);
+	}
+}
+
+// AppSync's APPSYNC_JS static check rejects resolver code that a globals
+// regex can't see: an emitted table-driven walker whose sibling rows carry
+// differently-shaped nested arrays (e.g. a per-level path mixed with a
+// per-level string list) makes AppSync's TypeScript-based checker infer the
+// wrong element type for a later computed property access, and it rejects
+// the resolver at CloudFormation deploy time with a real `TS2538` diagnostic
+// ("... cannot be used as an index type") — this bit `renderNormalizeNodeHelper`
+// in production (cos-infra SearchApiStack.Deploy, 2026-07-29). AppSync has no
+// offline emulator, but its checker is a real TypeScript `checkJs` pass, so
+// running the same content through the `typescript` compiler API locally
+// reproduces the identical diagnostic without needing live AWS credentials.
+const APPSYNC_UTILS_STUB_PATH = "/appsync-utils-stub.d.ts";
+const APPSYNC_UTILS_STUB =
+	'declare module "@aws-appsync/utils" {\n\texport const util: any;\n\texport const runtime: any;\n}\n';
+
+// Building one `ts.Program` per file re-parses the standard lib every call,
+// which dominates runtime once dozens of files are checked. All callers in
+// one test run share this single program instead.
+function assertAllAppsyncJsTypeSafe(
+	files: Array<{ name: string; content: string }>,
+): void {
+	const pathByName = new Map(
+		files.map((file, index) => [file.name, `/resolver-${index}.js`]),
+	);
+	const textByPath = new Map<string, string>([
+		[APPSYNC_UTILS_STUB_PATH, APPSYNC_UTILS_STUB],
+		...files.map(
+			(file) => [pathByName.get(file.name), file.content] as [string, string],
+		),
+	]);
+
+	const compilerOptions: ts.CompilerOptions = {
+		allowJs: true,
+		checkJs: true,
+		noEmit: true,
+		target: ts.ScriptTarget.ES2020,
+		module: ts.ModuleKind.ESNext,
+		moduleResolution: ts.ModuleResolutionKind.Bundler,
+	};
+
+	const host = ts.createCompilerHost(compilerOptions);
+	const getSourceFile = host.getSourceFile.bind(host);
+	host.getSourceFile = (name, languageVersion, ...rest) => {
+		const text = textByPath.get(name);
+		if (text === undefined)
+			return getSourceFile(name, languageVersion, ...rest);
+		return ts.createSourceFile(
+			name,
+			text,
+			languageVersion,
+			true,
+			name.endsWith(".d.ts") ? ts.ScriptKind.TS : ts.ScriptKind.JS,
+		);
+	};
+	host.fileExists = (name) => textByPath.has(name) || ts.sys.fileExists(name);
+	host.readFile = (name) => textByPath.get(name) ?? ts.sys.readFile(name);
+
+	const program = ts.createProgram(
+		[APPSYNC_UTILS_STUB_PATH, ...textByPath.keys()],
+		compilerOptions,
+		host,
+	);
+	const diagnostics = ts.getPreEmitDiagnostics(program);
+
+	for (const file of files) {
+		const path = pathByName.get(file.name);
+		const fileDiagnostics = diagnostics
+			.filter((diagnostic) => diagnostic.file?.fileName === path)
+			.map(
+				(diagnostic) =>
+					`TS${diagnostic.code}: ${ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n")}`,
+			);
+		assert.deepEqual(
+			fileDiagnostics,
+			[],
+			`${file.name} fails AppSync's APPSYNC_JS static check\n--- content ---\n${file.content}\n--- end ---`,
 		);
 	}
 }
@@ -2305,6 +2386,51 @@ describe("emitGraphQLResolver search filter DSL", () => {
 			const content = await readFile(join("test/snapshots", fileName), "utf8");
 			assertNoForbiddenGlobals(`test/snapshots/${fileName}`, content);
 		}
+	});
+
+	it("emitted normalizeNode walker passes AppSync's APPSYNC_JS static check (regression: jagged DOC_SPEC broke computed indexing)", async () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({ name: "packageId", keyword: true }),
+				makeField({
+					name: "members",
+					nested: true,
+					type: {
+						kind: "Model",
+						name: "Array",
+						indexer: { value: { kind: "Model" } },
+					} as unknown as Type,
+					subProjection: makeSubProjection("PackageMemberDoc", [
+						makeField({ name: "productId", keyword: true }),
+						makeField({ name: "productCode", keyword: true }),
+					]),
+				}),
+			],
+		});
+		const result = await emitGraphQLResolver(projection, defaultOptions);
+
+		const allFiles = [
+			{ name: "resolver", content: result.content },
+			...result.functions.map((fn) => ({ name: fn.name, content: fn.content })),
+		];
+
+		const snapshotFileNames = (
+			await readdir("test/snapshots", { recursive: true })
+		).filter((fileName) => fileName.endsWith(".js"));
+		const snapshotFiles = await Promise.all(
+			snapshotFileNames.map(async (fileName) => ({
+				name: `test/snapshots/${fileName}`,
+				content: await readFile(join("test/snapshots", fileName), "utf8"),
+			})),
+		);
+
+		assertAllAppsyncJsTypeSafe([
+			...allFiles.map((file) => ({
+				...file,
+				name: `emitted ${file.name}`,
+			})),
+			...snapshotFiles,
+		]);
 	});
 
 	it("emitted resolver passes @aws-appsync/eslint-plugin recommended config", async () => {

--- a/src/emit-graphql-resolver.ts
+++ b/src/emit-graphql-resolver.ts
@@ -755,30 +755,59 @@ function isArrayType(type: ResolvedProjectionField["type"]): boolean {
  * Returns `null` for a document that cannot be made schema-valid; the caller
  * drops it rather than letting non-null propagation null the whole page.
  *
- * Each path segment carries its own list flag, but a mapping can still hand
- * back a single object where the schema declares a list (or vice versa).
- * APPSYNC_JS has no `Array` global and no try/catch, so the flag is only
- * intent: `value.length !== undefined` is the actual list test, safe here
- * because a segment value is always an object or an array of objects.
+ * Every level and segment is unrolled into its own literal block at emit
+ * time rather than driven off a shared data table walked generically:
+ * AppSync's APPSYNC_JS static checker infers a single element type across
+ * all rows of a JS array literal, and a table whose rows carry
+ * different-shaped nested arrays (one level's path segments vs another's)
+ * gets that type wrong, rejecting a later `container[computedKey]` with
+ * "type ... cannot be used as an index type" even though every runtime value
+ * is a plain string. Emitting a literal property access per segment sidesteps
+ * the inference entirely.
+ *
+ * A mapping can still hand back a single object where the schema declares a
+ * list (or vice versa). APPSYNC_JS has no `Array` global and no try/catch, so
+ * `value.length !== undefined` is the list test, safe here because a segment
+ * value is always an object or an array of objects.
  */
 function renderNormalizeNodeHelper(levels: DocumentLevelSpec[]): string {
 	if (levels.length === 0) return "";
 
-	const specLiteral = JSON.stringify(
-		levels.map((level) => [level.path, level.lists, level.values]),
-	);
+	const levelBlocks = levels.map(renderDocumentLevelBlock).join("\n");
 
 	return `
-const DOC_SPEC = ${specLiteral};
-
 function ${NORMALIZE_NODE_HELPER}(node) {
 	if (node == null) return null;
-	for (const level of DOC_SPEC) {
+${levelBlocks}
+	return node;
+}
+`;
+}
+
+function renderDocumentLevelBlock(level: DocumentLevelSpec): string {
+	const traversalBlocks = level.path
+		.map(([name]) => renderPathSegmentBlock(name))
+		.join("\n");
+
+	return `	{
 		let containers = [node];
-		for (const segment of level[0]) {
+${traversalBlocks}
+		for (const container of containers) {
+			for (const name of ${JSON.stringify(level.lists)}) {
+				if (container[name] == null) container[name] = [];
+			}
+			for (const name of ${JSON.stringify(level.values)}) {
+				if (container[name] == null) return null;
+			}
+		}
+	}`;
+}
+
+function renderPathSegmentBlock(name: string): string {
+	return `		{
 			const next = [];
 			for (const container of containers) {
-				const value = container[segment[0]];
+				const value = container[${JSON.stringify(name)}];
 				if (value != null) {
 					if (value.length !== undefined) {
 						for (const item of value) {
@@ -790,19 +819,7 @@ function ${NORMALIZE_NODE_HELPER}(node) {
 				}
 			}
 			containers = next;
-		}
-		for (const container of containers) {
-			for (const name of level[1]) {
-				if (container[name] == null) container[name] = [];
-			}
-			for (const name of level[2]) {
-				if (container[name] == null) return null;
-			}
-		}
-	}
-	return node;
-}
-`;
+		}`;
 }
 
 /**

--- a/test/snapshots/opensearch-baseline/pet-public-search-doc-resolver.js
+++ b/test/snapshots/opensearch-baseline/pet-public-search-doc-resolver.js
@@ -53,33 +53,16 @@ export function response(ctx) {
 	};
 }
 
-const DOC_SPEC = [[[],["tags","aliases","approvals","bankAccountApprovals"],["id","name","species","birthDate","createdAt","owner","rank","stock","score","active"]]];
-
 function normalizeNode(node) {
 	if (node == null) return null;
-	for (const level of DOC_SPEC) {
+	{
 		let containers = [node];
-		for (const segment of level[0]) {
-			const next = [];
-			for (const container of containers) {
-				const value = container[segment[0]];
-				if (value != null) {
-					if (value.length !== undefined) {
-						for (const item of value) {
-							if (item != null) next.push(item);
-						}
-					} else {
-						next.push(value);
-					}
-				}
-			}
-			containers = next;
-		}
+
 		for (const container of containers) {
-			for (const name of level[1]) {
+			for (const name of ["tags","aliases","approvals","bankAccountApprovals"]) {
 				if (container[name] == null) container[name] = [];
 			}
-			for (const name of level[2]) {
+			for (const name of ["id","name","species","birthDate","createdAt","owner","rank","stock","score","active"]) {
 				if (container[name] == null) return null;
 			}
 		}

--- a/test/snapshots/opensearch-baseline/pet-search-doc-resolver.js
+++ b/test/snapshots/opensearch-baseline/pet-search-doc-resolver.js
@@ -57,16 +57,26 @@ export function response(ctx) {
 	};
 }
 
-const DOC_SPEC = [[[],["tags","aliases","approvals","bankAccountApprovals"],["id","name","species","birthDate","createdAt","owner","rank","stock","score","active"]],[[["tags",true]],[],["name"]],[[["approvals",true]],[],["type","grantedBy"]],[[["bankAccountApprovals",true]],[],["accountId","approvedBy"]]];
-
 function normalizeNode(node) {
 	if (node == null) return null;
-	for (const level of DOC_SPEC) {
+	{
 		let containers = [node];
-		for (const segment of level[0]) {
+
+		for (const container of containers) {
+			for (const name of ["tags","aliases","approvals","bankAccountApprovals"]) {
+				if (container[name] == null) container[name] = [];
+			}
+			for (const name of ["id","name","species","birthDate","createdAt","owner","rank","stock","score","active"]) {
+				if (container[name] == null) return null;
+			}
+		}
+	}
+	{
+		let containers = [node];
+		{
 			const next = [];
 			for (const container of containers) {
-				const value = container[segment[0]];
+				const value = container["tags"];
 				if (value != null) {
 					if (value.length !== undefined) {
 						for (const item of value) {
@@ -80,10 +90,64 @@ function normalizeNode(node) {
 			containers = next;
 		}
 		for (const container of containers) {
-			for (const name of level[1]) {
+			for (const name of []) {
 				if (container[name] == null) container[name] = [];
 			}
-			for (const name of level[2]) {
+			for (const name of ["name"]) {
+				if (container[name] == null) return null;
+			}
+		}
+	}
+	{
+		let containers = [node];
+		{
+			const next = [];
+			for (const container of containers) {
+				const value = container["approvals"];
+				if (value != null) {
+					if (value.length !== undefined) {
+						for (const item of value) {
+							if (item != null) next.push(item);
+						}
+					} else {
+						next.push(value);
+					}
+				}
+			}
+			containers = next;
+		}
+		for (const container of containers) {
+			for (const name of []) {
+				if (container[name] == null) container[name] = [];
+			}
+			for (const name of ["type","grantedBy"]) {
+				if (container[name] == null) return null;
+			}
+		}
+	}
+	{
+		let containers = [node];
+		{
+			const next = [];
+			for (const container of containers) {
+				const value = container["bankAccountApprovals"];
+				if (value != null) {
+					if (value.length !== undefined) {
+						for (const item of value) {
+							if (item != null) next.push(item);
+						}
+					} else {
+						next.push(value);
+					}
+				}
+			}
+			containers = next;
+		}
+		for (const container of containers) {
+			for (const name of []) {
+				if (container[name] == null) container[name] = [];
+			}
+			for (const name of ["accountId","approvedBy"]) {
 				if (container[name] == null) return null;
 			}
 		}

--- a/test/snapshots/opensearch-baseline/tag-search-doc-resolver.js
+++ b/test/snapshots/opensearch-baseline/tag-search-doc-resolver.js
@@ -52,33 +52,16 @@ export function response(ctx) {
 	};
 }
 
-const DOC_SPEC = [[[],[],["name"]]];
-
 function normalizeNode(node) {
 	if (node == null) return null;
-	for (const level of DOC_SPEC) {
+	{
 		let containers = [node];
-		for (const segment of level[0]) {
-			const next = [];
-			for (const container of containers) {
-				const value = container[segment[0]];
-				if (value != null) {
-					if (value.length !== undefined) {
-						for (const item of value) {
-							if (item != null) next.push(item);
-						}
-					} else {
-						next.push(value);
-					}
-				}
-			}
-			containers = next;
-		}
+
 		for (const container of containers) {
-			for (const name of level[1]) {
+			for (const name of []) {
 				if (container[name] == null) container[name] = [];
 			}
-			for (const name of level[2]) {
+			for (const name of ["name"]) {
 				if (container[name] == null) return null;
 			}
 		}


### PR DESCRIPTION
## Summary

Every `*-search-graphql` package built from 2.0.9 fails at AppSync deploy time: `The code contains one or more errors.` CloudFormation gives no detail beyond that; `aws appsync evaluate-code` against the published resolver reproduces the real diagnostic:

```
code.js(98,29): error TS2538: Type 'false' cannot be used as an index type.
code.js(98,29): error TS2538: Type 'true' cannot be used as an index type.
code.js(113,19): error TS2538: Type '(string | boolean)[]' cannot be used as an index type.
```

AppSync's APPSYNC_JS static check runs a real TypeScript `checkJs` pass. The response walker added in #176/#177 builds `DOC_SPEC`, a single array literal whose rows carry differently-shaped nested arrays — one level's `path` mixes a `[name, isList]` tuple, another level's `lists`/`values` are plain string arrays. That jaggedness makes the checker infer the wrong element type for `container[segment[0]]` and `container[name]`, and it rejects the resolver — confirmed by removing only the boolean (kept the jaggedness) and the same class of error still fired, isolating the cause to the jagged literal shape, not to any specific runtime value.

Every path segment and level is already known at emit time, so the walker is now generated as literal, per-level, per-segment blocks instead of a shared table walked generically. No property access is derived from an array literal element anymore, which removes the ambiguity entirely — verified end-to-end against `aws appsync evaluate-code` with the old code (rejected, identical diagnostics) and the new code (accepted, evaluates to the expected normalized document).

## Regression coverage

Adds `assertAllAppsyncJsTypeSafe`, which runs emitted resolvers (and every committed snapshot under `test/snapshots`) through the `typescript` compiler API in `allowJs`/`checkJs` mode. AppSync's own error codes are real TypeScript diagnostics (confirmed `TS2538` matches exactly between `aws appsync evaluate-code` and plain `tsc --checkJs`), so this reproduces the same class of failure offline, with no AWS credentials required — it fails against the pre-fix walker with the identical `TS2538` diagnostics and passes against the fix.

This gate covers structural type-inference failures in the emitted JS (jagged literals feeding computed property access, and future variants of the same class). It does not cover the full APPSYNC_JS runtime surface — resolver logic errors, data-source-specific behavior, or anything that only a live `evaluate-code` call or an actual deploy would catch. A live-credentialed equivalent would close that gap but needs AWS credentials this CI does not have.

## Test plan

- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm test` (440 unit tests + 28 emit/example tests, all green)
- [x] New regression test fails against the pre-fix walker (verified via `git stash`) with the exact `TS2538` diagnostics from production, passes after the fix
- [x] Verified against live AppSync (`aws appsync evaluate-code`, eu-central-1) with both the old and new resolver code