### PR TITLE
fix(mapping): map offsetDateTime to a date field

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Stacking `@filterable` and `@aggregatable` per field becomes noisy on a typical 
 
 | Field type | Default `@filterable` | Default `@aggregatable` | Default `@sortable` |
 | --- | --- | --- | --- |
-| `utcDateTime` / `plainDate` | `range` | `date_histogram(month)`, unbounded — see [Bounding a `date_histogram`](#bounding-a-date_histogram) | yes |
+| `utcDateTime` / `offsetDateTime` / `plainDate` | `range` | `date_histogram(month)`, unbounded — see [Bounding a `date_histogram`](#bounding-a-date_histogram) | yes |
 | `string` + `@keyword` | `term`, `terms`, `exists` | `terms` | yes |
 | free-text `string` (no `@keyword`) | (none) | (none) | no |
 | numeric (`int*`, `float*`, `decimal`, …) | `range` | `sum`, `avg`, `min`, `max` | yes |
@@ -337,7 +337,7 @@ In the example above:
 
 | TypeSpec type | TypeScript type |
 | --- | --- |
-| `string`, `plainDate`, `utcDateTime` | `string` |
+| `string`, `plainDate`, `utcDateTime`, `offsetDateTime` | `string` |
 | `int32`, `int64`, `float64`, etc. | `number` |
 | `boolean` | `boolean` |
 | `Model` (object) | inline `{ ... }` (searchable fields only) |
@@ -354,6 +354,7 @@ In the example above:
 | `float32`, `float64`, etc. | `double` |
 | `boolean` | `boolean` |
 | `plainDate`, `utcDateTime` | `date` |
+| `offsetDateTime` | `date` with `format: strict_date_optional_time` |
 | `Model` | `object` (with nested properties) |
 | `Model[]` + `@nested` | `nested` (with nested properties) |
 

--- a/src/aggregations.ts
+++ b/src/aggregations.ts
@@ -4,6 +4,7 @@ import type {
 	ResolvedProjection,
 	ResolvedProjectionField,
 } from "./projection.js";
+import { isDateScalarName } from "./utils.js";
 
 export interface AggregationEntry {
 	field: ResolvedProjectionField;
@@ -185,7 +186,7 @@ function isStringLikeType(type: ResolvedProjectionField["type"]): boolean {
 			if (current.name === "string") {
 				return true;
 			}
-			if (current.name === "plainDate" || current.name === "utcDateTime") {
+			if (isDateScalarName(current.name)) {
 				return false;
 			}
 			current = current.baseScalar;
@@ -201,7 +202,7 @@ function isStringLikeType(type: ResolvedProjectionField["type"]): boolean {
 			let current: typeof elementType | undefined = elementType;
 			while (current && current.kind === "Scalar") {
 				if (current.name === "string") return true;
-				if (current.name === "plainDate" || current.name === "utcDateTime") {
+				if (isDateScalarName(current.name)) {
 					return false;
 				}
 				current = current.baseScalar;

--- a/src/emit-doc-type.test.ts
+++ b/src/emit-doc-type.test.ts
@@ -148,6 +148,7 @@ describe("doc type emitter", () => {
 				@searchable active: boolean;
 				@searchable created: plainDate;
 				@searchable updated: utcDateTime;
+				@searchable dueDate: offsetDateTime;
 			}
 
 			model WidgetSearchDoc is SearchProjection<Widget> {}
@@ -162,6 +163,7 @@ describe("doc type emitter", () => {
 		assert.ok(emitted.content.includes("\tactive: boolean;"));
 		assert.ok(emitted.content.includes("\tcreated: string;"));
 		assert.ok(emitted.content.includes("\tupdated: string;"));
+		assert.ok(emitted.content.includes("\tdueDate: string;"));
 	});
 
 	it("renders nested inline object with correct indentation", async () => {

--- a/src/emit-doc-type.ts
+++ b/src/emit-doc-type.ts
@@ -157,6 +157,7 @@ function renderScalar(scalar: Scalar): string {
 		case "string":
 		case "plainDate":
 		case "utcDateTime":
+		case "offsetDateTime":
 			return "string";
 		case "int32":
 		case "int64":

--- a/src/emit-mapping.test.ts
+++ b/src/emit-mapping.test.ts
@@ -128,6 +128,40 @@ describe("mapping emitter", () => {
 		});
 	});
 
+	it("maps offsetDateTime to a date field accepting an ISO 8601 offset", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Assignment {
+        @searchable assignedAt: utcDateTime;
+        @searchable dueDate: offsetDateTime;
+        @searchable reminderDates: offsetDateTime[];
+      }
+
+      model AssignmentSearchDoc is SearchProjection<Assignment> {}
+    `);
+		assert.equal(diagnostics.length, 0);
+
+		const projection = runner.program
+			.getGlobalNamespaceType()
+			.models.get("AssignmentSearchDoc");
+		assert.ok(projection);
+
+		const resolved = resolveProjectionModel(runner.program, projection);
+		assert.ok(resolved);
+		const emitted = emitMapping(runner.program, resolved);
+		const parsed = JSON.parse(emitted.content);
+
+		assert.deepEqual(parsed.mappings.properties.dueDate, {
+			type: "date",
+			format: "strict_date_optional_time",
+		});
+		assert.deepEqual(parsed.mappings.properties.reminderDates, {
+			type: "date",
+			format: "strict_date_optional_time",
+		});
+		assert.deepEqual(parsed.mappings.properties.assignedAt, { type: "date" });
+	});
+
 	it("mapString without overrides returns text with keyword sub-field", () => {
 		const result = __test.mapString();
 		assert.equal(result.type, "text");

--- a/src/emit-mapping.ts
+++ b/src/emit-mapping.ts
@@ -152,6 +152,8 @@ function mapScalar(
 			case "utcDateTime":
 			case "plainDate":
 				return { type: "date" };
+			case "offsetDateTime":
+				return { type: "date", format: "strict_date_optional_time" };
 		}
 		current = current.baseScalar;
 	}

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -4,6 +4,7 @@ import type {
 	ResolvedProjection,
 	ResolvedProjectionField,
 } from "./projection.js";
+import { isDateScalarName } from "./utils.js";
 
 export interface FilterableEntry {
 	field: ResolvedProjectionField;
@@ -172,7 +173,7 @@ function isStringLikeType(type: ResolvedProjectionField["type"]): boolean {
 		let current: typeof type | undefined = type;
 		while (current && current.kind === "Scalar") {
 			if (current.name === "string") return true;
-			if (current.name === "plainDate" || current.name === "utcDateTime") {
+			if (isDateScalarName(current.name)) {
 				return false;
 			}
 			current = current.baseScalar;
@@ -186,7 +187,7 @@ function isStringLikeType(type: ResolvedProjectionField["type"]): boolean {
 			let current: typeof elementType | undefined = elementType;
 			while (current && current.kind === "Scalar") {
 				if (current.name === "string") return true;
-				if (current.name === "plainDate" || current.name === "utcDateTime") {
+				if (isDateScalarName(current.name)) {
 					return false;
 				}
 				current = current.baseScalar;

--- a/src/graphql-types.ts
+++ b/src/graphql-types.ts
@@ -49,6 +49,7 @@ function scalarToGraphQL(scalar: Scalar, context: GraphQLEmitContext): string {
 			case "string":
 			case "plainDate":
 			case "utcDateTime":
+			case "offsetDateTime":
 				return "String";
 			case "int64":
 			case "uint64":

--- a/src/projection.test.ts
+++ b/src/projection.test.ts
@@ -765,6 +765,34 @@ describe("@searchInfer", () => {
 		assert.equal(byName("tags")?.sortable, false);
 	});
 
+	it("infers sortable and a range filter on offsetDateTime", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Assignment {
+        assignedAt: utcDateTime;
+        dueDate: offsetDateTime;
+      }
+      @searchInfer
+      model AssignmentSearchDoc is SearchProjection<Assignment> {}
+    `);
+		assert.equal(diagnostics.length, 0);
+
+		const projection = runner.program
+			.getGlobalNamespaceType()
+			.models.get("AssignmentSearchDoc");
+		assert.ok(projection);
+		const resolved = resolveProjectionModel(runner.program, projection);
+		assert.ok(resolved);
+		const dueDate = resolved.fields.find((f) => f.name === "dueDate");
+		assert.ok(dueDate);
+
+		assert.equal(dueDate.sortable, true);
+		assert.deepEqual(dueDate.filterables, ["range"]);
+		assert.deepEqual(dueDate.aggregations, [
+			{ kind: "date_histogram", options: { interval: "month" } },
+		]);
+	});
+
 	it("@sortable on a field is honored even without @searchInfer", async () => {
 		const runner = await createRunner();
 		const diagnostics = await runner.diagnose(`

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -43,6 +43,7 @@ function isReachable(
 }
 
 import { reportDiagnostic } from "./lib.js";
+import { isDateScalarName } from "./utils.js";
 
 export interface ResolvedProjectionField {
 	name: string;
@@ -332,7 +333,7 @@ interface InferredDirectives {
  * Type-driven defaults for fields on a `@searchInfer` model.
  *
  * Per issue #92's inference table:
- * - utcDateTime / plainDate → range filter, date_histogram(month) agg
+ * - utcDateTime / offsetDateTime / plainDate → range filter, date_histogram(month) agg
  * - string + @keyword → term/exists filter, terms agg
  * - free-text string (no @keyword) → none, none
  * - numeric → range filter, sum/avg/min/max aggs
@@ -368,7 +369,7 @@ function inferDirectives(
 	if (type.kind === "Scalar") {
 		const root = scalarRootName(type);
 		if (root === "boolean") return { filterables: ["term", "terms"] };
-		if (root === "utcDateTime" || root === "plainDate") {
+		if (isDateScalarName(root)) {
 			return {
 				filterables: ["range"],
 				aggregations: [
@@ -431,7 +432,7 @@ function isSortableType(
 		const root = scalarRootName(type);
 		if (!root) return false;
 		if (root === "boolean") return true;
-		if (root === "utcDateTime" || root === "plainDate") return true;
+		if (isDateScalarName(root)) return true;
 		if (isNumericRootName(root)) return true;
 		if (root === "string") return flags.keyword;
 	}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,10 @@
+const DATE_SCALAR_NAMES = ["plainDate", "utcDateTime", "offsetDateTime"];
+
+export function isDateScalarName(name: string | undefined): boolean {
+	if (!name) return false;
+	return DATE_SCALAR_NAMES.includes(name);
+}
+
 export function toKebabCase(name: string): string {
 	return name
 		.replace(/([a-z0-9])([A-Z])/g, "$1-$2")


### PR DESCRIPTION
An `offsetDateTime` field falls through every scalar branch to `object`, so it cannot be indexed, filtered or sorted — and nothing in the emit output says so.

Business dates are ISO 8601 with an explicit timezone offset, so any projection carrying one — `WorkAssignment.dueDate` is the first — silently loses the field.

`offsetDateTime` now maps to `date` with `strict_date_optional_time`, in the scalar and array branches alike, and one shared date-scalar list drives the mapping, `@searchInfer` sorting and filtering, and the emitted document type. `utcDateTime` and `plainDate` are unchanged.

Refs #165 (`offsetDateTime` only — `plainTime`, `duration` and the loud-failure default stay open), refs stxcommodities/core-services#4164.
