### PR TITLE
fix(mapping): honour @keyword on an array of strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ In this example:
 | Decorator | Target | Effect | Example |
 | --- | --- | --- | --- |
 | `@searchable` | `ModelProperty` | Includes a property in projection resolution. | `@searchable name: string;` |
-| `@keyword` | `ModelProperty` (string) | Maps a string field as OpenSearch `keyword` instead of `text`. | `@searchable @keyword species: string;` |
+| `@keyword` | `ModelProperty` (string or string[]) | Maps a string field, or an array of strings, as OpenSearch `keyword` instead of `text`. | `@searchable @keyword species: string;` |
 | `@nested` | `ModelProperty` (Model[]) | Maps an array-of-model field as OpenSearch `nested` instead of `object`. | `@searchable @nested tags: Tag[];` |
 | `@analyzer("name")` | `ModelProperty` (string) | Sets the text analyzer in mapping output. | `@analyzer("edge_ngram") name: string;` |
 | `@boost(n)` | `ModelProperty` | Sets field boost factor in mapping output. Must be > 0. | `@boost(2.0) name: string;` |
@@ -350,6 +350,8 @@ In the example above:
 | --- | --- |
 | `string` | `text` (with `keyword` sub-field) |
 | `string` + `@keyword` | `keyword` |
+| `string[]` | `text` (with `keyword` sub-field) |
+| `string[]` + `@keyword` | `keyword` |
 | `int32`, `int64`, etc. | `long` |
 | `float32`, `float64`, etc. | `double` |
 | `boolean` | `boolean` |

--- a/src/decorators.test.ts
+++ b/src/decorators.test.ts
@@ -177,6 +177,38 @@ describe("decorators", () => {
 		assert.equal(hasDiagnosticCode(codes, "string-property-required"), true);
 	});
 
+	it("accepts keyword on an array of strings", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Assignment {
+        @searchable @keyword assigneeIds: string[];
+      }
+    `);
+
+		assert.equal(diagnostics.length, 0);
+
+		const assignment = runner.program
+			.getGlobalNamespaceType()
+			.models.get("Assignment");
+		assert.ok(assignment);
+
+		const assigneeIds = assignment.properties.get("assigneeIds");
+		assert.ok(assigneeIds);
+		assert.equal(isKeyword(runner.program, assigneeIds), true);
+	});
+
+	it("emits diagnostic for keyword on an array of non-strings", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Product {
+        @keyword ranks: int32[];
+      }
+    `);
+
+		const codes = diagnostics.map((x) => x.code);
+		assert.equal(hasDiagnosticCode(codes, "string-property-required"), true);
+	});
+
 	it("emits diagnostic for invalid analyzer target", async () => {
 		const runner = await createRunner();
 		const diagnostics = await runner.diagnose(`

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -145,7 +145,7 @@ export function $keyword(
 	context: DecoratorContext,
 	target: ModelProperty,
 ): void {
-	if (!isStringType(target.type)) {
+	if (!isStringOrStringArrayType(target.type)) {
 		reportDiagnostic(context.program, {
 			code: "string-property-required",
 			target,
@@ -313,6 +313,19 @@ function isStringType(type: Type): boolean {
 	}
 
 	return current.kind === "Scalar" && current.name === "string";
+}
+
+function isStringOrStringArrayType(type: Type): boolean {
+	if (isStringType(type)) {
+		return true;
+	}
+
+	if (type.kind !== "Model" || type.name !== "Array") {
+		return false;
+	}
+
+	const elementType = type.indexer?.value;
+	return elementType !== undefined && isStringType(elementType);
 }
 
 function isArrayOfModelType(type: Type): boolean {

--- a/src/emit-mapping.test.ts
+++ b/src/emit-mapping.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 
 import { createTestHost, createTestWrapper } from "@typespec/compiler/testing";
 import { __test, emitMapping } from "./emit-mapping.js";
+import { collectFilterables } from "./filters.js";
 import { resolveProjectionModel } from "./projection.js";
 import { OpenSearchEmitterTestLibrary } from "./testing/index.js";
 
@@ -160,6 +161,126 @@ describe("mapping emitter", () => {
 			format: "strict_date_optional_time",
 		});
 		assert.deepEqual(parsed.mappings.properties.assignedAt, { type: "date" });
+	});
+
+	it("maps a @keyword array of strings as keyword", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Assignment {
+        @searchable @keyword @filterable("terms") assigneeIds: string[];
+      }
+
+      model AssignmentSearchDoc is SearchProjection<Assignment> {}
+    `);
+		assert.equal(diagnostics.length, 0);
+
+		const projection = runner.program
+			.getGlobalNamespaceType()
+			.models.get("AssignmentSearchDoc");
+		assert.ok(projection);
+
+		const resolved = resolveProjectionModel(runner.program, projection);
+		assert.ok(resolved);
+		const emitted = emitMapping(runner.program, resolved);
+		const parsed = JSON.parse(emitted.content);
+
+		assert.deepEqual(parsed.mappings.properties.assigneeIds, {
+			type: "keyword",
+		});
+
+		const [filterable] = collectFilterables(resolved);
+		assert.equal(
+			filterable.openSearchField,
+			"assigneeIds",
+			"the filter addresses the bare field name, so the mapping must be a real keyword",
+		);
+	});
+
+	it("maps a filter-only array of strings as keyword", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Assignment {
+        @filterable("terms") assigneeIds: string[];
+      }
+
+      model AssignmentSearchDoc is SearchProjection<Assignment> {}
+    `);
+		assert.equal(diagnostics.length, 0);
+
+		const projection = runner.program
+			.getGlobalNamespaceType()
+			.models.get("AssignmentSearchDoc");
+		assert.ok(projection);
+
+		const resolved = resolveProjectionModel(runner.program, projection);
+		assert.ok(resolved);
+		const emitted = emitMapping(runner.program, resolved);
+		const parsed = JSON.parse(emitted.content);
+
+		assert.deepEqual(parsed.mappings.properties.assigneeIds, {
+			type: "keyword",
+		});
+	});
+
+	it("applies @boost and @ignoreAbove to an array of strings", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Product {
+        @searchable aliases: string[];
+      }
+
+      model ProductSearchDoc is SearchProjection<Product> {
+        @boost(3) @ignoreAbove(64)
+        aliases: string[];
+      }
+    `);
+		assert.equal(diagnostics.length, 0);
+
+		const projection = runner.program
+			.getGlobalNamespaceType()
+			.models.get("ProductSearchDoc");
+		assert.ok(projection);
+
+		const resolved = resolveProjectionModel(runner.program, projection);
+		assert.ok(resolved);
+		const emitted = emitMapping(runner.program, resolved);
+		const parsed = JSON.parse(emitted.content);
+
+		assert.deepEqual(parsed.mappings.properties.aliases, {
+			type: "text",
+			fields: { keyword: { type: "keyword", ignore_above: 64 } },
+			boost: 3,
+		});
+	});
+
+	it("maps a @keyword array on a sub-model property as keyword", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+      model Owner {
+        @searchable @keyword handles: string[];
+      }
+
+      model Product {
+        @searchable owner: Owner;
+      }
+
+      model ProductSearchDoc is SearchProjection<Product> {}
+    `);
+		assert.equal(diagnostics.length, 0);
+
+		const projection = runner.program
+			.getGlobalNamespaceType()
+			.models.get("ProductSearchDoc");
+		assert.ok(projection);
+
+		const resolved = resolveProjectionModel(runner.program, projection);
+		assert.ok(resolved);
+		const emitted = emitMapping(runner.program, resolved);
+		const parsed = JSON.parse(emitted.content);
+
+		assert.deepEqual(parsed.mappings.properties.owner.properties.handles, {
+			type: "keyword",
+		});
 	});
 
 	it("mapString without overrides returns text with keyword sub-field", () => {

--- a/src/emit-mapping.ts
+++ b/src/emit-mapping.ts
@@ -209,7 +209,13 @@ function mapSubProjectionField(
 function mapModel(
 	program: Program,
 	model: Model,
-	override?: { nested?: boolean },
+	override?: {
+		keyword?: boolean;
+		nested?: boolean;
+		analyzer?: string;
+		boost?: number;
+		ignoreAbove?: number;
+	},
 	defaultIgnoreAbove?: number,
 ): MappingProperty {
 	if (model.name === "Array" && model.indexer?.value) {
@@ -224,7 +230,10 @@ function mapModel(
 				),
 			};
 		}
-		return toMapping(program, elementType, undefined, defaultIgnoreAbove);
+		// An array maps as its element type, so the field's own directives
+		// apply to the element (filters and aggregations already address a
+		// @keyword array by its bare name). Issue #187.
+		return toMapping(program, elementType, override, defaultIgnoreAbove);
 	}
 
 	return {


### PR DESCRIPTION
What? `@keyword` now applies to an array of strings, and maps the field as OpenSearch `keyword`.

Why? The decorator was rejected on an array, and the mapping emitter dropped every directive on a scalar array element, so a string array could only be mapped as analyzed `text`. Issue #187.

How? The array branch maps its element type with the field's own directives, and the decorator accepts a string array. Filters and aggregations already address a keyword field by its bare name, so the mapping and the query agree.

Closes #187
