### PR TITLE
fix(graphql): split the response walker when the resolver-level file overflows the threshold

### DIFF
--- a/src/emit-graphql-resolver.test.ts
+++ b/src/emit-graphql-resolver.test.ts
@@ -4110,8 +4110,12 @@ describe("emitGraphQLResolver recursive pipeline split (issue #173)", () => {
 				c: unknown,
 			) => { params?: { body?: Record<string, unknown> } };
 		}
+		// `normalize*` functions (issue #179) run after `search` and mutate
+		// response hits, not the request body this helper assembles — skip them.
 		for (const fn of result.functions) {
-			if (fn.dataSource === "NONE") loadRequest(fn.content)(ctx);
+			if (fn.dataSource === "NONE" && !fn.name.startsWith("normalize")) {
+				loadRequest(fn.content)(ctx);
+			}
 		}
 		const search = result.functions.find((f) => f.dataSource === "OPENSEARCH");
 		if (!search) throw new Error("split pipeline has no OPENSEARCH function");
@@ -4407,6 +4411,250 @@ describe("emitGraphQLResolver recursive pipeline split (issue #173)", () => {
 			canonical(splitBody.aggs),
 			canonical(monoBody.aggs),
 			"split aggs (with search-side budget division) must match the monolithic aggs",
+		);
+	});
+});
+
+// Issue #179 — the recursive split (issue #173) only measured and subdivided
+// the request-side prepare/query/aggs functions. The resolver-level
+// after-mapping — which carries the response walker (normalizeNode, unrolled
+// per document level since issue #178) and the aggregation response mapping
+// — was never measured against the threshold and had no split path, so a wide
+// non-null response shape could ship a resolver-level file sitting just under
+// the 32,768-byte hard cap with no headroom (production: 31,011 bytes, 94% of
+// the cap). These tests cover the response-side split that closes that gap.
+describe("emitGraphQLResolver response-side split (issue #179)", () => {
+	const forcePipeline = {
+		defaultPageSize: 20,
+		maxPageSize: 100,
+		trackTotalHitsUpTo: 10000,
+		monolithicThresholdBytes: 0,
+	};
+
+	// No filterables/aggregations, so FILTER_SPEC/AGG_SPEC stay tiny and
+	// `prepare` never approaches the threshold — only the response walker
+	// (one document level per nested part, all fields required/non-null)
+	// grows with `nestedCount`, isolating the response-side split from the
+	// request-side one covered by the issue #173 tests above.
+	function wideResponseProjection(
+		nestedCount: number,
+		fieldsPerSub: number,
+	): ResolvedProjection {
+		const shapes = Array.from({ length: nestedCount }, (_, i) => `Part${i}`);
+		return makeProjection({
+			name: "WidgetSearchDoc",
+			indexName: "widgets",
+			fields: [
+				makeField({ name: "widgetId", keyword: true }),
+				...shapes.map((shape) =>
+					makeField({
+						name: `${shape.toLowerCase()}s`,
+						nested: true,
+						subProjection: makeSubProjection(
+							`${shape}SearchDoc`,
+							Array.from({ length: fieldsPerSub }, (_, j) =>
+								makeField({ name: `field${j}` }),
+							),
+						),
+						type: {
+							kind: "Model",
+							name: "Array",
+							indexer: { value: { kind: "Model" } },
+						} as unknown as Type,
+					}),
+				),
+			],
+		});
+	}
+
+	function allFiles(
+		result: EmitResult,
+	): { name: string; content: string; bytes: number }[] {
+		return [
+			{ name: "resolver", content: result.content },
+			...result.functions.map((fn) => ({ name: fn.name, content: fn.content })),
+		].map((f) => ({ ...f, bytes: Buffer.byteLength(f.content, "utf-8") }));
+	}
+
+	it("ships a single resolver-level file, unsplit, when the response walker fits under the threshold", async () => {
+		const result = await emitGraphQLResolver(
+			wideResponseProjection(20, 5),
+			forcePipeline,
+		);
+
+		assert.equal(result.mode, "pipeline");
+		assert.deepEqual(
+			result.functions.map((f) => f.name),
+			["prepare", "search"],
+		);
+		assert.ok(result.content.includes("let containers = [node];"));
+		for (const file of allFiles(result)) {
+			assert.ok(
+				file.bytes <= 31_000,
+				`${file.name} is ${file.bytes} bytes; expected to fit under the 31,000 B threshold unsplit`,
+			);
+		}
+	});
+
+	it("splits the response walker across normalize functions when the resolver-level file exceeds the 31,000 B threshold", async () => {
+		const result = await emitGraphQLResolver(
+			wideResponseProjection(48, 5),
+			forcePipeline,
+		);
+
+		assert.equal(result.mode, "pipeline");
+		const names = result.functions.map((f) => f.name);
+		assert.deepEqual(names, ["prepare", "search", "normalize", "normalize-1"]);
+		assert.deepEqual(
+			result.functions.map((f) => f.dataSource),
+			["NONE", "OPENSEARCH", "NONE", "NONE"],
+		);
+
+		// The resolver-level file no longer carries any walker code — that's
+		// the point of the split.
+		assert.ok(!result.content.includes("let containers = [node];"));
+		assert.ok(result.content.includes("ctx.stash.parsedBody"));
+		assert.ok(
+			result.functions
+				.filter((f) => f.name.startsWith("normalize"))
+				.every((f) => f.content.includes("let containers = [node];")),
+		);
+
+		for (const file of allFiles(result)) {
+			assert.ok(
+				file.bytes < 31_000,
+				`${file.name} is ${file.bytes} bytes; must stay under the 31,000 B split threshold`,
+			);
+			assert.ok(
+				file.bytes < APPSYNC_FUNCTION_BYTE_LIMIT,
+				`${file.name} is ${file.bytes} bytes; must stay under the 32,768 B AppSync hard cap`,
+			);
+		}
+	});
+
+	it("keeps every part under both caps across a range of response-heavy widths", async () => {
+		for (const nestedCount of [40, 48, 60, 90]) {
+			const result = await emitGraphQLResolver(
+				wideResponseProjection(nestedCount, 5),
+				forcePipeline,
+			);
+			for (const file of allFiles(result)) {
+				assert.ok(
+					file.bytes < 31_000,
+					`${nestedCount}-nested ${file.name} is ${file.bytes} bytes; must stay under 31,000 B`,
+				);
+				assert.ok(
+					file.bytes < APPSYNC_FUNCTION_BYTE_LIMIT,
+					`${nestedCount}-nested ${file.name} is ${file.bytes} bytes; must stay under ${APPSYNC_FUNCTION_BYTE_LIMIT}`,
+				);
+			}
+		}
+	});
+
+	it("split resolver-level file and normalize functions pass AppSync's APPSYNC_JS static check", async () => {
+		const result = await emitGraphQLResolver(
+			wideResponseProjection(48, 5),
+			forcePipeline,
+		);
+		assert.ok(result.functions.some((f) => f.name.startsWith("normalize")));
+
+		assertAllAppsyncJsTypeSafe(
+			allFiles(result).map((f) => ({
+				name: `emitted ${f.name}`,
+				content: f.content,
+			})),
+		);
+	});
+
+	// Threads a fake OpenSearch response through the split normalize functions
+	// exactly as the runtime would (search's response *is* the OS body; each
+	// NONE normalize function mutates hits in place and stashes/reads
+	// ctx.stash.parsedBody), then evaluates the resolver-level response() to
+	// build the final page — and compares it against the monolithic path
+	// (same fixture, threshold high enough to stay single-file) to prove the
+	// split doesn't change what a caller sees.
+	function runNormalizeChainAndRespond(
+		result: EmitResult,
+		osBody: Record<string, unknown>,
+		args: Record<string, unknown>,
+	): unknown {
+		const utilStub = {
+			base64Decode: (s: string) => Buffer.from(s, "base64").toString("utf8"),
+			base64Encode: (s: string) => Buffer.from(s, "utf8").toString("base64"),
+			error: (msg: string) => {
+				throw new Error(msg);
+			},
+		};
+		function loadRequest(source: string) {
+			const stripped = source
+				.replace(/^import \{ util \} from "@aws-appsync\/utils";?\n?/m, "")
+				.replace(/^export function /gm, "function ");
+			return new Function("util", `${stripped}\nreturn request;`)(utilStub) as (
+				c: unknown,
+			) => unknown;
+		}
+		const ctx = {
+			args,
+			stash: {} as Record<string, unknown>,
+			prev: { result: osBody },
+		};
+		for (const fn of result.functions) {
+			if (fn.name.startsWith("normalize")) loadRequest(fn.content)(ctx);
+		}
+		return evalResponse(result.content, ctx);
+	}
+
+	it("split-mode response matches the monolithic path: same drops, same list defaults, same page", async () => {
+		const projection = wideResponseProjection(60, 2);
+		const split = await emitGraphQLResolver(projection, forcePipeline);
+		assert.ok(split.functions.some((f) => f.name.startsWith("normalize")));
+
+		const monolithic = await emitGraphQLResolver(projection, {
+			...forcePipeline,
+			monolithicThresholdBytes: 10_000_000,
+		});
+		assert.equal(monolithic.mode, "monolithic");
+
+		function makeHit(id: string, opts: { dropWidget?: boolean } = {}) {
+			const parts: Record<string, unknown>[] = [];
+			for (let i = 0; i < 60; i++) {
+				parts.push({ field0: `v${i}`, field1: `w${i}` });
+			}
+			return {
+				_id: id,
+				sort: [id],
+				_source: {
+					widgetId: opts.dropWidget ? undefined : id,
+					...Object.fromEntries(
+						Array.from({ length: 60 }, (_, i) => [`part${i}s`, parts]),
+					),
+				},
+			};
+		}
+
+		const osBody = {
+			hits: {
+				total: { value: 2 },
+				hits: [makeHit("w1"), makeHit("w2", { dropWidget: true })],
+			},
+		};
+
+		const args = { first: 10 };
+		const splitResponse = runNormalizeChainAndRespond(
+			split,
+			JSON.parse(JSON.stringify(osBody)),
+			args,
+		);
+		const monoResponse = evalResponse(monolithic.content, {
+			args,
+			result: JSON.parse(JSON.stringify(osBody)),
+		});
+
+		assert.deepEqual(splitResponse, monoResponse);
+		assert.equal(
+			(splitResponse as { edges: unknown[] }).edges.length,
+			1,
+			"the hit missing the required widgetId must be dropped in both modes",
 		);
 	});
 });

--- a/src/emit-graphql-resolver.ts
+++ b/src/emit-graphql-resolver.ts
@@ -67,7 +67,7 @@ export interface ResolverOptions {
 	autoDateHistogramBuckets?: number;
 }
 
-const DEFAULT_MONOLITHIC_THRESHOLD_BYTES = 32_000;
+const DEFAULT_MONOLITHIC_THRESHOLD_BYTES = 31_000;
 
 /**
  * AppSync's hard per-function code limit. `CreateFunction` rejects any resolver
@@ -254,50 +254,61 @@ export async function emitGraphQLResolver(
 	// Level 1: the single prepare fits the per-function target, so ship the
 	// original two-function shape byte-for-byte. Only when the whole request
 	// side overflows the cap does the recursive split take over (issue #173).
-	if (Buffer.byteLength(prepareContent, "utf-8") <= functionThreshold) {
-		return {
-			queryFieldName,
-			mode: "pipeline",
-			fileName: `${baseName}-resolver.js`,
-			content: resolverContent,
-			functions: [
-				{
-					name: "prepare",
-					fileName: `${baseName}-fn-prepare.js`,
-					content: prepareContent,
-					dataSource: "NONE",
-				},
-				{
-					name: "search",
-					fileName: `${baseName}-fn-search.js`,
-					content: renderSearchFunction(projection.indexName),
-					dataSource: "OPENSEARCH",
-				},
-			],
-		};
-	}
+	const requestFunctions: EmittedPipelineFunction[] =
+		Buffer.byteLength(prepareContent, "utf-8") <= functionThreshold
+			? [
+					{
+						name: "prepare",
+						fileName: `${baseName}-fn-prepare.js`,
+						content: prepareContent,
+						dataSource: "NONE",
+					},
+					{
+						name: "search",
+						fileName: `${baseName}-fn-search.js`,
+						content: renderSearchFunction(projection.indexName),
+						dataSource: "OPENSEARCH",
+					},
+				]
+			: // Levels 2/3: split the request side across NONE functions that each
+				// contribute to shared ctx.stash structures, and let the OPENSEARCH
+				// `search` function assemble the body from them (issue #173).
+				buildSplitPipeline({
+					baseName,
+					indexName: projection.indexName,
+					textFields,
+					keywordFields,
+					textSortFields,
+					aggregations,
+					searchFilterShape,
+					options,
+					functionThreshold,
+				});
 
-	// Levels 2/3: split the request side across NONE functions that each
-	// contribute to shared ctx.stash structures, and let the OPENSEARCH `search`
-	// function assemble the body from them (issue #173).
-	const functions = buildSplitPipeline({
-		baseName,
-		indexName: projection.indexName,
-		textFields,
-		keywordFields,
-		textSortFields,
-		aggregations,
-		searchFilterShape,
-		options,
-		functionThreshold,
-	});
+	// The resolver-level after-mapping carries the response walker (issue #178
+	// unrolled it into per-level literal blocks) and the aggregation mapping.
+	// Neither is measured by the request-side split above, so a wide non-null
+	// response shape can overflow the cap with no split path at all (issue
+	// #179). When it does, partition the walker across further NONE functions
+	// that run after `search` and mutate the shared hits in place; the
+	// resolver-level file then only assembles the already-normalized page.
+	const responseSplit =
+		documentSpec.length > 0 &&
+		Buffer.byteLength(resolverContent, "utf-8") > functionThreshold
+			? buildNormalizeFunctions(baseName, documentSpec, functionThreshold)
+			: [];
+
+	const finalResolverContent =
+		responseSplit.length > 0
+			? renderSplitNormalizeResolver(aggregations, documentSpec, options)
+			: resolverContent;
 
 	return {
 		queryFieldName,
 		mode: "pipeline",
 		fileName: `${baseName}-resolver.js`,
-		content: resolverContent,
-		functions,
+		content: finalResolverContent,
+		functions: [...requestFunctions, ...responseSplit],
 	};
 }
 
@@ -820,6 +831,189 @@ function renderPathSegmentBlock(name: string): string {
 			}
 			containers = next;
 		}`;
+}
+
+/**
+ * Response-side split (issue #179): a level's traversal always re-derives its
+ * `containers` frontier from `node` (the hit's `_source`), never from a prior
+ * level's result, so levels apply commutatively — the same property the
+ * request-side FILTER_SPEC split (issue #173) relies on. A level whose parent
+ * list is still unfilled just sees an empty frontier and applies no defaults
+ * for that branch, which is the same outcome as the parent already being `[]`;
+ * order across levels — and across whichever pipeline function renders them —
+ * never changes the result.
+ *
+ * Used inside the per-hit loop of a `normalize` pipeline function rather than
+ * a standalone `node => node | null` helper: a hit is dropped by marking the
+ * shared `__searchDropped` flag on the hit wrapper (never on `_source`, which
+ * is what the GraphQL response reads), so the loop can keep going instead of
+ * returning out of the whole function.
+ */
+function renderDocumentLevelBlockForHitLoop(level: DocumentLevelSpec): string {
+	const traversalBlocks = level.path
+		.map(([name]) => renderPathSegmentBlock(name))
+		.join("\n");
+
+	return `		{
+			let containers = [node];
+${traversalBlocks}
+			for (const container of containers) {
+				for (const name of ${JSON.stringify(level.lists)}) {
+					if (container[name] == null) container[name] = [];
+				}
+				for (const name of ${JSON.stringify(level.values)}) {
+					if (container[name] == null) invalid = true;
+				}
+			}
+		}`;
+}
+
+/**
+ * A NONE pipeline function that applies a slice of the document-level walker
+ * to every hit on the page, mutating each hit's `_source` in place (issue
+ * #179). Runs after `search`; `isFirst` reads the OpenSearch body straight
+ * from `ctx.prev.result` and stashes it for every function downstream
+ * (including the resolver-level after-mapping), since the split may need
+ * several of these before the page is fully normalized.
+ */
+function renderNormalizeFunction(
+	levels: DocumentLevelSpec[],
+	isFirst: boolean,
+): string {
+	const levelBlocks = levels.map(renderDocumentLevelBlockForHitLoop).join("\n");
+	const intake = isFirst
+		? `	const parsedBody = ctx.prev.result;
+	ctx.stash.parsedBody = parsedBody;
+	const hits = parsedBody.hits.hits;`
+		: `	const hits = ctx.stash.parsedBody.hits.hits;`;
+
+	return `import { util } from "@aws-appsync/utils";
+
+export function request(ctx) {
+${intake}
+	for (const hit of hits) {
+		if (hit.__searchDropped) continue;
+		const node = hit._source;
+		if (node == null) {
+			hit.__searchDropped = true;
+			continue;
+		}
+		let invalid = false;
+${levelBlocks}
+		if (invalid) hit.__searchDropped = true;
+	}
+	return { payload: null };
+}
+
+export function response(ctx) {
+	return ctx.result;
+}
+`;
+}
+
+/**
+ * Partitions the document-level walker across `normalize`/`normalize-N` NONE
+ * functions when the resolver-level after-mapping alone overflows the
+ * threshold (issue #179) — the response-side counterpart to
+ * `buildQueryFunctions`/`buildAggsFunctions`. Packing measures every bin
+ * against the `isFirst` render, which is the larger of the two shapes (it
+ * carries the `ctx.prev.result` intake), so the actual first bin never
+ * exceeds what packing already verified.
+ */
+function buildNormalizeFunctions(
+	baseName: string,
+	levels: DocumentLevelSpec[],
+	functionThreshold: number,
+): EmittedPipelineFunction[] {
+	const bins = packByThreshold(
+		levels,
+		(bin) => renderNormalizeFunction(bin, true),
+		functionThreshold,
+	);
+	return bins.map((bin, i) => ({
+		name: i === 0 ? "normalize" : `normalize-${i}`,
+		fileName:
+			i === 0
+				? `${baseName}-fn-normalize.js`
+				: `${baseName}-fn-normalize-${i}.js`,
+		content: renderNormalizeFunction(bin, i === 0),
+		dataSource: "NONE" as const,
+	}));
+}
+
+/**
+ * Resolver-level after-mapping used once the response walker has been split
+ * across `normalize` functions (issue #179). Those functions already
+ * mutated every hit's `_source` in place and marked undeliverable documents
+ * via `__searchDropped`, so this file only assembles the page — no walker
+ * code lives here, which is the point of the split.
+ */
+function renderSplitNormalizeResolver(
+	aggregations: AggregationEntry[],
+	documentSpec: DocumentLevelSpec[],
+	options: ResolverOptions,
+): string {
+	// A `terms` aggregation's `sub.topHits` embeds hits from an aggregation
+	// bucket — a different OS response subtree than the top-level `hits.hits`
+	// the `normalize` functions mutate — so it still needs the walker inline
+	// here. That combination is rare; keep it correct rather than folding it
+	// into the split.
+	const aggregationsNeedWalker = aggregations.some(aggregationHasTopHits);
+	const walkerDocumentSpec = aggregationsNeedWalker ? documentSpec : [];
+	const normalizeNodeHelper = aggregationsNeedWalker
+		? renderNormalizeNodeHelper(documentSpec)
+		: "";
+	const responseAggregationsPreamble =
+		renderResponseAggregationsPreamble(aggregations);
+	const responseAggregations = renderResponseAggregations(
+		aggregations,
+		walkerDocumentSpec,
+	);
+
+	return `import { util } from "@aws-appsync/utils";
+
+export function request(ctx) {
+	return {};
+}
+
+export function response(ctx) {
+	if (ctx.error) {
+		return util.error(ctx.error.message, ctx.error.type);
+	}
+
+	const parsedBody = ctx.stash.parsedBody;
+	const hits = parsedBody.hits.hits;
+	const totalHits = parsedBody.hits.total.value;
+	const args = ctx.args;
+	const size = Math.min(args.first || ${options.defaultPageSize}, ${options.maxPageSize});
+
+	const hasNextPage = hits.length > size;
+	const page = hits.slice(0, size);
+	const edges = [];
+	for (const hit of page) {
+		if (hit.__searchDropped) {
+			console.log("dropping unrepresentable document", hit._id);
+		} else {
+			edges.push({ node: hit._source, cursor: util.base64Encode(JSON.stringify(hit.sort)) });
+		}
+	}
+${responseAggregationsPreamble}
+	return {
+		edges,
+		totalCount: totalHits,${responseAggregations}
+		pageInfo: {
+			hasNextPage,
+			endCursor: page.length > 0 ? util.base64Encode(JSON.stringify(page[page.length - 1].sort)) : null,
+		},
+	};
+}
+${normalizeNodeHelper}`;
+}
+
+function aggregationHasTopHits(entry: AggregationEntry): boolean {
+	if (entry.kind !== "terms") return false;
+	const opts = (entry.options ?? {}) as { topHits?: number };
+	return typeof opts.topHits === "number" && opts.topHits > 0;
 }
 
 /**

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -167,7 +167,7 @@ export async function $onEmit(
 			maxPageSize: pageOptions.maxPageSize,
 			trackTotalHitsUpTo: graphqlOptions["track-total-hits-up-to"] ?? 10000,
 			monolithicThresholdBytes:
-				graphqlOptions["monolithic-threshold-bytes"] ?? 32000,
+				graphqlOptions["monolithic-threshold-bytes"] ?? 31000,
 			autoDateHistogramBuckets:
 				graphqlOptions["auto-date-histogram-buckets"] ??
 				DEFAULT_AUTO_DATE_HISTOGRAM_BUCKETS,

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -284,7 +284,7 @@ export const $lib = createTypeSpecLibrary({
 						"monolithic-threshold-bytes": {
 							type: "number",
 							nullable: true,
-							default: 32000,
+							default: 31000,
 						},
 						"auto-date-histogram-buckets": {
 							type: "number",


### PR DESCRIPTION
## Root cause

The recursive pipeline split (#175) measures and subdivides only the request-side `prepare`/`prepare-query`/`prepare-aggs` functions. The resolver-level after-mapping — which carries the response walker (`normalizeNode`, unrolled per document level since #178) and the aggregation response mapping — was never measured against the split threshold and had no split path at all. Only the final 32,768-byte hard error caught it, with zero headroom.

A projection with a wide non-null response shape can therefore ship a resolver-level file sitting just under the hard cap with no margin: `tlm-search-graphql/task-search-doc-resolver.js` reached 31,011 bytes (94% of the cap) in core-services after the #178 unroll, entirely outside what the split machinery accounted for.

Filed as #179.

## Fix

- Lower the default split threshold from 32,000 to 31,000 bytes — real headroom under the 32,768 hard cap.
- Partition the document-level walker across `normalize`/`normalize-N` NONE pipeline functions (mirroring the existing query/aggs partitioning) when the resolver-level file alone exceeds the threshold. Each `normalize` function mutates the shared page's hits in place and marks undeliverable documents; the resolver-level file then only assembles the already-normalized page.
- A level's traversal always re-derives its container frontier from the hit's `_source`, never from a prior level's result, so levels apply commutatively regardless of which function renders them or in what order — the same property the request-side FILTER_SPEC split relies on.
- A `terms` aggregation's `sub.topHits` embeds hits from a different OS response subtree than the page-level `hits.hits` the `normalize` functions process, so that combination keeps the walker inline rather than folding into the split.

## Overlap with #174

#174 restructures the request-side `prepare` split further. This PR only touches the response side (the resolver-level after-mapping and the new `normalize` functions) — no shared code path, no expected conflict.

## Testing

- `docs/... ` n/a — no docs.
- New tests in `emitGraphQLResolver response-side split (issue #179)`: unsplit-when-fits, splits when the resolver-level file exceeds 31,000 B, byte caps across a width range, `assertAllAppsyncJsTypeSafe` on the split output, and a split-vs-monolithic functional equivalence check (same drops, same list defaults, same page).
- Full `npm test` (build, lint, unit, emit, example suites) passes locally.
- Attempted `aws appsync evaluate-code` against an emitted split function; the available role lacks `appsync:EvaluateCode` (`AccessDeniedException`). Validation relies on the offline `tsc --allowJs --checkJs` static check, which is the same mechanism the repo's APPSYNC_JS gate (added with #178/2.0.10) uses to reproduce AppSync's `checkJs` diagnostics without live credentials.