### PR TITLE
fix(aggregations): never emit an uncapped bucketing aggregation (#3556)

### DIFF
--- a/src/decorators.test.ts
+++ b/src/decorators.test.ts
@@ -437,7 +437,7 @@ describe("decorators", () => {
 		]);
 	});
 
-	it("accepts date_histogram bounds with only one end", async () => {
+	it("rejects date_histogram bounds with only one end", async () => {
 		const runner = await createRunner();
 		const diagnostics = await runner.diagnose(`
       model Product {
@@ -446,18 +446,14 @@ describe("decorators", () => {
       }
     `);
 
-		assert.equal(diagnostics.length, 0);
+		const codes = diagnostics.map((x) => x.code);
+		assert.equal(hasDiagnosticCode(codes, "invalid-aggregation-options"), true);
 		const validTo = runner.program
 			.getGlobalNamespaceType()
 			.models.get("Product")
 			?.properties.get("validTo");
 		assert.ok(validTo);
-		assert.deepEqual(getAggregatableDirectives(runner.program, validTo), [
-			{
-				kind: "date_histogram",
-				options: { interval: "month", bounds: { max: "now" } },
-			},
-		]);
+		assert.equal(getAggregatableDirectives(runner.program, validTo), undefined);
 	});
 
 	it("emits diagnostic for empty date_histogram bounds", async () => {
@@ -473,10 +469,11 @@ describe("decorators", () => {
 		assert.equal(hasDiagnosticCode(codes, "invalid-aggregation-options"), true);
 	});
 
-	// Issue #150: auto_date_histogram's minimum_interval has no week/quarter
-	// spelling, so these two intervals cannot get an automatic bucket ceiling.
-	// Warn rather than error — existing specs must keep compiling.
-	it("warns when a week/quarter date_histogram declares no bounds", async () => {
+	// auto_date_histogram's minimum_interval has no week/quarter spelling, so
+	// these two intervals cannot get an automatic bucket ceiling; with no bounds
+	// to clamp the range either, the histogram cannot be capped at all — the
+	// #3556 failure. Fail at compile rather than emit an uncappable aggregation.
+	it("errors when a week/quarter date_histogram declares no bounds", async () => {
 		for (const interval of ["week", "quarter"]) {
 			const runner = await createRunner();
 			const diagnostics = await runner.diagnose(`
@@ -486,11 +483,21 @@ describe("decorators", () => {
         }
       `);
 
-			const warning = diagnostics.find(
+			const error = diagnostics.find(
 				(x) => x.code.indexOf("unboundable-date-histogram-interval") !== -1,
 			);
-			assert.ok(warning, `${interval} without bounds should warn`);
-			assert.equal(warning.severity, "warning");
+			assert.ok(error, `${interval} without bounds should error`);
+			assert.equal(error.severity, "error");
+			const validTo = runner.program
+				.getGlobalNamespaceType()
+				.models.get("Product")
+				?.properties.get("validTo");
+			assert.ok(validTo);
+			assert.equal(
+				getAggregatableDirectives(runner.program, validTo),
+				undefined,
+				`${interval} without bounds must not store an uncappable directive`,
+			);
 		}
 	});
 

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -387,7 +387,10 @@ export function supportsMinimumInterval(interval: DateHistogramInterval) {
 /**
  * `hard_bounds` for a `date_histogram`. Values are whatever OpenSearch accepts
  * as a date: an ISO 8601 instant (`"2020-01-01T00:00:00Z"`) or date math
- * (`"now-5y"`). At least one end is required; an omitted end tracks the data.
+ * (`"now-5y"`). Both ends are required: OpenSearch's `hard_bounds` only clamps
+ * the ends it is given, so a one-sided bound leaves the other end tracking the
+ * data and a far-future sentinel date still blows the bucket count. Two ends
+ * pin the range, which pins the bucket count.
  */
 export interface DateHistogramBounds {
 	min?: string;
@@ -480,8 +483,10 @@ function validateDateHistogramBounds(
 		}
 		bounds[end] = value;
 	}
-	if (bounds.min === undefined && bounds.max === undefined) {
-		return reason("bounds requires at least one of min or max");
+	if (bounds.min === undefined || bounds.max === undefined) {
+		return reason(
+			"bounds requires both min and max — a one-sided bound leaves the open end tracking the data, so a far-future sentinel date (e.g. 9999-12-31) still exceeds search.max_buckets and fails the search",
+		);
 	}
 	return bounds;
 }
@@ -520,6 +525,7 @@ function validateOptions(
 					format: { interval },
 					target,
 				});
+				return undefined;
 			}
 			return { interval };
 		}

--- a/src/emit-graphql-resolver.test.ts
+++ b/src/emit-graphql-resolver.test.ts
@@ -1046,12 +1046,12 @@ describe("emitGraphQLResolver", () => {
 		assert.ok(combinedContent(result).includes("const AGG_SPEC = ["));
 		assert.ok(
 			combinedContent(result).includes(
-				'{n:"byTag",a:{ terms: { field: "tags.keyword" } }}',
+				'{n:"byTag",a:{ terms: { field: "tags.keyword", size: 10 } }}',
 			),
 		);
 		assert.ok(
 			combinedContent(result).includes(
-				'{n:"bySpecies",a:{ terms: { field: "species" } }}',
+				'{n:"bySpecies",a:{ terms: { field: "species", size: 10 } }}',
 			),
 		);
 	});
@@ -1221,7 +1221,7 @@ describe("emitGraphQLResolver", () => {
 		assert.deepEqual(body.aggs, {
 			_tags: {
 				nested: { path: "tags" },
-				aggs: { byTagName: { terms: { field: "tags.name" } } },
+				aggs: { byTagName: { terms: { field: "tags.name", size: 10 } } },
 			},
 		});
 	});
@@ -1236,7 +1236,7 @@ describe("emitGraphQLResolver", () => {
 			selectionSetList: ["aggregations", "aggregations/bySpecies"],
 		});
 		assert.deepEqual(body.aggs, {
-			bySpecies: { terms: { field: "species" } },
+			bySpecies: { terms: { field: "species", size: 10 } },
 		});
 	});
 
@@ -1257,7 +1257,7 @@ describe("emitGraphQLResolver", () => {
 			_tags: {
 				nested: { path: "tags" },
 				aggs: {
-					byTagName: { terms: { field: "tags.name" } },
+					byTagName: { terms: { field: "tags.name", size: 10 } },
 					missingTagNoteCount: { missing: { field: "tags.note.keyword" } },
 				},
 			},
@@ -1328,11 +1328,11 @@ describe("emitGraphQLResolver", () => {
 			],
 		});
 		assert.deepEqual(body.aggs, {
-			bySpecies: { terms: { field: "species" } },
+			bySpecies: { terms: { field: "species", size: 10 } },
 			_tags: {
 				nested: { path: "tags" },
 				aggs: {
-					byTagName: { terms: { field: "tags.name" } },
+					byTagName: { terms: { field: "tags.name", size: 10 } },
 					missingTagNoteCount: { missing: { field: "tags.note.keyword" } },
 				},
 			},
@@ -1458,6 +1458,197 @@ describe("emitGraphQLResolver", () => {
 		);
 	});
 
+	// Regression net for #3556: every bucketing aggregation the emitter produces
+	// must carry a hard bucket ceiling, so no query can grow its bucket count
+	// past OpenSearch's search.max_buckets and time out. `date_histogram` caps
+	// its range with a two-sided `hard_bounds`; `auto_date_histogram` caps its
+	// count with `buckets`; `terms` caps its count with `size`. A plain
+	// `date_histogram` without two-sided bounds, or a `terms` without `size`, is
+	// the uncapped shape that caused the prod gateway timeout.
+	function balancedBodyAt(
+		source: string,
+		openIndex: number,
+		open: string,
+		close: string,
+	): string {
+		let depth = 0;
+		for (let i = openIndex; i < source.length; i++) {
+			if (source[i] === open) depth++;
+			else if (source[i] === close) {
+				depth--;
+				if (depth === 0) return source.slice(openIndex, i + 1);
+			}
+		}
+		throw new Error("unbalanced delimiters in emitted source");
+	}
+
+	function objectBodyAt(source: string, openBraceIndex: number): string {
+		return balancedBodyAt(source, openBraceIndex, "{", "}");
+	}
+
+	// Aggregation `terms`/`date_histogram` bodies live only inside the emitted
+	// `AGG_SPEC` literal. Filter clauses also emit `terms: { [field]: value }`,
+	// which is bounded by the caller's input array and is not an aggregation, so
+	// the scan is scoped to AGG_SPEC to avoid flagging those.
+	function aggSpecRegions(content: string): string {
+		const marker = "const AGG_SPEC = ";
+		let out = "";
+		let from = content.indexOf(marker);
+		while (from >= 0) {
+			const bracket = content.indexOf("[", from);
+			out += `${balancedBodyAt(content, bracket, "[", "]")}\n`;
+			from = content.indexOf(marker, bracket);
+		}
+		return out;
+	}
+
+	function assertNoUncappedAggregation(label: string, source: string): void {
+		const content = aggSpecRegions(source);
+		const dateHistogramKey = /\bdate_histogram\s*:\s*\{/g;
+		for (
+			let match = dateHistogramKey.exec(content);
+			match !== null;
+			match = dateHistogramKey.exec(content)
+		) {
+			const body = objectBodyAt(content, match.index + match[0].length - 1);
+			assert.ok(
+				body.includes("hard_bounds"),
+				`${label}: date_histogram without hard_bounds grows its bucket count over an open range\n${body}`,
+			);
+			assert.ok(
+				body.includes('"min"') && body.includes('"max"'),
+				`${label}: date_histogram hard_bounds must clamp both ends — a one-sided bound leaves the open end tracking the data\n${body}`,
+			);
+		}
+
+		const termsKey = /\bterms\s*:\s*\{/g;
+		for (
+			let match = termsKey.exec(content);
+			match !== null;
+			match = termsKey.exec(content)
+		) {
+			const body = objectBodyAt(content, match.index + match[0].length - 1);
+			assert.ok(
+				/\bsize\s*:/.test(body),
+				`${label}: terms aggregation without an explicit size\n${body}`,
+			);
+		}
+	}
+
+	it("this guard fails on an uncapped aggregation body (proves it can catch the #3556 shape)", () => {
+		assert.throws(
+			() =>
+				assertNoUncappedAggregation(
+					"uncapped terms",
+					'const AGG_SPEC = [{n:"byX",a:{ terms: { field: "x" } }}];',
+				),
+			/without an explicit size/,
+		);
+		assert.throws(
+			() =>
+				assertNoUncappedAggregation(
+					"uncapped date_histogram",
+					'const AGG_SPEC = [{n:"byD",a:{ date_histogram: { field: "d", calendar_interval: "month" } }}];',
+				),
+			/without hard_bounds/,
+		);
+		assert.throws(
+			() =>
+				assertNoUncappedAggregation(
+					"one-sided bounds",
+					'const AGG_SPEC = [{n:"byD",a:{ date_histogram: { field: "d", calendar_interval: "month", hard_bounds: {"min":"2020-01-01T00:00:00Z"} } }}];',
+				),
+			/clamp both ends/,
+		);
+		// A filter-clause `terms` (not an aggregation) must not be flagged.
+		assertNoUncappedAggregation(
+			"filter terms is not an aggregation",
+			'const AGG_SPEC = [{n:"byX",a:{ terms: { field: "x", size: 10 } }}];\noutFilters.push({ terms: { [node.f]: value } });',
+		);
+	});
+
+	it("every emitted bucketing aggregation carries a hard bucket ceiling (#3556)", async () => {
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "species",
+					keyword: true,
+					aggregations: ["terms"],
+				}),
+				makeField({
+					name: "counterpartyId",
+					keyword: true,
+					aggregations: [
+						{
+							kind: "terms",
+							options: {
+								topHits: 3,
+								sub: { latestValidTo: { kind: "max", field: "validTo" } },
+							},
+						},
+					],
+				}),
+				makeField({
+					name: "notional",
+					type: { kind: "Scalar", name: "float64" } as unknown as Type,
+					aggregations: ["sum", "avg", "min", "max"],
+				}),
+				makeField({
+					name: "validFrom",
+					type: { kind: "Scalar", name: "utcDateTime" } as unknown as Type,
+					aggregations: [
+						{ kind: "date_histogram", options: { interval: "month" } },
+					],
+				}),
+				makeField({
+					name: "validTo",
+					type: { kind: "Scalar", name: "utcDateTime" } as unknown as Type,
+					aggregations: [
+						{
+							kind: "date_histogram",
+							options: {
+								interval: "month",
+								bounds: { min: "2020-01-01T00:00:00Z", max: "now" },
+							},
+						},
+					],
+				}),
+				makeField({
+					name: "tags",
+					nested: true,
+					type: {
+						kind: "Model",
+						name: "Array",
+						indexer: { value: { kind: "Model" } },
+					} as unknown as Type,
+					subProjection: makeSubProjection("TagDoc", [
+						makeField({ name: "name", keyword: true, aggregations: ["terms"] }),
+					]),
+				}),
+			],
+		});
+		const result = await emitGraphQLResolver(projection, defaultOptions);
+		for (const file of [
+			{ name: result.fileName, content: result.content },
+			...result.functions.map((fn) => ({
+				name: fn.fileName,
+				content: fn.content,
+			})),
+		]) {
+			assertNoUncappedAggregation(`emitted ${file.name}`, file.content);
+		}
+	});
+
+	it("committed baseline snapshots carry no uncapped aggregation (#3556)", async () => {
+		const snapshotFiles = (
+			await readdir("test/snapshots", { recursive: true })
+		).filter((fileName) => fileName.endsWith(".js"));
+		for (const fileName of snapshotFiles) {
+			const content = await readFile(join("test/snapshots", fileName), "utf8");
+			assertNoUncappedAggregation(`test/snapshots/${fileName}`, content);
+		}
+	});
+
 	it("emits an auto_date_histogram floored at the declared interval when no bounds are given", async () => {
 		const projection = makeProjection({
 			fields: [
@@ -1537,7 +1728,7 @@ describe("emitGraphQLResolver", () => {
 		);
 	});
 
-	it("keeps a week/quarter histogram at its declared interval (no minimum_interval spelling exists)", async () => {
+	it("refuses to emit a bounds-less week/quarter histogram (no cap is possible)", async () => {
 		for (const interval of ["week", "quarter"] as const) {
 			const projection = makeProjection({
 				fields: [
@@ -1548,17 +1739,10 @@ describe("emitGraphQLResolver", () => {
 					}),
 				],
 			});
-			const result = await emitGraphQLResolver(projection, defaultOptions);
-			const content = combinedContent(result);
-			assert.ok(
-				content.includes(
-					`{n:"byValidFromOverTime",a:{ date_histogram: { field: "validFrom", calendar_interval: "${interval}" } }}`,
-				),
-				`${interval} must keep its declared interval rather than silently shift resolution`,
-			);
-			assert.ok(
-				!content.includes("auto_date_histogram"),
-				`auto_date_histogram cannot express a ${interval} floor`,
+			await assert.rejects(
+				() => emitGraphQLResolver(projection, defaultOptions),
+				/without bounds/,
+				`a bounds-less ${interval} histogram has no bucket ceiling and must fail at emit`,
 			);
 		}
 	});
@@ -1710,7 +1894,7 @@ describe("emitGraphQLResolver", () => {
 		const result = await emitGraphQLResolver(projection, defaultOptions);
 		assert.ok(
 			combinedContent(result).includes(
-				'{n:"byCounterpartyId",a:{ terms: { field: "counterpartyId" }, aggs: { "latestValidTo": { max: { field: "validTo" } } } }}',
+				'{n:"byCounterpartyId",a:{ terms: { field: "counterpartyId", size: 10 }, aggs: { "latestValidTo": { max: { field: "validTo" } } } }}',
 			),
 		);
 		assert.ok(
@@ -1734,7 +1918,7 @@ describe("emitGraphQLResolver", () => {
 
 		assert.ok(
 			combinedContent(result).includes(
-				'{n:"byCounterpartyId",a:{ terms: { field: "counterpartyId" }, aggs: { "hits": { top_hits: { size: 5 } } } }}',
+				'{n:"byCounterpartyId",a:{ terms: { field: "counterpartyId", size: 10 }, aggs: { "hits": { top_hits: { size: 5 } } } }}',
 			),
 			"terms agg request must include hits sub-agg with top_hits.size",
 		);
@@ -1865,7 +2049,7 @@ describe("emitGraphQLResolver", () => {
 		// selected ones share ONE `{ nested: ..., aggs: { ... } }` wrapper at
 		// request time instead of one wrapper each (issue #105).
 		for (const specEntry of [
-			'{n:"byTagName",g:"_tags",p:"tags",a:{ terms: { field: "tags.name" } }}',
+			'{n:"byTagName",g:"_tags",p:"tags",a:{ terms: { field: "tags.name", size: 10 } }}',
 			'{n:"uniqueTagNameCount",g:"_tags",p:"tags",a:{ cardinality: { field: "tags.name" } }}',
 			'{n:"missingTagNoteCount",g:"_tags",p:"tags",a:{ missing: { field: "tags.note.keyword" } }}',
 		]) {
@@ -1910,7 +2094,7 @@ describe("emitGraphQLResolver", () => {
 		const result = await emitGraphQLResolver(projection, defaultOptions);
 		assert.ok(
 			combinedContent(result).includes(
-				'{n:"byTag",a:{ terms: { field: "tags.keyword" } }}',
+				'{n:"byTag",a:{ terms: { field: "tags.keyword", size: 10 } }}',
 			),
 		);
 		// Aggs for non-@nested fields must not be wrapped in `{ nested: ... }`.

--- a/src/emit-graphql-resolver.ts
+++ b/src/emit-graphql-resolver.ts
@@ -106,6 +106,16 @@ export const MAX_PIPELINE_FUNCTIONS = 10;
 export const DEFAULT_AUTO_DATE_HISTOGRAM_BUCKETS = 10_000;
 
 /**
+ * Explicit `size` on every emitted `terms` aggregation. OpenSearch defaults an
+ * absent `size` to 10, so relying on that default already bounded the bucket
+ * count — but the emitter's invariant is that no bucketing aggregation ships
+ * without a hard ceiling visible in the emitted body, so the default is made
+ * explicit. Set to OpenSearch's own default so the emitted queries return the
+ * same buckets they always have.
+ */
+export const DEFAULT_TERMS_SIZE = 10;
+
+/**
  * Soft per-request bucket budget: a third of OpenSearch's default
  * `search.max_buckets` (65,535). That cap counts every bucket in the whole
  * request, not one aggregation, so the emitted `buildAggs` divides this budget
@@ -2295,11 +2305,14 @@ function renderAggInner(entry: AggregationEntry): string {
 		if (supportsMinimumInterval(interval)) {
 			return `${AUTO_DATE_HISTOGRAM_HELPER}(${fieldLit}, ${intervalLit})`;
 		}
-		// `week`/`quarter` have no `minimum_interval` spelling. Emitting a
-		// coarser floor would silently drop resolution the author asked for and
-		// a finer one would silently add detail, so keep the declared histogram
-		// as-is; the decorator warns that bounds are the only lever here.
-		return `{ ${aggType}: { field: ${fieldLit}, calendar_interval: ${intervalLit} } }`;
+		// `week`/`quarter` have no `minimum_interval` spelling and no bounds to
+		// clamp the range, so neither the count nor the range can be capped —
+		// the exact #3556 failure. The decorator already rejects this at compile
+		// (unboundable-date-histogram-interval), so this is an unreachable
+		// backstop: never emit an uncapped histogram.
+		throw new Error(
+			`cannot emit a bounded histogram for interval "${interval}" without bounds: auto_date_histogram has no "${interval}" minimum_interval and there is no range to clamp. Add bounds: { min, max } or use year/month/day/hour.`,
+		);
 	}
 	if (entry.kind === "range") {
 		const ranges =
@@ -2307,8 +2320,8 @@ function renderAggInner(entry: AggregationEntry): string {
 		const rangesLit = JSON.stringify(ranges);
 		return `{ ${aggType}: { field: ${fieldLit}, ranges: ${rangesLit} } }`;
 	}
-	if (entry.kind === "terms" && entry.options) {
-		const opts = entry.options as {
+	if (entry.kind === "terms") {
+		const opts = (entry.options ?? {}) as {
 			sub?: Record<string, { kind: string; field: string }>;
 			topHits?: number;
 		};
@@ -2316,7 +2329,7 @@ function renderAggInner(entry: AggregationEntry): string {
 		const hasSub = subEntries.length > 0;
 		const hasTopHits = typeof opts.topHits === "number" && opts.topHits > 0;
 		if (!hasSub && !hasTopHits) {
-			return `{ ${aggType}: { field: ${fieldLit} } }`;
+			return `{ ${aggType}: { field: ${fieldLit}, size: ${DEFAULT_TERMS_SIZE} } }`;
 		}
 		const subLines = subEntries.map(
 			([name, spec]) =>
@@ -2325,7 +2338,7 @@ function renderAggInner(entry: AggregationEntry): string {
 		if (hasTopHits) {
 			subLines.push(`"hits": { top_hits: { size: ${opts.topHits} } }`);
 		}
-		return `{ ${aggType}: { field: ${fieldLit} }, aggs: { ${subLines.join(", ")} } }`;
+		return `{ ${aggType}: { field: ${fieldLit}, size: ${DEFAULT_TERMS_SIZE} }, aggs: { ${subLines.join(", ")} } }`;
 	}
 	return `{ ${aggType}: { field: ${fieldLit} } }`;
 }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -114,9 +114,9 @@ export const $lib = createTypeSpecLibrary({
 			},
 		},
 		"unboundable-date-histogram-interval": {
-			severity: "warning",
+			severity: "error",
 			messages: {
-				default: paramMessage`@aggregatable("date_histogram", { interval: "${"interval"}" }) has no bounds, and OpenSearch cannot express a "${"interval"}" floor for auto_date_histogram. This histogram spans whatever range the data holds, so a far-future sentinel date (e.g. 9999-12-31) will exceed search.max_buckets and fail the search. Add bounds: { min, max } to pin the range.`,
+				default: paramMessage`@aggregatable("date_histogram", { interval: "${"interval"}" }) has no bounds, and OpenSearch cannot express a "${"interval"}" floor for auto_date_histogram. This histogram spans whatever range the data holds, so a far-future sentinel date (e.g. 9999-12-31) will exceed search.max_buckets and fail the search. Add bounds: { min, max } to pin the range, or choose an interval auto_date_histogram can floor (year, month, day, hour).`,
 			},
 		},
 		"positive-boost-required": {

--- a/test/example.js
+++ b/test/example.js
@@ -139,7 +139,9 @@ test("emits graphql aggregation types and resolver block", async () => {
 	assert.ok(prepare.includes("const AGG_SPEC = ["));
 	assert.ok(prepare.includes("body.aggs = aggs;"));
 	assert.ok(
-		prepare.includes('{n:"byAlias",a:{ terms: { field: "aliases.keyword" } }}'),
+		prepare.includes(
+			'{n:"byAlias",a:{ terms: { field: "aliases.keyword", size: 10 } }}',
+		),
 	);
 	assert.ok(
 		prepare.includes(
@@ -229,7 +231,7 @@ test("emits nested-aware aggregations on nested sub-projections", async () => {
 	// request (prepare function); the response mapping in the resolver
 	// after-mapping reads the grouped shape — issues #105, #150.
 	for (const specEntry of [
-		'{n:"byTagName",g:"_tags",p:"tags",a:{ terms: { field: "tags.name" } }}',
+		'{n:"byTagName",g:"_tags",p:"tags",a:{ terms: { field: "tags.name", size: 10 } }}',
 		'{n:"uniqueTagNameCount",g:"_tags",p:"tags",a:{ cardinality: { field: "tags.name" } }}',
 		'{n:"missingTagNoteCount",g:"_tags",p:"tags",a:{ missing: { field: "tags.note.keyword" } }}',
 	]) {

--- a/test/snapshots/opensearch-baseline/person-search-doc-fn-prepare.js
+++ b/test/snapshots/opensearch-baseline/person-search-doc-fn-prepare.js
@@ -2,7 +2,7 @@ import { util } from "@aws-appsync/utils";
 
 const FILTER_SPEC = [{i:"id",k:"term",f:"id"}, {i:"idIn",k:"terms",f:"id"}, {i:"idExists",k:"exists",f:"id"}, {i:"address",k:"object",c:[{i:"country",k:"term",f:"address.country"}, {i:"countryIn",k:"terms",f:"address.country"}, {i:"countryExists",k:"exists",f:"address.country"}, {i:"city",k:"term",f:"address.city"}, {i:"cityIn",k:"terms",f:"address.city"}, {i:"cityExists",k:"exists",f:"address.city"}]}];
 
-const AGG_SPEC = [{n:"byId",a:{ terms: { field: "id" } }}, {n:"byCountry",a:{ terms: { field: "country" } }}, {n:"byCity",a:{ terms: { field: "city" } }}];
+const AGG_SPEC = [{n:"byId",a:{ terms: { field: "id", size: 10 } }}, {n:"byCountry",a:{ terms: { field: "country", size: 10 } }}, {n:"byCity",a:{ terms: { field: "city", size: 10 } }}];
 
 export function request(ctx) {
 	const args = ctx.args;

--- a/test/snapshots/opensearch-baseline/pet-public-search-doc-fn-prepare.js
+++ b/test/snapshots/opensearch-baseline/pet-public-search-doc-fn-prepare.js
@@ -2,7 +2,7 @@ import { util } from "@aws-appsync/utils";
 
 const FILTER_SPEC = [{i:"species",k:"term",f:"species"}, {i:"speciesNot",k:"term_negate",f:"species"}, {i:"birthDate",k:"range",f:"birthDate"}, {i:"createdAt",k:"range",f:"createdAt"}, {i:"nicknameExists",k:"exists",f:"nickname.keyword"}, {i:"rank",k:"range",f:"rank"}];
 
-const AGG_SPEC = [{n:"bySpecies",a:{ terms: { field: "species" } }}, {n:"byAlias",a:{ terms: { field: "aliases.keyword" } }}, {n:"uniqueAliasCount",a:{ cardinality: { field: "aliases.keyword" } }}, {n:"missingNicknameCount",a:{ missing: { field: "nickname.keyword" } }}];
+const AGG_SPEC = [{n:"bySpecies",a:{ terms: { field: "species", size: 10 } }}, {n:"byAlias",a:{ terms: { field: "aliases.keyword", size: 10 } }}, {n:"uniqueAliasCount",a:{ cardinality: { field: "aliases.keyword" } }}, {n:"missingNicknameCount",a:{ missing: { field: "nickname.keyword" } }}];
 
 export function request(ctx) {
 	const args = ctx.args;

--- a/test/snapshots/opensearch-baseline/pet-search-doc-fn-prepare.js
+++ b/test/snapshots/opensearch-baseline/pet-search-doc-fn-prepare.js
@@ -2,7 +2,7 @@ import { util } from "@aws-appsync/utils";
 
 const FILTER_SPEC = [{i:"namePrefix",k:"prefix",f:"name"}, {i:"nameMatch",k:"match",f:"name"}, {i:"species",k:"term",f:"species"}, {i:"speciesNot",k:"term_negate",f:"species"}, {i:"birthDate",k:"range",f:"birthDate"}, {i:"createdAt",k:"range",f:"createdAt"}, {i:"tags",k:"nested",p:"tags",c:[{i:"name",k:"term",f:"tags.name"}, {i:"nameNot",k:"term_negate",f:"tags.name"}, {i:"noteExists",k:"exists",f:"tags.note.keyword"}]}, {i:"nicknameExists",k:"exists",f:"nickname.keyword"}, {i:"rank",k:"range",f:"rank"}];
 
-const AGG_SPEC = [{n:"bySpecies",a:{ terms: { field: "species" } }}, {n:"byAlias",a:{ terms: { field: "aliases.keyword" } }}, {n:"uniqueAliasCount",a:{ cardinality: { field: "aliases.keyword" } }}, {n:"missingNicknameCount",a:{ missing: { field: "nickname.keyword" } }}, {n:"byTagName",g:"_tags",p:"tags",a:{ terms: { field: "tags.name" } }}, {n:"uniqueTagNameCount",g:"_tags",p:"tags",a:{ cardinality: { field: "tags.name" } }}, {n:"missingTagNoteCount",g:"_tags",p:"tags",a:{ missing: { field: "tags.note.keyword" } }}];
+const AGG_SPEC = [{n:"bySpecies",a:{ terms: { field: "species", size: 10 } }}, {n:"byAlias",a:{ terms: { field: "aliases.keyword", size: 10 } }}, {n:"uniqueAliasCount",a:{ cardinality: { field: "aliases.keyword" } }}, {n:"missingNicknameCount",a:{ missing: { field: "nickname.keyword" } }}, {n:"byTagName",g:"_tags",p:"tags",a:{ terms: { field: "tags.name", size: 10 } }}, {n:"uniqueTagNameCount",g:"_tags",p:"tags",a:{ cardinality: { field: "tags.name" } }}, {n:"missingTagNoteCount",g:"_tags",p:"tags",a:{ missing: { field: "tags.note.keyword" } }}];
 
 export function request(ctx) {
 	const args = ctx.args;

--- a/test/snapshots/opensearch-baseline/tag-search-doc-fn-prepare.js
+++ b/test/snapshots/opensearch-baseline/tag-search-doc-fn-prepare.js
@@ -2,7 +2,7 @@ import { util } from "@aws-appsync/utils";
 
 const FILTER_SPEC = [{i:"name",k:"term",f:"name"}, {i:"nameNot",k:"term_negate",f:"name"}, {i:"noteExists",k:"exists",f:"note.keyword"}];
 
-const AGG_SPEC = [{n:"byName",a:{ terms: { field: "name" } }}, {n:"uniqueNameCount",a:{ cardinality: { field: "name" } }}, {n:"missingNoteCount",a:{ missing: { field: "note.keyword" } }}];
+const AGG_SPEC = [{n:"byName",a:{ terms: { field: "name", size: 10 } }}, {n:"uniqueNameCount",a:{ cardinality: { field: "name" } }}, {n:"missingNoteCount",a:{ missing: { field: "note.keyword" } }}];
 
 export function request(ctx) {
 	const args = ctx.args;


### PR DESCRIPTION
## Invariant

The emitter never produces a bucketing aggregation whose bucket count can grow with the data. Every emitted `date_histogram` and `terms` carries a hard bucket ceiling, or the emit fails with a clear diagnostic.

## Why

A monthly `date_histogram` over a validity window whose upper bound is an open-ended sentinel (`9999-12-31`) produced roughly 96k buckets, exceeded OpenSearch's `search.max_buckets`, and timed out counterparty search (#3556). Two earlier fixes budgeted the bounds-less `auto_date_histogram` path, but a bounded histogram and an interval that `auto_date_histogram` cannot express still fell through to an uncapped `calendar_interval`.

## What is now guaranteed

- `date_histogram` bounds require both `min` and `max`; the clamped range emits `hard_bounds`. A one-sided bound leaves the open end tracking the data and is rejected at decoration time.
- A bounds-less `date_histogram` on an interval `auto_date_histogram` has no `minimum_interval` for (week, quarter) is a compile error, with an emitter throw as a backstop, instead of an uncapped `calendar_interval`.
- `terms` always emit an explicit `size`, making OpenSearch's implicit ceiling explicit and visible in review.

A structural guard test scans every emitted resolver and the committed baseline snapshots and fails on any uncapped bucketing aggregation, closing the #3556 class of failure against regression.