### PR TITLE
fix(rest-resolver): encode an array query param the HTTP datasource accepts

### DIFF
--- a/src/emit-rest-resolver.test.ts
+++ b/src/emit-rest-resolver.test.ts
@@ -32,7 +32,24 @@ const listPets: RestOperationShape = {
 	httpMethod: "GET",
 	path: "/pets",
 	pathParams: [],
-	queryParams: [{ name: "status", optional: true }],
+	queryParams: [
+		{ name: "status", optional: true, array: false, explode: true },
+	],
+};
+
+const listPetsByStatuses: RestOperationShape = {
+	...listPets,
+	queryParams: [
+		{ name: "continuationToken", optional: true, array: false, explode: true },
+		{ name: "status", optional: true, array: true, explode: true },
+	],
+};
+
+const listPetsByCsvStatuses: RestOperationShape = {
+	...listPets,
+	queryParams: [
+		{ name: "status", optional: true, array: true, explode: false },
+	],
 };
 
 describe("restResolverFileName", () => {
@@ -83,6 +100,32 @@ describe("emitRestResolver request rendering", () => {
 		assert.ok(content.includes("query: {"));
 	});
 
+	it("keeps an exploded array param out of params.query", () => {
+		const { content } = emitRestResolver(listPetsByStatuses);
+		assert.ok(!content.includes("query: {"));
+		assert.ok(content.includes("params: { headers: BASE_HEADERS(ctx) }"));
+		assert.ok(content.includes("resourcePath: `/pets${queryString(ctx)}`"));
+	});
+
+	it("joins a non-exploded array param into a single params.query value", () => {
+		const { content } = emitRestResolver(listPetsByCsvStatuses);
+		assert.ok(content.includes('"status": ctx.args.status?.join(",")'));
+		assert.ok(!content.includes("queryString(ctx)"));
+	});
+
+	it("appends the query string after interpolated path params", () => {
+		const { content } = emitRestResolver({
+			...listPetsByStatuses,
+			path: "/owners/{ownerId}/pets",
+			pathParams: [{ name: "ownerId" }],
+		});
+		assert.ok(
+			content.includes(
+				"resourcePath: `/owners/${util.urlEncode(ctx.args.ownerId)}/pets${queryString(ctx)}`",
+			),
+		);
+	});
+
 	it("omits query and body blocks when neither is present", () => {
 		const { content } = emitRestResolver(getPet);
 		assert.ok(content.includes("params: { headers: BASE_HEADERS(ctx) }"));
@@ -111,6 +154,95 @@ describe("emitRestResolver request rendering", () => {
 	it("leaves resourcePath unchanged when no prefix given (issue #140)", () => {
 		const { content } = emitRestResolver(createPet);
 		assert.ok(content.includes('resourcePath: "/pets"'));
+	});
+});
+
+interface AppSyncUtil {
+	urlEncode(value: string): string;
+}
+
+interface HttpRequest {
+	method: string;
+	resourcePath: string;
+	params: { headers: Record<string, string>; query?: Record<string, unknown> };
+}
+
+type RequestFactory = (
+	util: AppSyncUtil,
+	ctx: { args: Record<string, unknown> },
+) => HttpRequest;
+
+function evaluateRequest(
+	op: RestOperationShape,
+	args: Record<string, unknown>,
+): HttpRequest {
+	const { content } = emitRestResolver(op);
+	const body = content
+		.replace('import { util } from "@aws-appsync/utils";', "")
+		.replaceAll("export function", "function");
+	const factory = new Function(
+		"util",
+		"ctx",
+		`${body}\nreturn request(ctx);`,
+	) as RequestFactory;
+
+	return factory(
+		{ urlEncode: (value) => encodeURIComponent(value).replaceAll("%20", "+") },
+		{ args },
+	);
+}
+
+describe("emitRestResolver array query params", () => {
+	it("repeats the key once per element of an exploded array", () => {
+		const { resourcePath } = evaluateRequest(listPetsByStatuses, {
+			status: ["Available", "Pending"],
+		});
+		assert.equal(resourcePath, "/pets?status=Available&status=Pending");
+	});
+
+	it("url-encodes each element", () => {
+		const { resourcePath } = evaluateRequest(listPetsByStatuses, {
+			status: ["a/b", "c d"],
+		});
+		assert.equal(resourcePath, "/pets?status=a%2Fb&status=c+d");
+	});
+
+	it("carries scalar params alongside the repeated key", () => {
+		const { resourcePath } = evaluateRequest(listPetsByStatuses, {
+			continuationToken: "abc",
+			status: ["Sold"],
+		});
+		assert.equal(resourcePath, "/pets?continuationToken=abc&status=Sold");
+	});
+
+	it("drops absent optional params and emits no lone question mark", () => {
+		const request = evaluateRequest(listPetsByStatuses, {});
+		assert.equal(request.resourcePath, "/pets");
+		assert.equal(request.params.query, undefined);
+	});
+
+	it("emits nothing for an empty array", () => {
+		const { resourcePath } = evaluateRequest(listPetsByStatuses, {
+			status: [],
+		});
+		assert.equal(resourcePath, "/pets");
+	});
+
+	it("comma-joins a non-exploded array into params.query", () => {
+		const { params, resourcePath } = evaluateRequest(listPetsByCsvStatuses, {
+			status: ["Available", "Pending"],
+		});
+		assert.equal(resourcePath, "/pets");
+		assert.deepEqual(params.query, { status: "Available,Pending" });
+	});
+
+	it("never puts an array into params.query", () => {
+		for (const op of [listPetsByStatuses, listPetsByCsvStatuses]) {
+			const { params } = evaluateRequest(op, { status: ["Available"] });
+			for (const value of Object.values(params.query ?? {})) {
+				assert.equal(typeof value, "string");
+			}
+		}
 	});
 });
 
@@ -203,8 +335,24 @@ describe("emitRestResolver error mapping", () => {
 });
 
 describe("emitRestResolver APPSYNC_JS validity", () => {
+	it("uses no runtime feature the APPSYNC_JS runtime lacks", () => {
+		const { content } = emitRestResolver(listPetsByStatuses);
+		for (const unsupported of ["Array.isArray", "try", "while", "throw"]) {
+			assert.ok(
+				!content.includes(unsupported),
+				`${unsupported} is not supported by APPSYNC_JS`,
+			);
+		}
+	});
+
 	it("emits no async/await and imports only @aws-appsync/utils", () => {
-		for (const op of [getPet, createPet, listPets]) {
+		for (const op of [
+			getPet,
+			createPet,
+			listPets,
+			listPetsByStatuses,
+			listPetsByCsvStatuses,
+		]) {
 			const { content } = emitRestResolver(op);
 			assert.ok(
 				content.startsWith('import { util } from "@aws-appsync/utils";'),

--- a/src/emit-rest-resolver.ts
+++ b/src/emit-rest-resolver.ts
@@ -1,4 +1,4 @@
-import type { RestOperationShape } from "./rest-operations.js";
+import type { RestOperationShape, RestQueryParam } from "./rest-operations.js";
 
 /**
  * APPSYNC_JS resolver codegen for `@restResolver` operations (issue #134).
@@ -60,6 +60,7 @@ export function emitRestResolver(
 		"\treturn mapResponse(ctx);",
 		"}",
 		"",
+		...(needsQueryString(op) ? [renderQueryString(op), ""] : []),
 		renderMapResponse(options.errorMap),
 		"",
 	].join("\n");
@@ -90,15 +91,31 @@ function renderBaseHeaders(injectHeaders?: Record<string, string>): string {
 	return ["const BASE_HEADERS = (ctx) => ({", ...lines, "});"].join("\n");
 }
 
+/**
+ * `params.query` is a string→string map (AppSync HTTP data source reference),
+ * so it cannot hold a repeated key. An exploded array parameter therefore has
+ * to be serialized into the resourcePath's own query string instead.
+ */
+function needsQueryString(op: RestOperationShape): boolean {
+	return op.queryParams.some((param) => param.array && param.explode);
+}
+
+function queryValueExpression(param: RestQueryParam): string {
+	if (!param.array) return `ctx.args.${param.name}`;
+	return `ctx.args.${param.name}?.join(",")`;
+}
+
 function renderRequest(
 	op: RestOperationShape,
 	resourcePathPrefix?: string,
 ): string {
 	const paramsLines: string[] = ["\t\t\theaders: BASE_HEADERS(ctx),"];
-	if (op.queryParams.length > 0) {
+	if (op.queryParams.length > 0 && !needsQueryString(op)) {
 		paramsLines.push("\t\t\tquery: {");
 		for (const param of op.queryParams) {
-			paramsLines.push(`\t\t\t\t"${param.name}": ctx.args.${param.name},`);
+			paramsLines.push(
+				`\t\t\t\t"${param.name}": ${queryValueExpression(param)},`,
+			);
 		}
 		paramsLines.push("\t\t\t},");
 	}
@@ -135,14 +152,49 @@ function renderResourcePath(
 	resourcePathPrefix?: string,
 ): string {
 	const prefix = resourcePathPrefix ?? "";
+	const suffix = needsQueryString(op) ? "${queryString(ctx)}" : "";
 	if (op.pathParams.length === 0) {
-		return `"${prefix}${op.path}"`;
+		return suffix
+			? `\`${prefix}${op.path}${suffix}\``
+			: `"${prefix}${op.path}"`;
 	}
 	const interpolated = op.path.replace(
 		/\{([^}]+)\}/g,
 		(_match, name: string) => `\${util.urlEncode(ctx.args.${name})}`,
 	);
-	return `\`${prefix}${interpolated}\``;
+	return `\`${prefix}${interpolated}${suffix}\``;
+}
+
+/**
+ * Builds the resourcePath query string for operations carrying an exploded
+ * array parameter. Exploded arrays repeat the key, everything else contributes
+ * a single pair; absent optional args drop out. APPSYNC_JS has no
+ * `Array.isArray`, so the array/scalar split is decided here at emit time.
+ */
+function renderQueryString(op: RestOperationShape): string {
+	const appendLines = op.queryParams.map((param) =>
+		param.array && param.explode
+			? `\tappendEach(parts, "${param.name}", ctx.args.${param.name});`
+			: `\tappend(parts, "${param.name}", ${queryValueExpression(param)});`,
+	);
+
+	return [
+		"function queryString(ctx) {",
+		"\tconst parts = [];",
+		...appendLines,
+		'\treturn parts.length === 0 ? "" : `?${parts.join("&")}`;',
+		"}",
+		"",
+		"function append(parts, name, value) {",
+		"\tif (value === undefined || value === null) return;",
+		"\tparts.push(`${name}=${util.urlEncode(`${value}`)}`);",
+		"}",
+		"",
+		"function appendEach(parts, name, values) {",
+		"\tif (values === undefined || values === null) return;",
+		"\tfor (const value of values) append(parts, name, value);",
+		"}",
+	].join("\n");
 }
 
 /**
@@ -174,5 +226,6 @@ export const __test = {
 	renderBaseHeaders,
 	renderRequest,
 	renderResourcePath,
+	renderQueryString,
 	renderMapResponse,
 };

--- a/src/rest-operations.test.ts
+++ b/src/rest-operations.test.ts
@@ -144,6 +144,35 @@ describe("resolveRestOperation", () => {
 		);
 	});
 
+	it("resolves array-ness and explode for @query params", async () => {
+		const { resolved } = await resolveFixture(`
+      model Pet { petId: string; }
+
+      @route("/pets")
+      namespace Pets {
+        @restResolver @get op listPets(
+          @query(#{ explode: true }) status?: string[],
+          @query tag?: string[],
+          @query(#{ explode: true }) name?: string,
+        ): Pet[];
+      }
+    `);
+
+		const [listPets] = resolved;
+		assert.deepEqual(
+			listPets.queryParams.map(({ name, array, explode }) => ({
+				name,
+				array,
+				explode,
+			})),
+			[
+				{ name: "status", array: true, explode: true },
+				{ name: "tag", array: true, explode: false },
+				{ name: "name", array: false, explode: true },
+			],
+		);
+	});
+
 	it("maps PUT/PATCH/DELETE to Mutation", async () => {
 		const { resolved } = await resolveFixture(`
       model Pet { petId: string; }

--- a/src/rest-operations.ts
+++ b/src/rest-operations.ts
@@ -28,6 +28,13 @@ export interface RestPathParam {
 export interface RestQueryParam {
 	name: string;
 	optional: boolean;
+	/** The parameter is array-typed, so it serializes to more than one value. */
+	array: boolean;
+	/**
+	 * RFC-6570 explode, as resolved by `@typespec/http`. An exploded array
+	 * repeats the key (`?s=a&s=b`); a non-exploded one joins on a comma.
+	 */
+	explode: boolean;
 	/** Source ModelProperty — used by the SDL emitter for arg typing. */
 	property?: ModelProperty;
 }
@@ -90,6 +97,14 @@ export function toRestGraphQLTypeName(verb: string): RestGraphQLTypeName {
 	return verb.toLowerCase() === "get" ? "Query" : "Mutation";
 }
 
+function isArrayType(type: Type): boolean {
+	return (
+		type.kind === "Model" &&
+		type.name === "Array" &&
+		type.indexer?.value !== undefined
+	);
+}
+
 export function resolveRestOperation(
 	program: Program,
 	operation: Operation,
@@ -105,6 +120,8 @@ export function resolveRestOperation(
 			queryParams.push({
 				name: parameter.name,
 				optional: parameter.param.optional,
+				array: isArrayType(parameter.param.type),
+				explode: parameter.explode,
 				property: parameter.param,
 			});
 		}

--- a/test/petstore/main.tsp
+++ b/test/petstore/main.tsp
@@ -28,4 +28,12 @@ namespace Pets {
 	@restResolver @get op getPet(@path petId: string): Pet;
 	@restResolver @post op createPet(@body input: CreatePetInput): Pet;
 	@restResolver @get op listPets(@query status?: string): Pet[];
+
+	@restResolver
+	@route("/search")
+	@get
+	op searchPets(
+		@query(#{ explode: true }) status?: PetStatus[],
+		@query(#{ explode: true }) name?: string,
+	): Pet[];
 }

--- a/test/rest-example.js
+++ b/test/rest-example.js
@@ -62,6 +62,35 @@ test("resolver: query params land in params.query", async () => {
 	assert.ok(resolver.includes('"status": ctx.args.status'));
 });
 
+test("resolver: an exploded array param repeats its key in the resourcePath", async () => {
+	const resolver = await readFile(`${EMIT_DIR}/Query.searchPets.js`, "utf8");
+
+	assert.ok(!resolver.includes("query: {"));
+	assert.ok(
+		resolver.includes("resourcePath: `/pets/search${queryString(ctx)}`"),
+	);
+
+	const request = new Function(
+		"util",
+		"ctx",
+		`${resolver
+			.replace('import { util } from "@aws-appsync/utils";', "")
+			.replaceAll("export function", "function")}\nreturn request(ctx);`,
+	);
+	const { resourcePath } = request(
+		{ urlEncode: (value) => encodeURIComponent(value) },
+		{
+			args: { status: ["Available", "Sold"], name: "Rex" },
+			identity: { resolverContext: { userId: "u1" } },
+		},
+	);
+
+	assert.equal(
+		resourcePath,
+		"/pets/search?status=Available&status=Sold&name=Rex",
+	);
+});
+
 test("resolver: injectHeaders config expands into BASE_HEADERS", async () => {
 	const resolver = await readFile(`${EMIT_DIR}/Query.getPet.js`, "utf8");
 
@@ -76,7 +105,7 @@ test("manifest: REST entries carry typeName/httpMethod/resourcePath/dataSource, 
 		await readFile(`${EMIT_DIR}/graphql-resolvers.json`, "utf8"),
 	);
 
-	assert.equal(manifest.resolvers.length, 3);
+	assert.equal(manifest.resolvers.length, 4);
 
 	const getPet = manifest.resolvers.find((r) => r.fieldName === "getPet");
 	assert.deepEqual(getPet, {
@@ -105,6 +134,7 @@ test("generated resolvers contain no async or disallowed globals (APPSYNC_JS)", 
 		"Query.getPet.js",
 		"Query.listPets.js",
 		"Mutation.createPet.js",
+		"Query.searchPets.js",
 	]) {
 		const resolver = await readFile(`${EMIT_DIR}/${fileName}`, "utf8");
 		assert.ok(!resolver.includes("async "), `${fileName} uses async`);

--- a/test/snapshots/petstore/Query.searchPets.js
+++ b/test/snapshots/petstore/Query.searchPets.js
@@ -1,0 +1,44 @@
+import { util } from "@aws-appsync/utils";
+
+const BASE_HEADERS = (ctx) => ({
+	"Content-Type": "application/json",
+	"x-user-id": ctx.identity.resolverContext.userId,
+});
+
+export function request(ctx) {
+	return {
+		method: "GET",
+		resourcePath: `/pets/search${queryString(ctx)}`,
+		params: { headers: BASE_HEADERS(ctx) },
+	};
+}
+
+export function response(ctx) {
+	return mapResponse(ctx);
+}
+
+function queryString(ctx) {
+	const parts = [];
+	appendEach(parts, "status", ctx.args.status);
+	append(parts, "name", ctx.args.name);
+	return parts.length === 0 ? "" : `?${parts.join("&")}`;
+}
+
+function append(parts, name, value) {
+	if (value === undefined || value === null) return;
+	parts.push(`${name}=${util.urlEncode(`${value}`)}`);
+}
+
+function appendEach(parts, name, values) {
+	if (values === undefined || values === null) return;
+	for (const value of values) append(parts, name, value);
+}
+
+function mapResponse(ctx) {
+	const { statusCode, body } = ctx.result;
+	const parsed = body ? JSON.parse(body) : null;
+	if (statusCode >= 200 && statusCode < 300) return parsed;
+	if (statusCode === 409) util.error(parsed?.message ?? body, "ConflictError");
+	if (statusCode === 403) util.error(parsed?.message ?? body, "ForbiddenError");
+	util.error(parsed?.message ?? body, `Http${statusCode}`, parsed);
+}

--- a/test/snapshots/petstore/graphql-resolvers.json
+++ b/test/snapshots/petstore/graphql-resolvers.json
@@ -29,6 +29,16 @@
       "mode": "monolithic",
       "resolverFile": "Query.listPets.js",
       "sdlFile": "pet.graphql"
+    },
+    {
+      "typeName": "Query",
+      "fieldName": "searchPets",
+      "dataSource": "HTTP",
+      "httpMethod": "GET",
+      "resourcePath": "/pets/search",
+      "mode": "monolithic",
+      "resolverFile": "Query.searchPets.js",
+      "sdlFile": "pet.graphql"
     }
   ]
 }

--- a/test/snapshots/petstore/package.json
+++ b/test/snapshots/petstore/package.json
@@ -8,6 +8,7 @@
     "./Mutation.createPet.js": "./Mutation.createPet.js",
     "./pet.graphql": "./pet.graphql",
     "./Query.getPet.js": "./Query.getPet.js",
-    "./Query.listPets.js": "./Query.listPets.js"
+    "./Query.listPets.js": "./Query.listPets.js",
+    "./Query.searchPets.js": "./Query.searchPets.js"
   }
 }

--- a/test/snapshots/petstore/pet.graphql
+++ b/test/snapshots/petstore/pet.graphql
@@ -20,6 +20,7 @@ input CreatePetInput {
 type Query {
   getPet(petId: String!): Pet
   listPets(status: String): [Pet!]
+  searchPets(status: [PetStatus!], name: String): [Pet!]
 }
 
 type Mutation {


### PR DESCRIPTION
Emit an array-valued `@query` parameter in a form the AppSync HTTP data source accepts.

`params.query` is documented as a string→string map, so an array arg was forwarded as a JS array and rejected — a working backend filter became unreachable.

An exploded array now repeats its key inside the `resourcePath` query string; a non-exploded one comma-joins into a single `params.query` value, following the `explode` resolved by `@typespec/http`.

Context: stxcommodities/core-services#4310