### PR TITLE
feat(decorator): declare cross-domain view joins

### DIFF
--- a/README.md
+++ b/README.md
@@ -763,11 +763,21 @@ model PetCareSearchDoc is SearchProjection<Pet> {
 }
 ```
 
-`@resolvableBy` states how a row of the model is fetched: the key it is read by, and — second argument — the index that discovers every row carrying that key. It binds to the model's `@restResolver` read operation.
+`@resolvableBy` states how a row of the model is fetched: the key it is read by, and — second argument — the index that discovers every row carrying that key.
 
 `@dependsOn` states one joined entity on a projection. `lookup` fetches the row while the document is composed. `inbound` marks the joined model as an invalidation trigger: a write there re-indexes the driving entity's document.
 
 Both joins are left joins. Waffles the beagle has a passport; Nugget, a stray, does not, so `passport` is absent on his document and `ownershipHistory` is `[]`. Rehoming Waffles writes an `OwnershipRecord` and re-indexes his document.
+
+### Field binding
+
+A declaration says where the joined value lands, not only that it exists. Each `@dependsOn` binds to **exactly one** projection field — the one typed as the entity or as its search document. A `lookup` fills a single-valued field, an `inbound` fills an array. That binding is what names the resolver method and what `dependencies[].field` carries.
+
+Until the emitter composes the joined values, a bound field is absent from the emitted document type, mapping and SDL, and `join-field-not-composed` says so on every compile.
+
+### The read a join runs against
+
+`@resolvableBy` binds to the `@restResolver` GET operation that returns the model **and takes its declared key as a path or query parameter**. A sibling `listX()` over the same model is not that read — nothing hands it the key — so only the designated one carries a `resolvableBy` block.
 
 ### Manifest blocks
 
@@ -793,40 +803,55 @@ The projection's `opensearch-projections.json` entry carries `dependencies[]`, o
   "name": "PetCareSearchDoc",
   "indexName": "pet_care_v1",
   "dependencies": [
-    { "entity": "PetPassport", "direction": "lookup", "joinKey": "passportId" },
+    {
+      "entity": "PetPassport",
+      "direction": "lookup",
+      "joinKey": "passportId",
+      "field": "passport"
+    },
     {
       "entity": "OwnershipRecord",
       "direction": "inbound",
       "joinKey": "petId",
+      "field": "ownershipHistory",
       "index": "byPetId"
     }
   ]
 }
 ```
 
+`index` appears on an `inbound` entry only: a lookup fetches the row its key names, so the discovery index has nothing to say about it.
+
 Both blocks ship a JSON schema, exported from the package as `./schema/resolvable-by.schema.json` and `./schema/dependencies.schema.json`. Each key is omitted when nothing declares it, so a spec with no joins emits an unchanged manifest.
 
 ### Join resolver (`*-join-resolver.ts`)
 
-A projection with dependencies gets a TypeScript interface for the reads its declarations imply — one method per declaration, taking the join key and returning the joined shape:
+A projection with dependencies gets a TypeScript interface for the reads its declarations imply — one method per declaration, named for the field it fills, taking the join key and returning that field's declared type:
 
 ```ts
 export interface PetCareSearchDocJoinResolver {
-	lookupPetPassport(passportId: string): Promise<PetPassportSearchDoc | undefined>;
-	discoverOwnershipRecord(petId: string): Promise<OwnershipRecordSearchDoc[]>;
+	lookupPassport(passportId: string): Promise<PetPassportSearchDoc | undefined>;
+	discoverOwnershipHistory(petId: string): Promise<OwnershipRecordSearchDoc[]>;
 }
 ```
 
-A `lookup` returns one row or nothing; a discovery returns however many rows the index holds. The joined type is the entity's search document when the spec declares one, and the entity itself otherwise. Two declarations that would share a method name are told apart by their join key (`lookupPetPassportByLitterPassportId`).
+A `lookup` returns one row or nothing; a discovery returns however many rows the index holds. Naming the method after the field keeps two joins over the same entity apart, since a model cannot declare a property twice.
 
 ### Diagnostics
 
-| Code | Fires when |
-| --- | --- |
-| `unknown-join-key` | A key path names a property the model does not own — `@resolvableBy` takes a key on its own model, a `lookup` takes a key on the projection's source model, an `inbound` takes a key on the joined entity. |
-| `join-index-required` | An `inbound` join names an entity whose `@resolvableBy` declares no index, so nothing can discover the rows. |
-| `undeclared-join-resolution` | A `@dependsOn` names a model carrying no `@resolvableBy`, so nothing states how a row of it is fetched. |
-| `invalid-join-direction` | A direction other than `lookup` or `inbound`. |
+| Code | Severity | Fires when |
+| --- | --- | --- |
+| `unknown-join-key` | error | A key path names a property the model does not own, inheritance included — `@resolvableBy` takes a key on its own model, a `lookup` takes a key on the projection's source model, an `inbound` takes a key on the joined entity. |
+| `join-index-required` | error | An `inbound` join names an entity whose `@resolvableBy` declares no index, so nothing can discover the rows. |
+| `undeclared-join-resolution` | error | A `@dependsOn` names a model carrying no `@resolvableBy`, so nothing states how a row of it is fetched. |
+| `invalid-join-direction` | error | A direction other than `lookup` or `inbound`. |
+| `join-requires-projection` | error | `@dependsOn` sits on a model that is not a `SearchProjection<T>`. |
+| `join-field-missing` | error | No projection field is typed to receive the declared entity. |
+| `join-field-ambiguous` | error | More than one field could receive it, so nothing decides which. |
+| `join-field-arity` | error | A `lookup` bound to an array field, or an `inbound` bound to a single-valued one. |
+| `join-field-not-composed` | warning | The binding holds, but the joined value is not yet composed into the document. |
+| `join-read-operation-missing` | warning | No `@restResolver` GET returns the entity and takes its declared key, so the join has nothing to call. |
+
 
 ## Index settings (analyzers, tokenizers, filters)
 

--- a/README.md
+++ b/README.md
@@ -271,6 +271,8 @@ In this example:
 | `@filterable(...kinds)` | `ModelProperty` | Declares filter inputs on the GraphQL `<Type>SearchFilter` input. Allowed kinds: `"term"`, `"term_negate"`, `"terms"`, `"exists"`, `"range"`, `"prefix"`, `"match"`. `"terms"` produces a `<field>In: [Type!]` multi-value input (chip-style filters). On a `@nested` array field, `"exists"` becomes a path-level nested-existence check. `"prefix"` (`<field>Prefix: String`, OpenSearch `prefix`) and `"match"` (`<field>Match: String`, OpenSearch `match`) query the **analyzed** field rather than the `.keyword` sub-field, so an `@analyzer` (e.g. edge-ngram) registered on the field is exercised by the query — this is how partial / begins-with / contains matching is expressed. | `@filterable("term", "terms") status: string;` / `@analyzer("edge_ngram") @filterable("prefix", "match") name: string;` |
 | `@searchInfer` | `Model` (projection) | Walks the source model's fields and applies type-driven default `@filterable` / `@aggregatable` / `@sortable` capabilities (see [Inference](#searchinfer-type-driven-defaults)). Explicit decorators on a field always win on their axis. | `@searchInfer model TradeSearchDoc is SearchProjection<Trade> {}` |
 | `@searchSkip` | `ModelProperty` | Opts a field out of `@searchInfer` inference. The field is still included in response shape if `@searchable` / `@nested` apply; without those, the field is excluded entirely. | `@searchable @searchSkip auditTrail: string;` |
+| `@resolvableBy(Model.key)` / `@resolvableBy(Model.key, "index")` | `Model` | Declares how a row of the model is fetched for a cross-domain join: the key it is read by, and the index that discovers many rows by that key. See [Cross-domain view joins](#cross-domain-view-joins). | `@resolvableBy(OwnershipRecord.petId, "byPetId")` |
+| `@dependsOn(Entity, direction, joinKey)` | `Model` (projection) | Declares one joined entity on a projection. `"lookup"` fetches the row while the document is composed; `"inbound"` marks a write on the joined model as a re-index trigger for the driving document. See [Cross-domain view joins](#cross-domain-view-joins). | `@dependsOn(PetPassport, "lookup", Pet.passportId)` |
 | `@sortable` | `ModelProperty` | Exposes the field on the projection's `<Type>SortField` enum + `<Type>SortInput` so callers can pass `sortBy: [<Type>SortInput!]`. Inferred for keyword strings, numerics, dates, booleans, enums, and unions when the projection model has `@searchInfer`. Resolver falls back to `_score, _id` when `sortBy` is omitted. | `@sortable @keyword name: string;` |
 
 ## `@searchInfer` (type-driven defaults)
@@ -728,6 +730,104 @@ The message names the file and its size. Work in this order:
 
 Do not raise the constant in the assertion. 32,768 is an AWS limit, not a project policy — a green test with a raised cap fails at deploy instead.
 
+## Cross-domain view joins
+
+`SearchProjection<T>` resolves fields from one source model, so a field owned by another spec cannot enter the document and no manifest key says a write over there should re-index anything here. `@resolvableBy` and `@dependsOn` declare that join.
+
+A pet care view wants three things in one index: the pet, its passport (a separate spec, joined by `passportId`), and its ownership history (records that reference the pet as `petId`).
+
+```typespec
+@resolvableBy(PetPassport.passportId)
+model PetPassport {
+  passportId: string;
+  @searchable @keyword microchipId: string;
+  @searchable @keyword issuedCountry: string;
+  @searchable @keyword vaccinations: string[];
+}
+
+@resolvableBy(OwnershipRecord.petId, "byPetId")
+model OwnershipRecord {
+  ownershipRecordId: string;
+  petId: string;
+  @searchable @keyword ownerName: string;
+  @searchable @filterable("range") transferredAt: utcDateTime;
+}
+
+@searchProjection
+@indexName("pet_care_v1")
+@dependsOn(PetPassport, "lookup", Pet.passportId)
+@dependsOn(OwnershipRecord, "inbound", OwnershipRecord.petId)
+model PetCareSearchDoc is SearchProjection<Pet> {
+  passport?: PetPassportSearchDoc;
+  @nested ownershipHistory: OwnershipRecordSearchDoc[];
+}
+```
+
+`@resolvableBy` states how a row of the model is fetched: the key it is read by, and — second argument — the index that discovers every row carrying that key. It binds to the model's `@restResolver` read operation.
+
+`@dependsOn` states one joined entity on a projection. `lookup` fetches the row while the document is composed. `inbound` marks the joined model as an invalidation trigger: a write there re-indexes the driving entity's document.
+
+Both joins are left joins. Waffles the beagle has a passport; Nugget, a stray, does not, so `passport` is absent on his document and `ownershipHistory` is `[]`. Rehoming Waffles writes an `OwnershipRecord` and re-indexes his document.
+
+### Manifest blocks
+
+The read operation's `graphql-resolvers.json` entry carries a `resolvableBy` block:
+
+```json
+{
+  "typeName": "Query",
+  "fieldName": "listOwnershipRecords",
+  "resourcePath": "/ownership-records",
+  "resolvableBy": {
+    "entity": "OwnershipRecord",
+    "key": "petId",
+    "index": "byPetId"
+  }
+}
+```
+
+The projection's `opensearch-projections.json` entry carries `dependencies[]`, one object per declaration:
+
+```json
+{
+  "name": "PetCareSearchDoc",
+  "indexName": "pet_care_v1",
+  "dependencies": [
+    { "entity": "PetPassport", "direction": "lookup", "joinKey": "passportId" },
+    {
+      "entity": "OwnershipRecord",
+      "direction": "inbound",
+      "joinKey": "petId",
+      "index": "byPetId"
+    }
+  ]
+}
+```
+
+Both blocks ship a JSON schema, exported from the package as `./schema/resolvable-by.schema.json` and `./schema/dependencies.schema.json`. Each key is omitted when nothing declares it, so a spec with no joins emits an unchanged manifest.
+
+### Join resolver (`*-join-resolver.ts`)
+
+A projection with dependencies gets a TypeScript interface for the reads its declarations imply — one method per declaration, taking the join key and returning the joined shape:
+
+```ts
+export interface PetCareSearchDocJoinResolver {
+	lookupPetPassport(passportId: string): Promise<PetPassportSearchDoc | undefined>;
+	discoverOwnershipRecord(petId: string): Promise<OwnershipRecordSearchDoc[]>;
+}
+```
+
+A `lookup` returns one row or nothing; a discovery returns however many rows the index holds. The joined type is the entity's search document when the spec declares one, and the entity itself otherwise. Two declarations that would share a method name are told apart by their join key (`lookupPetPassportByLitterPassportId`).
+
+### Diagnostics
+
+| Code | Fires when |
+| --- | --- |
+| `unknown-join-key` | A key path names a property the model does not own — `@resolvableBy` takes a key on its own model, a `lookup` takes a key on the projection's source model, an `inbound` takes a key on the joined entity. |
+| `join-index-required` | An `inbound` join names an entity whose `@resolvableBy` declares no index, so nothing can discover the rows. |
+| `undeclared-join-resolution` | A `@dependsOn` names a model carrying no `@resolvableBy`, so nothing states how a row of it is fetched. |
+| `invalid-join-direction` | A direction other than `lookup` or `inbound`. |
+
 ## Index settings (analyzers, tokenizers, filters)
 
 Use `@indexSettings` to embed analysis configuration in the mapping output. The value is a JSON string that will be emitted as the `settings` block:
@@ -805,6 +905,7 @@ npm test          # runs build + lint + unit tests + emit test + example test
 - `src/**/*.test.ts` — unit tests (decorators, projection resolution, emitters)
 - `test/main.tsp` — integration fixture compiled by `npm run test:emit`
 - `test/example.js` — validates emitted output files against expectations
+- `test/pet-care/main.tsp` — cross-domain join fixture compiled by `npm run test:emit:joins`; `test/pet-care-example.js` validates the emitted blocks against the published JSON schemas
 - `test/string-modules.js` — validates the `resolvers/` and `schema/` string modules, their `exports` subpaths and the barrels against the manifest
 
 ## License

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
 				"@aws-appsync/eslint-plugin": "^2.0.2",
 				"@biomejs/biome": "^2.3.7",
 				"@types/node": "^22.18.11",
+				"ajv": "^8.20.0",
 				"conventional-changelog-conventionalcommits": "^9.1.0",
 				"eslint": "^9.39.4",
 				"semantic-release": "^25.0.7",
@@ -2462,9 +2463,9 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 	},
 	"files": [
 		"dist",
+		"schema",
 		"tsp"
 	],
 	"exports": {
@@ -20,20 +21,23 @@
 			"types": "./dist/index.d.ts",
 			"default": "./dist/index.js",
 			"typespec": "./tsp/main.tsp"
-		}
+		},
+		"./schema/resolvable-by.schema.json": "./schema/resolvable-by.schema.json",
+		"./schema/dependencies.schema.json": "./schema/dependencies.schema.json"
 	},
 	"scripts": {
 		"fix": "npx @biomejs/biome check --write",
 		"lint": "npx @biomejs/biome check",
 		"build": "tsc",
 		"watch": "tsc --watch",
-		"test": "npm run build && npm run lint && npm run test:unit && npm run test:emit && npm run test:emit:rest && npm run test:emit:rest:id && npm run test:emit:package && npm run test:emit:package:split && npm run test:example",
+		"test": "npm run build && npm run lint && npm run test:unit && npm run test:emit && npm run test:emit:rest && npm run test:emit:rest:id && npm run test:emit:joins && npm run test:emit:package && npm run test:emit:package:split && npm run test:example",
 		"test:emit": "tsp compile test/main.tsp --config test/tspconfig.yaml",
 		"test:emit:rest": "tsp compile test/petstore/main.tsp --config test/petstore/tspconfig.yaml",
 		"test:emit:rest:id": "tsp compile test/petstore-id/main.tsp --config test/petstore-id/tspconfig.yaml",
+		"test:emit:joins": "tsp compile test/pet-care/main.tsp --config test/pet-care/tspconfig.yaml",
 		"test:emit:package": "tsp compile test/main.tsp --config test/package/tspconfig.yaml",
 		"test:emit:package:split": "tsp compile test/main.tsp --config test/package/tspconfig.split.yaml",
-		"test:example": "node --test test/example.js test/regression.js test/rest-example.js test/rest-id-example.js test/package-exports.js test/string-modules.js",
+		"test:example": "node --test test/example.js test/regression.js test/rest-example.js test/rest-id-example.js test/pet-care-example.js test/package-exports.js test/string-modules.js",
 		"test:unit": "node --test --import=tsx src/**/*.test.ts",
 		"prepublishOnly": "tsc"
 	},
@@ -45,6 +49,7 @@
 		"@aws-appsync/eslint-plugin": "^2.0.2",
 		"@biomejs/biome": "^2.3.7",
 		"@types/node": "^22.18.11",
+		"ajv": "^8.20.0",
 		"conventional-changelog-conventionalcommits": "^9.1.0",
 		"eslint": "^9.39.4",
 		"semantic-release": "^25.0.7",

--- a/schema/dependencies.schema.json
+++ b/schema/dependencies.schema.json
@@ -6,7 +6,7 @@
 	"type": "array",
 	"items": {
 		"type": "object",
-		"required": ["entity", "direction", "joinKey"],
+		"required": ["entity", "direction", "joinKey", "field"],
 		"additionalProperties": false,
 		"properties": {
 			"entity": {
@@ -23,19 +23,35 @@
 				"type": "string",
 				"minLength": 1
 			},
+			"field": {
+				"description": "Property of the projection the joined value lands in. A lookup fills a single-valued field, an inbound an array.",
+				"type": "string",
+				"minLength": 1
+			},
 			"index": {
-				"description": "Index the joined rows are discovered by, carried from the entity's resolvableBy declaration.",
+				"description": "Index the joined rows are discovered by, carried from the entity's resolvableBy declaration. An inbound join only.",
 				"type": "string",
 				"minLength": 1
 			}
 		},
-		"if": {
-			"properties": { "direction": { "const": "inbound" } },
-			"required": ["direction"]
-		},
-		"then": {
-			"properties": { "index": { "type": "string", "minLength": 1 } },
-			"required": ["index"]
-		}
+		"allOf": [
+			{
+				"if": {
+					"properties": { "direction": { "const": "inbound" } },
+					"required": ["direction"]
+				},
+				"then": {
+					"properties": { "index": { "type": "string", "minLength": 1 } },
+					"required": ["index"]
+				}
+			},
+			{
+				"if": {
+					"properties": { "direction": { "const": "lookup" } },
+					"required": ["direction"]
+				},
+				"then": { "properties": { "index": false } }
+			}
+		]
 	}
 }

--- a/schema/dependencies.schema.json
+++ b/schema/dependencies.schema.json
@@ -1,0 +1,41 @@
+{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "https://kattebak.github.io/typespec-opensearch-emitter/schema/dependencies.schema.json",
+	"title": "dependencies",
+	"description": "Cross-domain joins a projection composes its document from. Emitted on the opensearch-projections.json entry of the projection, one object per @dependsOn declaration.",
+	"type": "array",
+	"items": {
+		"type": "object",
+		"required": ["entity", "direction", "joinKey"],
+		"additionalProperties": false,
+		"properties": {
+			"entity": {
+				"description": "Joined model.",
+				"type": "string",
+				"minLength": 1
+			},
+			"direction": {
+				"description": "lookup fetches the row while the document is composed; inbound marks a write on the joined model as a re-index trigger for the driving document.",
+				"enum": ["lookup", "inbound"]
+			},
+			"joinKey": {
+				"description": "Property the join runs over — on the projection's source model for a lookup, on the joined model for an inbound.",
+				"type": "string",
+				"minLength": 1
+			},
+			"index": {
+				"description": "Index the joined rows are discovered by, carried from the entity's resolvableBy declaration.",
+				"type": "string",
+				"minLength": 1
+			}
+		},
+		"if": {
+			"properties": { "direction": { "const": "inbound" } },
+			"required": ["direction"]
+		},
+		"then": {
+			"properties": { "index": { "type": "string", "minLength": 1 } },
+			"required": ["index"]
+		}
+	}
+}

--- a/schema/resolvable-by.schema.json
+++ b/schema/resolvable-by.schema.json
@@ -1,0 +1,26 @@
+{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "https://kattebak.github.io/typespec-opensearch-emitter/schema/resolvable-by.schema.json",
+	"title": "resolvableBy",
+	"description": "How a joined entity is fetched. Emitted on the graphql-resolvers.json entry of the read operation that serves the entity.",
+	"type": "object",
+	"required": ["entity", "key"],
+	"additionalProperties": false,
+	"properties": {
+		"entity": {
+			"description": "Model the read operation returns.",
+			"type": "string",
+			"minLength": 1
+		},
+		"key": {
+			"description": "Property of that model a row is read by.",
+			"type": "string",
+			"minLength": 1
+		},
+		"index": {
+			"description": "Index that discovers every row carrying the key. Absent when the entity can only be fetched a single row at a time.",
+			"type": "string",
+			"minLength": 1
+		}
+	}
+}

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -6,6 +6,10 @@ import type {
 	Program,
 	Type,
 } from "@typespec/compiler";
+import type {
+	JoinDependencyDeclaration,
+	ResolvableByDeclaration,
+} from "./joins.js";
 import { reportDiagnostic, StateKeys } from "./lib.js";
 
 export const namespace = "Kattebak.OpenSearch";
@@ -139,6 +143,74 @@ export function getGraphqlDirectives(
 	target: Model,
 ): string[] | undefined {
 	return program.stateMap(StateKeys.graphqlDirectives).get(target);
+}
+
+export function $resolvableBy(
+	context: DecoratorContext,
+	target: Model,
+	key: ModelProperty,
+	index?: string,
+): void {
+	context.program.stateMap(StateKeys.resolvableBy).set(target, {
+		key,
+		...(index !== undefined ? { index } : {}),
+	});
+}
+
+/**
+ * How a row of the model is fetched for a cross-domain view join (issue #194):
+ * the key it is read by, and — when declared — the index that discovers every
+ * row carrying that key. `undefined` means the model states no way to fetch it,
+ * so no projection may declare a `@dependsOn` on it.
+ */
+export function getResolvableBy(
+	program: Program,
+	target: Model,
+): ResolvableByDeclaration | undefined {
+	return program.stateMap(StateKeys.resolvableBy).get(target);
+}
+
+export function $dependsOn(
+	context: DecoratorContext,
+	target: Model,
+	entity: Model,
+	direction: string,
+	joinKey: ModelProperty,
+): void {
+	// Decorators are applied bottom-up, so the argument node position is what
+	// restores the order the declarations were written in.
+	const argumentTarget = context.getArgumentTarget(0);
+	const pos =
+		argumentTarget && "pos" in argumentTarget ? argumentTarget.pos : 0;
+	const stored: StoredJoinDependency[] =
+		context.program.stateMap(StateKeys.dependsOn).get(target) ?? [];
+	context.program
+		.stateMap(StateKeys.dependsOn)
+		.set(target, [...stored, { entity, direction, joinKey, pos }]);
+}
+
+interface StoredJoinDependency extends JoinDependencyDeclaration {
+	pos: number;
+}
+
+/**
+ * The joins declared on a projection via `@dependsOn`, in source order. The
+ * declarations are returned unvalidated — `validateJoinDeclarations` reports
+ * an unknown direction, an unresolvable entity and a stray join key.
+ */
+export function getJoinDependencies(
+	program: Program,
+	target: Model,
+): JoinDependencyDeclaration[] {
+	const stored: StoredJoinDependency[] =
+		program.stateMap(StateKeys.dependsOn).get(target) ?? [];
+	return [...stored]
+		.sort((a, b) => a.pos - b.pos)
+		.map(({ entity, direction, joinKey }) => ({
+			entity,
+			direction,
+			joinKey,
+		}));
 }
 
 export function $keyword(

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -178,10 +178,15 @@ export function $dependsOn(
 	joinKey: ModelProperty,
 ): void {
 	// Decorators are applied bottom-up, so the argument node position is what
-	// restores the order the declarations were written in.
+	// restores the order the declarations were written in. Falling back to a
+	// constant would silently reverse `dependencies[]`, so demand the position.
 	const argumentTarget = context.getArgumentTarget(0);
-	const pos =
-		argumentTarget && "pos" in argumentTarget ? argumentTarget.pos : 0;
+	if (!argumentTarget || !("pos" in argumentTarget)) {
+		throw new Error(
+			`@dependsOn on ${target.name} cannot resolve its argument position, so declaration order cannot be preserved.`,
+		);
+	}
+	const pos = argumentTarget.pos;
 	const stored: StoredJoinDependency[] =
 		context.program.stateMap(StateKeys.dependsOn).get(target) ?? [];
 	context.program

--- a/src/emit-doc-type.ts
+++ b/src/emit-doc-type.ts
@@ -1,6 +1,7 @@
 import type {
 	Enum,
 	Model,
+	ModelProperty,
 	Program,
 	Scalar,
 	Type,
@@ -84,6 +85,28 @@ export function emitDocType(
 		fileName,
 		content: parts.join("\n"),
 	};
+}
+
+export function renderPropertyType(
+	program: Program,
+	property: ModelProperty,
+): string {
+	return renderType(program, property.type);
+}
+
+/**
+ * The whole model as a TypeScript interface — every property, not the
+ * `@searchable` subset a projection resolves. Used for a joined entity the
+ * spec declares no `SearchProjection<T>` for (issue #194).
+ */
+export function renderEntityInterface(program: Program, model: Model): string {
+	const fields = Array.from(model.properties.values()).map((property) => ({
+		name: getSearchAs(program, property) ?? property.name,
+		type: property.type,
+		optional: property.optional,
+	}));
+
+	return `export interface ${model.name} ${renderBlock(program, fields, 1)}`;
 }
 
 /**

--- a/src/emit-index.ts
+++ b/src/emit-index.ts
@@ -1,4 +1,8 @@
 import { collectSubProjections, toDocTypeFileName } from "./emit-doc-type.js";
+import {
+	toJoinResolverFileName,
+	toJoinResolverInterfaceName,
+} from "./emit-join-resolver.js";
 import type { ResolvedProjection, TopLevelProjection } from "./projection.js";
 
 export interface EmittedIndexFile {
@@ -51,6 +55,14 @@ export function emitIndex(projections: TopLevelProjection[]): EmittedIndexFile {
 		lines.push(
 			`export const ${toIndexConstantName(projection.projectionModel.name)} = "${projection.indexName}";`,
 		);
+		if (projection.joins && projection.joins.length > 0) {
+			const joinResolverFile = toJoinResolverFileName(
+				projection.projectionModel.name,
+			).replace(/\.ts$/, ".js");
+			lines.push(
+				`export type { ${toJoinResolverInterfaceName(projection.projectionModel.name)} } from "./${joinResolverFile}";`,
+			);
+		}
 	}
 
 	return {

--- a/src/emit-join-resolver.test.ts
+++ b/src/emit-join-resolver.test.ts
@@ -1,0 +1,190 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { createTestHost, createTestWrapper } from "@typespec/compiler/testing";
+import { emitJoinResolver } from "./emit-join-resolver.js";
+import { resolveJoinDependencies } from "./joins.js";
+import {
+	isSearchProjectionModel,
+	type ResolvedProjection,
+	resolveProjectionModel,
+} from "./projection.js";
+import { OpenSearchEmitterTestLibrary } from "./testing/index.js";
+
+async function createRunner() {
+	const host = await createTestHost({
+		libraries: [OpenSearchEmitterTestLibrary],
+	});
+
+	return createTestWrapper(host, {
+		autoImports: ["@kattebak/typespec-opensearch-emitter"],
+		autoUsings: ["Kattebak.OpenSearch"],
+	});
+}
+
+async function resolveAll(code: string) {
+	const runner = await createRunner();
+	await runner.diagnose(code);
+
+	const program = runner.program;
+	const projections: ResolvedProjection[] = [];
+	for (const model of program.getGlobalNamespaceType().models.values()) {
+		if (!isSearchProjectionModel(program, model)) continue;
+		const projection = resolveProjectionModel(program, model);
+		if (!projection) continue;
+		projections.push({
+			...projection,
+			joins: resolveJoinDependencies(program, model),
+		});
+	}
+
+	return { program, projections };
+}
+
+const PET_CARE = `
+	model Pet {
+		@searchable @keyword petId: string;
+		@searchable @keyword passportId: string;
+	}
+
+	@resolvableBy(PetPassport.passportId)
+	model PetPassport {
+		passportId: string;
+		@searchable @keyword microchipId: string;
+	}
+
+	@resolvableBy(OwnershipRecord.petId, "byPetId")
+	model OwnershipRecord {
+		ownershipRecordId: string;
+		petId: string;
+		@searchable @keyword ownerName: string;
+	}
+
+	model PetPassportSearchDoc is SearchProjection<PetPassport> {}
+	model OwnershipRecordSearchDoc is SearchProjection<OwnershipRecord> {}
+
+	@searchProjection
+	@indexName("pet_care_v1")
+	@dependsOn(PetPassport, "lookup", Pet.passportId)
+	@dependsOn(OwnershipRecord, "inbound", OwnershipRecord.petId)
+	model PetCareSearchDoc is SearchProjection<Pet> {
+		passport?: PetPassportSearchDoc;
+		@nested ownershipHistory: OwnershipRecordSearchDoc[];
+	}
+`;
+
+function emitFor(
+	program: Parameters<typeof emitJoinResolver>[0],
+	projections: ResolvedProjection[],
+	name: string,
+) {
+	const projection = projections.find(
+		(x) => x.projectionModel.name === name,
+	) as ResolvedProjection;
+	assert.ok(projection);
+	return emitJoinResolver(program, projection, projections);
+}
+
+describe("emitJoinResolver", () => {
+	it("emits one method per declaration, typed from the joined document", async () => {
+		const { program, projections } = await resolveAll(PET_CARE);
+
+		const file = emitFor(program, projections, "PetCareSearchDoc");
+		assert.ok(file);
+		assert.equal(file.fileName, "pet-care-search-doc-join-resolver.ts");
+
+		assert.equal(
+			file.content,
+			`import type { OwnershipRecordSearchDoc } from "./ownership-record-search-doc.js";
+import type { PetPassportSearchDoc } from "./pet-passport-search-doc.js";
+
+export interface PetCareSearchDocJoinResolver {
+	lookupPetPassport(passportId: string): Promise<PetPassportSearchDoc | undefined>;
+	discoverOwnershipRecord(petId: string): Promise<OwnershipRecordSearchDoc[]>;
+}
+`,
+		);
+	});
+
+	it("emits nothing for a projection with no declared joins", async () => {
+		const { program, projections } = await resolveAll(`
+			model Pet {
+				@searchable @keyword petId: string;
+			}
+
+			@searchProjection
+			@indexName("pets_v1")
+			model PetSearchDoc is SearchProjection<Pet> {}
+		`);
+
+		assert.equal(emitFor(program, projections, "PetSearchDoc"), undefined);
+	});
+
+	it("declares the entity inline when the spec projects no document for it", async () => {
+		const { program, projections } = await resolveAll(`
+			model Pet {
+				@searchable @keyword petId: string;
+				@searchable @keyword passportId: string;
+			}
+
+			@resolvableBy(PetPassport.passportId)
+			model PetPassport {
+				passportId: string;
+				microchipId: string;
+				boosterDue?: utcDateTime;
+			}
+
+			@searchProjection
+			@indexName("pet_care_v1")
+			@dependsOn(PetPassport, "lookup", Pet.passportId)
+			model PetCareSearchDoc is SearchProjection<Pet> {}
+		`);
+
+		const file = emitFor(program, projections, "PetCareSearchDoc");
+		assert.ok(file);
+		assert.ok(!file.content.includes("import type"));
+		assert.ok(
+			file.content.includes(`export interface PetPassport {
+	passportId: string;
+	microchipId: string;
+	boosterDue?: string;
+}`),
+		);
+		assert.ok(
+			file.content.includes(
+				"lookupPetPassport(passportId: string): Promise<PetPassport | undefined>;",
+			),
+		);
+	});
+
+	it("disambiguates two joins that would otherwise share a method name", async () => {
+		const { program, projections } = await resolveAll(`
+			model Pet {
+				@searchable @keyword petId: string;
+				@searchable @keyword passportId: string;
+				@searchable @keyword litterPassportId: string;
+			}
+
+			@resolvableBy(PetPassport.passportId)
+			model PetPassport {
+				passportId: string;
+				@searchable @keyword microchipId: string;
+			}
+
+			@searchProjection
+			@indexName("pet_care_v1")
+			@dependsOn(PetPassport, "lookup", Pet.passportId)
+			@dependsOn(PetPassport, "lookup", Pet.litterPassportId)
+			model PetCareSearchDoc is SearchProjection<Pet> {}
+		`);
+
+		const file = emitFor(program, projections, "PetCareSearchDoc");
+		assert.ok(file);
+		assert.ok(file.content.includes("lookupPetPassport(passportId: string)"));
+		assert.ok(
+			file.content.includes(
+				"lookupPetPassportByLitterPassportId(litterPassportId: string)",
+			),
+		);
+	});
+});

--- a/src/emit-join-resolver.test.ts
+++ b/src/emit-join-resolver.test.ts
@@ -1,30 +1,36 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
+import type { Program } from "@typespec/compiler";
 import { createTestHost, createTestWrapper } from "@typespec/compiler/testing";
+import { HttpTestLibrary } from "@typespec/http/testing";
 import { emitJoinResolver } from "./emit-join-resolver.js";
 import { resolveJoinDependencies } from "./joins.js";
 import {
-	isSearchProjectionModel,
 	type ResolvedProjection,
 	resolveProjectionModel,
 } from "./projection.js";
+import { isSearchProjectionModel } from "./projection-source.js";
 import { OpenSearchEmitterTestLibrary } from "./testing/index.js";
 
 async function createRunner() {
 	const host = await createTestHost({
-		libraries: [OpenSearchEmitterTestLibrary],
+		libraries: [HttpTestLibrary, OpenSearchEmitterTestLibrary],
 	});
 
 	return createTestWrapper(host, {
-		autoImports: ["@kattebak/typespec-opensearch-emitter"],
-		autoUsings: ["Kattebak.OpenSearch"],
+		autoImports: ["@typespec/http", "@kattebak/typespec-opensearch-emitter"],
+		autoUsings: ["TypeSpec.Http", "Kattebak.OpenSearch"],
 	});
 }
 
 async function resolveAll(code: string) {
 	const runner = await createRunner();
-	await runner.diagnose(code);
+	const diagnostics = await runner.diagnose(code);
+	assert.deepEqual(
+		diagnostics.filter((x) => x.severity === "error"),
+		[],
+	);
 
 	const program = runner.program;
 	const projections: ResolvedProjection[] = [];
@@ -39,6 +45,16 @@ async function resolveAll(code: string) {
 	}
 
 	return { program, projections };
+}
+
+function emitFor(
+	program: Program,
+	projections: ResolvedProjection[],
+	name: string,
+) {
+	const projection = projections.find((x) => x.projectionModel.name === name);
+	assert.ok(projection);
+	return emitJoinResolver(program, projection);
 }
 
 const PET_CARE = `
@@ -71,22 +87,20 @@ const PET_CARE = `
 		passport?: PetPassportSearchDoc;
 		@nested ownershipHistory: OwnershipRecordSearchDoc[];
 	}
+
+	@route("/pet-passports")
+	namespace PetPassports {
+		@restResolver @get op getPetPassport(@path passportId: string): PetPassport;
+	}
+
+	@route("/ownership-records")
+	namespace OwnershipRecords {
+		@restResolver @get op listOwnershipRecords(@query petId: string): OwnershipRecord[];
+	}
 `;
 
-function emitFor(
-	program: Parameters<typeof emitJoinResolver>[0],
-	projections: ResolvedProjection[],
-	name: string,
-) {
-	const projection = projections.find(
-		(x) => x.projectionModel.name === name,
-	) as ResolvedProjection;
-	assert.ok(projection);
-	return emitJoinResolver(program, projection, projections);
-}
-
 describe("emitJoinResolver", () => {
-	it("emits one method per declaration, typed from the joined document", async () => {
+	it("names each method for the field it fills and types it from that field", async () => {
 		const { program, projections } = await resolveAll(PET_CARE);
 
 		const file = emitFor(program, projections, "PetCareSearchDoc");
@@ -99,8 +113,8 @@ describe("emitJoinResolver", () => {
 import type { PetPassportSearchDoc } from "./pet-passport-search-doc.js";
 
 export interface PetCareSearchDocJoinResolver {
-	lookupPetPassport(passportId: string): Promise<PetPassportSearchDoc | undefined>;
-	discoverOwnershipRecord(petId: string): Promise<OwnershipRecordSearchDoc[]>;
+	lookupPassport(passportId: string): Promise<PetPassportSearchDoc | undefined>;
+	discoverOwnershipHistory(petId: string): Promise<OwnershipRecordSearchDoc[]>;
 }
 `,
 		);
@@ -120,7 +134,7 @@ export interface PetCareSearchDocJoinResolver {
 		assert.equal(emitFor(program, projections, "PetSearchDoc"), undefined);
 	});
 
-	it("declares the entity inline when the spec projects no document for it", async () => {
+	it("declares the entity inline when the field names the model itself", async () => {
 		const { program, projections } = await resolveAll(`
 			model Pet {
 				@searchable @keyword petId: string;
@@ -137,7 +151,14 @@ export interface PetCareSearchDocJoinResolver {
 			@searchProjection
 			@indexName("pet_care_v1")
 			@dependsOn(PetPassport, "lookup", Pet.passportId)
-			model PetCareSearchDoc is SearchProjection<Pet> {}
+			model PetCareSearchDoc is SearchProjection<Pet> {
+				passport?: PetPassport;
+			}
+
+			@route("/pet-passports")
+			namespace PetPassports {
+				@restResolver @get op getPetPassport(@path passportId: string): PetPassport;
+			}
 		`);
 
 		const file = emitFor(program, projections, "PetCareSearchDoc");
@@ -152,12 +173,12 @@ export interface PetCareSearchDocJoinResolver {
 		);
 		assert.ok(
 			file.content.includes(
-				"lookupPetPassport(passportId: string): Promise<PetPassport | undefined>;",
+				"lookupPassport(passportId: string): Promise<PetPassport | undefined>;",
 			),
 		);
 	});
 
-	it("disambiguates two joins that would otherwise share a method name", async () => {
+	it("keeps two joins over the same entity apart by the field each fills", async () => {
 		const { program, projections } = await resolveAll(`
 			model Pet {
 				@searchable @keyword petId: string;
@@ -171,19 +192,45 @@ export interface PetCareSearchDocJoinResolver {
 				@searchable @keyword microchipId: string;
 			}
 
+			@resolvableBy(LitterPassport.passportId)
+			model LitterPassport {
+				passportId: string;
+				@searchable @keyword breederId: string;
+			}
+
+			model PetPassportSearchDoc is SearchProjection<PetPassport> {}
+			model LitterPassportSearchDoc is SearchProjection<LitterPassport> {}
+
 			@searchProjection
 			@indexName("pet_care_v1")
 			@dependsOn(PetPassport, "lookup", Pet.passportId)
-			@dependsOn(PetPassport, "lookup", Pet.litterPassportId)
-			model PetCareSearchDoc is SearchProjection<Pet> {}
+			@dependsOn(LitterPassport, "lookup", Pet.litterPassportId)
+			model PetCareSearchDoc is SearchProjection<Pet> {
+				passport?: PetPassportSearchDoc;
+				litterPassport?: LitterPassportSearchDoc;
+			}
+
+			@route("/passports")
+			namespace Passports {
+				@restResolver @get op getPetPassport(@path passportId: string): PetPassport;
+			}
+
+			@route("/litter-passports")
+			namespace LitterPassports {
+				@restResolver @get op getLitterPassport(@path passportId: string): LitterPassport;
+			}
 		`);
 
 		const file = emitFor(program, projections, "PetCareSearchDoc");
 		assert.ok(file);
-		assert.ok(file.content.includes("lookupPetPassport(passportId: string)"));
 		assert.ok(
 			file.content.includes(
-				"lookupPetPassportByLitterPassportId(litterPassportId: string)",
+				"lookupPassport(passportId: string): Promise<PetPassportSearchDoc | undefined>;",
+			),
+		);
+		assert.ok(
+			file.content.includes(
+				"lookupLitterPassport(litterPassportId: string): Promise<LitterPassportSearchDoc | undefined>;",
 			),
 		);
 	});

--- a/src/emit-join-resolver.ts
+++ b/src/emit-join-resolver.ts
@@ -1,0 +1,128 @@
+import type { Model, Program } from "@typespec/compiler";
+import {
+	renderEntityInterface,
+	renderPropertyType,
+	toDocTypeFileName,
+} from "./emit-doc-type.js";
+import type { ResolvedJoinDependency } from "./joins.js";
+import type { ResolvedProjection } from "./projection.js";
+import { toKebabCase } from "./utils.js";
+
+export interface EmittedJoinResolverFile {
+	fileName: string;
+	content: string;
+}
+
+export function toJoinResolverFileName(projectionModelName: string): string {
+	return `${toKebabCase(projectionModelName)}-join-resolver.ts`;
+}
+
+export function toJoinResolverInterfaceName(
+	projectionModelName: string,
+): string {
+	return `${projectionModelName}JoinResolver`;
+}
+
+/**
+ * The join-resolver interface a projection's `@dependsOn` declarations imply
+ * (issue #194): one method per declaration, named for its direction, taking
+ * the join key and returning the joined shape. Both joins are left joins, so a
+ * `lookup` may resolve to nothing and a discovery may resolve to no rows.
+ * `undefined` when the projection declares no joins.
+ */
+export function emitJoinResolver(
+	program: Program,
+	projection: ResolvedProjection,
+	allProjections: ResolvedProjection[],
+): EmittedJoinResolverFile | undefined {
+	const joins = projection.joins ?? [];
+	if (joins.length === 0) {
+		return undefined;
+	}
+
+	const documentTypeByEntity = new Map<Model, string>();
+	for (const candidate of allProjections) {
+		if (!documentTypeByEntity.has(candidate.sourceModel)) {
+			documentTypeByEntity.set(
+				candidate.sourceModel,
+				candidate.projectionModel.name,
+			);
+		}
+	}
+
+	const imports = new Map<string, string>();
+	const localInterfaces = new Map<string, string>();
+	const usedMethodNames = new Set<string>();
+	const methods: string[] = [];
+
+	for (const join of joins) {
+		const documentType = documentTypeByEntity.get(join.entity);
+		if (documentType) {
+			const file = toDocTypeFileName(documentType).replace(/\.ts$/, ".js");
+			imports.set(
+				documentType,
+				`import type { ${documentType} } from "./${file}";`,
+			);
+		} else if (!localInterfaces.has(join.entity.name)) {
+			localInterfaces.set(
+				join.entity.name,
+				renderEntityInterface(program, join.entity),
+			);
+		}
+
+		const joinedType = documentType ?? join.entity.name;
+		const methodName = uniqueMethodName(join, usedMethodNames);
+		usedMethodNames.add(methodName);
+
+		const argument = `${join.joinKey.name}: ${renderPropertyType(program, join.joinKey)}`;
+		const returnType =
+			join.direction === "lookup"
+				? `Promise<${joinedType} | undefined>`
+				: `Promise<${joinedType}[]>`;
+
+		methods.push(`\t${methodName}(${argument}): ${returnType};`);
+	}
+
+	const parts: string[] = [];
+	const importLines = [...imports.entries()]
+		.sort(([a], [b]) => a.localeCompare(b))
+		.map(([, line]) => line);
+	if (importLines.length > 0) {
+		parts.push(importLines.join("\n"), "");
+	}
+	for (const [, declaration] of [...localInterfaces.entries()].sort(
+		([a], [b]) => a.localeCompare(b),
+	)) {
+		parts.push(`${declaration}\n`);
+	}
+	parts.push(
+		`export interface ${toJoinResolverInterfaceName(projection.projectionModel.name)} {\n${methods.join("\n")}\n}\n`,
+	);
+
+	return {
+		fileName: toJoinResolverFileName(projection.projectionModel.name),
+		content: parts.join("\n"),
+	};
+}
+
+function uniqueMethodName(
+	join: ResolvedJoinDependency,
+	used: ReadonlySet<string>,
+): string {
+	const verb = join.direction === "lookup" ? "lookup" : "discover";
+	const base = `${verb}${join.entity.name}`;
+	if (!used.has(base)) {
+		return base;
+	}
+	return `${base}By${capitalize(join.joinKey.name)}`;
+}
+
+function capitalize(value: string): string {
+	return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+export const __test = {
+	toJoinResolverFileName,
+	toJoinResolverInterfaceName,
+	uniqueMethodName,
+};

--- a/src/emit-join-resolver.ts
+++ b/src/emit-join-resolver.ts
@@ -4,8 +4,9 @@ import {
 	renderPropertyType,
 	toDocTypeFileName,
 } from "./emit-doc-type.js";
-import type { ResolvedJoinDependency } from "./joins.js";
+import { unwrapArrayElement } from "./joins.js";
 import type { ResolvedProjection } from "./projection.js";
+import { isSearchProjectionModel } from "./projection-source.js";
 import { toKebabCase } from "./utils.js";
 
 export interface EmittedJoinResolverFile {
@@ -25,60 +26,56 @@ export function toJoinResolverInterfaceName(
 
 /**
  * The join-resolver interface a projection's `@dependsOn` declarations imply
- * (issue #194): one method per declaration, named for its direction, taking
- * the join key and returning the joined shape. Both joins are left joins, so a
- * `lookup` may resolve to nothing and a discovery may resolve to no rows.
- * `undefined` when the projection declares no joins.
+ * (issue #194): one method per declaration, named for the document field it
+ * fills, taking the join key and returning that field's declared type. Both
+ * joins are left joins, so a `lookup` may resolve to nothing and a discovery
+ * to no rows. `undefined` when the projection declares no joins.
  */
 export function emitJoinResolver(
 	program: Program,
 	projection: ResolvedProjection,
-	allProjections: ResolvedProjection[],
 ): EmittedJoinResolverFile | undefined {
 	const joins = projection.joins ?? [];
 	if (joins.length === 0) {
 		return undefined;
 	}
 
-	const documentTypeByEntity = new Map<Model, string>();
-	for (const candidate of allProjections) {
-		if (!documentTypeByEntity.has(candidate.sourceModel)) {
-			documentTypeByEntity.set(
-				candidate.sourceModel,
-				candidate.projectionModel.name,
-			);
-		}
-	}
-
 	const imports = new Map<string, string>();
 	const localInterfaces = new Map<string, string>();
-	const usedMethodNames = new Set<string>();
+	const methodNames = new Set<string>();
 	const methods: string[] = [];
 
 	for (const join of joins) {
-		const documentType = documentTypeByEntity.get(join.entity);
-		if (documentType) {
-			const file = toDocTypeFileName(documentType).replace(/\.ts$/, ".js");
-			imports.set(
-				documentType,
-				`import type { ${documentType} } from "./${file}";`,
-			);
-		} else if (!localInterfaces.has(join.entity.name)) {
-			localInterfaces.set(
-				join.entity.name,
-				renderEntityInterface(program, join.entity),
+		const joined = unwrapArrayElement(join.field.type) ?? join.field.type;
+		if (joined.kind !== "Model") {
+			throw new Error(
+				`Join field "${join.field.name}" on ${projection.projectionModel.name} does not resolve to a model.`,
 			);
 		}
 
-		const joinedType = documentType ?? join.entity.name;
-		const methodName = uniqueMethodName(join, usedMethodNames);
-		usedMethodNames.add(methodName);
+		if (isSearchProjectionModel(program, joined)) {
+			const file = toDocTypeFileName(joined.name).replace(/\.ts$/, ".js");
+			imports.set(
+				joined.name,
+				`import type { ${joined.name} } from "./${file}";`,
+			);
+		} else if (!localInterfaces.has(joined.name)) {
+			localInterfaces.set(joined.name, renderEntityInterface(program, joined));
+		}
+
+		const methodName = toMethodName(join.direction, join.field.name);
+		if (methodNames.has(methodName)) {
+			throw new Error(
+				`Join-resolver method "${methodName}" is declared twice on ${projection.projectionModel.name}.`,
+			);
+		}
+		methodNames.add(methodName);
 
 		const argument = `${join.joinKey.name}: ${renderPropertyType(program, join.joinKey)}`;
 		const returnType =
 			join.direction === "lookup"
-				? `Promise<${joinedType} | undefined>`
-				: `Promise<${joinedType}[]>`;
+				? `Promise<${joined.name} | undefined>`
+				: `Promise<${joined.name}[]>`;
 
 		methods.push(`\t${methodName}(${argument}): ${returnType};`);
 	}
@@ -105,24 +102,17 @@ export function emitJoinResolver(
 	};
 }
 
-function uniqueMethodName(
-	join: ResolvedJoinDependency,
-	used: ReadonlySet<string>,
-): string {
-	const verb = join.direction === "lookup" ? "lookup" : "discover";
-	const base = `${verb}${join.entity.name}`;
-	if (!used.has(base)) {
-		return base;
-	}
-	return `${base}By${capitalize(join.joinKey.name)}`;
-}
-
-function capitalize(value: string): string {
-	return value.charAt(0).toUpperCase() + value.slice(1);
+/**
+ * Named for the field it fills, so two joins over the same entity stay apart
+ * without a disambiguation rule — a model cannot declare a property twice.
+ */
+function toMethodName(direction: string, fieldName: string): string {
+	const verb = direction === "lookup" ? "lookup" : "discover";
+	return `${verb}${fieldName.charAt(0).toUpperCase()}${fieldName.slice(1)}`;
 }
 
 export const __test = {
 	toJoinResolverFileName,
 	toJoinResolverInterfaceName,
-	uniqueMethodName,
+	toMethodName,
 };

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -20,6 +20,10 @@ import {
 } from "./emit-graphql-resolver.js";
 import { emitGraphQLSdl, resolveDirectives } from "./emit-graphql-sdl.js";
 import { emitIndex } from "./emit-index.js";
+import {
+	emitJoinResolver,
+	toJoinResolverFileName,
+} from "./emit-join-resolver.js";
 import { emitMapping } from "./emit-mapping.js";
 import {
 	type EmittedRestResolverFile,
@@ -39,6 +43,11 @@ import {
 	resolverModuleSpecifier,
 	sdlModuleSpecifier,
 } from "./emit-string-module.js";
+import {
+	type ResolvableByManifestEntry,
+	resolveJoinDependencies,
+	toJoinDependencyManifestEntry,
+} from "./joins.js";
 import { type OpenSearchEmitterOptions, reportDiagnostic } from "./lib.js";
 import {
 	isSearchProjectionModel,
@@ -73,9 +82,16 @@ export async function $onEmit(
 		return;
 	}
 
-	const resolved = projectionModels
+	const resolved: ResolvedProjection[] = projectionModels
 		.map((model) => resolveProjectionModel(context.program, model))
-		.filter((x): x is ResolvedProjection => x !== undefined);
+		.filter((x): x is ResolvedProjection => x !== undefined)
+		.map((projection) => ({
+			...projection,
+			joins: resolveJoinDependencies(
+				context.program,
+				projection.projectionModel,
+			),
+		}));
 
 	// Issue #123 — `is SearchProjection<T>` declares a projection-shaped type;
 	// `@searchProjection` is the additional gate for *top-level* emission
@@ -103,6 +119,21 @@ export async function $onEmit(
 	// that named files no consumer could resolve as soon as a projection's
 	// emitted shape stopped matching the assumed one.
 	const artifactFileNames: string[] = [];
+
+	// Issue #194 — a projection declaring `@dependsOn` ships the join-resolver
+	// interface its declarations imply, top-level or nested-only alike.
+	for (const projection of resolved) {
+		const joinResolverFile = emitJoinResolver(
+			context.program,
+			projection,
+			resolved,
+		);
+		if (!joinResolverFile) continue;
+		await emitFile(context.program, {
+			path: resolvePath(context.emitterOutputDir, joinResolverFile.fileName),
+			content: joinResolverFile.content,
+		});
+	}
 
 	for (const projection of topLevel) {
 		const docTypeFile = emitDocType(context.program, projection);
@@ -432,6 +463,13 @@ function serializeProjections(resolved: TopLevelProjection[]) {
 			...(projection.indexSettings
 				? { indexSettings: projection.indexSettings }
 				: {}),
+			// `dependencies` (issue #194) is omitted when a projection declares
+			// no `@dependsOn`, so an unjoined spec emits an unchanged manifest.
+			...(projection.joins && projection.joins.length > 0
+				? {
+						dependencies: projection.joins.map(toJoinDependencyManifestEntry),
+					}
+				: {}),
 			fields: projection.fields.map((field) => ({
 				name: field.name,
 				...(field.projectedName ? { projectedName: field.projectedName } : {}),
@@ -471,6 +509,9 @@ function generateRestManifestEntries(
 		mode: "monolithic",
 		resolverFile: restResolverFileName(op),
 		sdlFile: sdlFileName ?? restSdlFileName(op),
+		// `resolvableBy` (issue #194) names the entity this read serves a join
+		// for; omitted when the returned model declares none.
+		...(op.resolvableBy ? { resolvableBy: op.resolvableBy } : {}),
 	}));
 }
 
@@ -501,6 +542,7 @@ interface RestManifestEntry {
 	mode: "monolithic";
 	resolverFile: string;
 	sdlFile: string;
+	resolvableBy?: ResolvableByManifestEntry;
 }
 
 interface NestedTypeManifestEntry {
@@ -675,6 +717,10 @@ function generateTsConfig(
 
 	for (const projection of projections) {
 		tsFiles.push(toDocTypeFileName(projection.projectionModel.name));
+
+		if (projection.joins && projection.joins.length > 0) {
+			tsFiles.push(toJoinResolverFileName(projection.projectionModel.name));
+		}
 
 		for (const subProj of collectSubProjections(projection)) {
 			const subFileName = toDocTypeFileName(subProj.projectionModel.name);

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -123,11 +123,7 @@ export async function $onEmit(
 	// Issue #194 — a projection declaring `@dependsOn` ships the join-resolver
 	// interface its declarations imply, top-level or nested-only alike.
 	for (const projection of resolved) {
-		const joinResolverFile = emitJoinResolver(
-			context.program,
-			projection,
-			resolved,
-		);
+		const joinResolverFile = emitJoinResolver(context.program, projection);
 		if (!joinResolverFile) continue;
 		await emitFile(context.program, {
 			path: resolvePath(context.emitterOutputDir, joinResolverFile.fileName),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,11 @@
+import type { Program } from "@typespec/compiler";
+import { validateJoinDeclarations } from "./joins.js";
+
 export {
 	$aggregatable,
 	$analyzer,
 	$boost,
+	$dependsOn,
 	$filterable,
 	$graphqlDirectives,
 	$graphqlId,
@@ -10,6 +14,7 @@ export {
 	$indexSettings,
 	$keyword,
 	$nested,
+	$resolvableBy,
 	$restResolver,
 	$searchAs,
 	$searchable,
@@ -25,6 +30,8 @@ export {
 	getIgnoreAbove,
 	getIndexName,
 	getIndexSettings,
+	getJoinDependencies,
+	getResolvableBy,
 	getSearchAs,
 	isGraphqlId,
 	isKeyword,
@@ -38,4 +45,17 @@ export {
 	namespace,
 } from "./decorators.js";
 export { $onEmit } from "./emitter.js";
+export {
+	JOIN_DIRECTIONS,
+	type JoinDependencyDeclaration,
+	type JoinDependencyManifestEntry,
+	type JoinDirection,
+	type ResolvableByDeclaration,
+	type ResolvableByManifestEntry,
+	type ResolvedJoinDependency,
+} from "./joins.js";
 export { $lib } from "./lib.js";
+
+export function $onValidate(program: Program): void {
+	validateJoinDeclarations(program);
+}

--- a/src/joins.test.ts
+++ b/src/joins.test.ts
@@ -1,43 +1,43 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
+import type { Diagnostic } from "@typespec/compiler";
 import { createTestHost, createTestWrapper } from "@typespec/compiler/testing";
+import { HttpTestLibrary } from "@typespec/http/testing";
 import { getJoinDependencies, getResolvableBy } from "./decorators.js";
 import {
 	resolveJoinDependencies,
 	toJoinDependencyManifestEntry,
 	toResolvableByManifestEntry,
 } from "./joins.js";
+import { resolveProjectionModel } from "./projection.js";
 import { OpenSearchEmitterTestLibrary } from "./testing/index.js";
 
 async function createRunner() {
 	const host = await createTestHost({
-		libraries: [OpenSearchEmitterTestLibrary],
+		libraries: [HttpTestLibrary, OpenSearchEmitterTestLibrary],
 	});
 
 	return createTestWrapper(host, {
-		autoImports: ["@kattebak/typespec-opensearch-emitter"],
-		autoUsings: ["Kattebak.OpenSearch"],
+		autoImports: ["@typespec/http", "@kattebak/typespec-opensearch-emitter"],
+		autoUsings: ["TypeSpec.Http", "Kattebak.OpenSearch"],
 	});
 }
 
-function hasDiagnosticCode(
-	diagnosticCodes: readonly string[],
-	code: string,
-): boolean {
-	return diagnosticCodes.some((x) => x.endsWith(`/${code}`) || x === code);
+function shortCode(diagnostic: Diagnostic): string {
+	return diagnostic.code.replace(/^.*\//, "");
 }
 
-function diagnosticsWithCode(
-	diagnostics: readonly { code: string; target: unknown }[],
+function withCode(
+	diagnostics: readonly Diagnostic[],
 	code: string,
-) {
-	return diagnostics.filter((x) => hasDiagnosticCode([x.code], code));
+): Diagnostic[] {
+	return diagnostics.filter((x) => shortCode(x) === code);
 }
 
 // The pet care view from issue #194: Waffles the beagle has a passport,
 // Nugget the stray does not. Both joins are left joins.
-const PET_CARE = `
+const ENTITIES = `
 	model Pet {
 		@searchable @keyword petId: string;
 		@searchable @keyword name: string;
@@ -62,6 +62,22 @@ const PET_CARE = `
 
 	model PetPassportSearchDoc is SearchProjection<PetPassport> {}
 	model OwnershipRecordSearchDoc is SearchProjection<OwnershipRecord> {}
+`;
+
+const READS = `
+	@route("/pet-passports")
+	namespace PetPassports {
+		@restResolver @get op getPetPassport(@path passportId: string): PetPassport;
+	}
+
+	@route("/ownership-records")
+	namespace OwnershipRecords {
+		@restResolver @get op listOwnershipRecords(@query petId: string): OwnershipRecord[];
+	}
+`;
+
+const PET_CARE = `
+	${ENTITIES}
 
 	@searchProjection
 	@indexName("pet_care_v1")
@@ -71,6 +87,8 @@ const PET_CARE = `
 		passport?: PetPassportSearchDoc;
 		@nested ownershipHistory: OwnershipRecordSearchDoc[];
 	}
+
+	${READS}
 `;
 
 describe("@resolvableBy / @dependsOn", () => {
@@ -79,9 +97,13 @@ describe("@resolvableBy / @dependsOn", () => {
 		const diagnostics = await runner.diagnose(PET_CARE);
 
 		assert.deepEqual(
-			diagnostics.map((x) => x.code),
+			diagnostics.filter((x) => x.severity === "error"),
 			[],
 		);
+		assert.deepEqual(diagnostics.map(shortCode), [
+			"join-field-not-composed",
+			"join-field-not-composed",
+		]);
 
 		const globals = runner.program.getGlobalNamespaceType();
 		const passport = globals.models.get("PetPassport");
@@ -100,10 +122,12 @@ describe("@resolvableBy / @dependsOn", () => {
 		assert.equal(ownershipResolvable?.key, ownership.properties.get("petId"));
 		assert.equal(ownershipResolvable?.index, "byPetId");
 
-		const dependencies = getJoinDependencies(runner.program, petCare);
-		assert.equal(dependencies.length, 2);
 		assert.deepEqual(
-			dependencies.map((x) => [x.entity.name, x.direction, x.joinKey.name]),
+			getJoinDependencies(runner.program, petCare).map((x) => [
+				x.entity.name,
+				x.direction,
+				x.joinKey.name,
+			]),
 			[
 				["PetPassport", "lookup", "passportId"],
 				["OwnershipRecord", "inbound", "petId"],
@@ -111,20 +135,7 @@ describe("@resolvableBy / @dependsOn", () => {
 		);
 	});
 
-	it("does not warn that a join-provided field is absent from the source model", async () => {
-		const runner = await createRunner();
-		const diagnostics = await runner.diagnose(PET_CARE);
-
-		assert.equal(
-			hasDiagnosticCode(
-				diagnostics.map((x) => x.code),
-				"projection-field-not-on-source",
-			),
-			false,
-		);
-	});
-
-	it("resolves dependencies into manifest entries, carrying the declared index", async () => {
+	it("binds each declaration to the field it fills, carrying the index on the discovery join only", async () => {
 		const runner = await createRunner();
 		await runner.diagnose(PET_CARE);
 
@@ -133,19 +144,26 @@ describe("@resolvableBy / @dependsOn", () => {
 			.models.get("PetCareSearchDoc");
 		assert.ok(petCare);
 
-		const dependencies = resolveJoinDependencies(runner.program, petCare).map(
-			toJoinDependencyManifestEntry,
+		assert.deepEqual(
+			resolveJoinDependencies(runner.program, petCare).map(
+				toJoinDependencyManifestEntry,
+			),
+			[
+				{
+					entity: "PetPassport",
+					direction: "lookup",
+					joinKey: "passportId",
+					field: "passport",
+				},
+				{
+					entity: "OwnershipRecord",
+					direction: "inbound",
+					joinKey: "petId",
+					field: "ownershipHistory",
+					index: "byPetId",
+				},
+			],
 		);
-
-		assert.deepEqual(dependencies, [
-			{ entity: "PetPassport", direction: "lookup", joinKey: "passportId" },
-			{
-				entity: "OwnershipRecord",
-				direction: "inbound",
-				joinKey: "petId",
-				index: "byPetId",
-			},
-		]);
 	});
 
 	it("resolves a resolvableBy manifest entry per entity", async () => {
@@ -170,6 +188,52 @@ describe("@resolvableBy / @dependsOn", () => {
 		assert.equal(toResolvableByManifestEntry(runner.program, pet), undefined);
 	});
 
+	it("accepts a join key inherited from a base model", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+			model Chipped {
+				passportId: string;
+			}
+
+			model Pet {
+				@searchable @keyword petId: string;
+			}
+
+			model Registered {
+				passportId: string;
+			}
+
+			@resolvableBy(PetPassport.passportId)
+			model PetPassport extends Registered {
+				@searchable @keyword microchipId: string;
+			}
+
+			model PetPassportSearchDoc is SearchProjection<PetPassport> {}
+
+			@searchProjection
+			@indexName("pet_care_v1")
+			@dependsOn(PetPassport, "lookup", PetCareSource.passportId)
+			model PetCareSearchDoc is SearchProjection<PetCareSource> {
+				passport?: PetPassportSearchDoc;
+			}
+
+			model PetCareSource extends Chipped {
+				@searchable @keyword petId: string;
+			}
+
+			@route("/pet-passports")
+			namespace PetPassports {
+				@restResolver @get op getPetPassport(@path passportId: string): PetPassport;
+			}
+		`);
+
+		assert.deepEqual(withCode(diagnostics, "unknown-join-key"), []);
+		assert.deepEqual(
+			diagnostics.filter((x) => x.severity === "error"),
+			[],
+		);
+	});
+
 	it("reports unknown-join-key when @resolvableBy names a key on another model", async () => {
 		const runner = await createRunner();
 		const diagnostics = await runner.diagnose(`
@@ -184,7 +248,7 @@ describe("@resolvableBy / @dependsOn", () => {
 			}
 		`);
 
-		const reported = diagnosticsWithCode(diagnostics, "unknown-join-key");
+		const reported = withCode(diagnostics, "unknown-join-key");
 		assert.equal(reported.length, 1);
 
 		const pet = runner.program.getGlobalNamespaceType().models.get("Pet");
@@ -194,23 +258,19 @@ describe("@resolvableBy / @dependsOn", () => {
 	it("reports unknown-join-key when a lookup join key is not on the source model", async () => {
 		const runner = await createRunner();
 		const diagnostics = await runner.diagnose(`
-			model Pet {
-				@searchable @keyword petId: string;
-			}
-
-			@resolvableBy(PetPassport.passportId)
-			model PetPassport {
-				passportId: string;
-				@searchable @keyword microchipId: string;
-			}
+			${ENTITIES}
 
 			@searchProjection
 			@indexName("pet_care_v1")
 			@dependsOn(PetPassport, "lookup", PetPassport.passportId)
-			model PetCareSearchDoc is SearchProjection<Pet> {}
+			model PetCareSearchDoc is SearchProjection<Pet> {
+				passport?: PetPassportSearchDoc;
+			}
+
+			${READS}
 		`);
 
-		const reported = diagnosticsWithCode(diagnostics, "unknown-join-key");
+		const reported = withCode(diagnostics, "unknown-join-key");
 		assert.equal(reported.length, 1);
 
 		const passport = runner.program
@@ -232,13 +292,17 @@ describe("@resolvableBy / @dependsOn", () => {
 				@searchable @keyword ownerName: string;
 			}
 
+			model OwnershipRecordSearchDoc is SearchProjection<OwnershipRecord> {}
+
 			@searchProjection
 			@indexName("pet_care_v1")
 			@dependsOn(OwnershipRecord, "inbound", OwnershipRecord.petId)
-			model PetCareSearchDoc is SearchProjection<Pet> {}
+			model PetCareSearchDoc is SearchProjection<Pet> {
+				@nested ownershipHistory: OwnershipRecordSearchDoc[];
+			}
 		`);
 
-		const reported = diagnosticsWithCode(diagnostics, "join-index-required");
+		const reported = withCode(diagnostics, "join-index-required");
 		assert.equal(reported.length, 1);
 
 		const ownership = runner.program
@@ -260,16 +324,17 @@ describe("@resolvableBy / @dependsOn", () => {
 				@searchable @keyword microchipId: string;
 			}
 
+			model PetPassportSearchDoc is SearchProjection<PetPassport> {}
+
 			@searchProjection
 			@indexName("pet_care_v1")
 			@dependsOn(PetPassport, "lookup", Pet.passportId)
-			model PetCareSearchDoc is SearchProjection<Pet> {}
+			model PetCareSearchDoc is SearchProjection<Pet> {
+				passport?: PetPassportSearchDoc;
+			}
 		`);
 
-		const reported = diagnosticsWithCode(
-			diagnostics,
-			"undeclared-join-resolution",
-		);
+		const reported = withCode(diagnostics, "undeclared-join-resolution");
 		assert.equal(reported.length, 1);
 
 		const passport = runner.program
@@ -281,24 +346,19 @@ describe("@resolvableBy / @dependsOn", () => {
 	it("reports invalid-join-direction for a direction that is neither lookup nor inbound", async () => {
 		const runner = await createRunner();
 		const diagnostics = await runner.diagnose(`
-			model Pet {
-				@searchable @keyword petId: string;
-				@searchable @keyword passportId: string;
-			}
-
-			@resolvableBy(PetPassport.passportId)
-			model PetPassport {
-				passportId: string;
-				@searchable @keyword microchipId: string;
-			}
+			${ENTITIES}
 
 			@searchProjection
 			@indexName("pet_care_v1")
 			@dependsOn(PetPassport, "outbound", Pet.passportId)
-			model PetCareSearchDoc is SearchProjection<Pet> {}
+			model PetCareSearchDoc is SearchProjection<Pet> {
+				passport?: PetPassportSearchDoc;
+			}
+
+			${READS}
 		`);
 
-		const reported = diagnosticsWithCode(diagnostics, "invalid-join-direction");
+		const reported = withCode(diagnostics, "invalid-join-direction");
 		assert.equal(reported.length, 1);
 
 		const petCare = runner.program
@@ -307,23 +367,175 @@ describe("@resolvableBy / @dependsOn", () => {
 		assert.equal(reported[0].target, petCare);
 	});
 
-	it("drops an unresolvable declaration rather than emitting a half-formed dependency", async () => {
+	it("reports join-requires-projection when @dependsOn sits on a plain model", async () => {
 		const runner = await createRunner();
-		await runner.diagnose(`
-			model Pet {
-				@searchable @keyword petId: string;
-				@searchable @keyword passportId: string;
+		const diagnostics = await runner.diagnose(`
+			${ENTITIES}
+
+			@dependsOn(PetPassport, "lookup", Pet.passportId)
+			model PetCareView {
+				passport?: PetPassportSearchDoc;
 			}
 
-			model PetPassport {
-				passportId: string;
-				@searchable @keyword microchipId: string;
-			}
+			${READS}
+		`);
+
+		const reported = withCode(diagnostics, "join-requires-projection");
+		assert.equal(reported.length, 1);
+
+		const view = runner.program
+			.getGlobalNamespaceType()
+			.models.get("PetCareView");
+		assert.equal(reported[0].target, view);
+	});
+
+	it("reports join-field-missing when nothing on the projection receives the join", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+			${ENTITIES}
 
 			@searchProjection
 			@indexName("pet_care_v1")
 			@dependsOn(PetPassport, "lookup", Pet.passportId)
 			model PetCareSearchDoc is SearchProjection<Pet> {}
+
+			${READS}
+		`);
+
+		const reported = withCode(diagnostics, "join-field-missing");
+		assert.equal(reported.length, 1);
+
+		const petCare = runner.program
+			.getGlobalNamespaceType()
+			.models.get("PetCareSearchDoc");
+		assert.equal(reported[0].target, petCare);
+	});
+
+	it("reports join-field-ambiguous when two fields could receive the same join", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+			${ENTITIES}
+
+			@searchProjection
+			@indexName("pet_care_v1")
+			@dependsOn(PetPassport, "lookup", Pet.passportId)
+			model PetCareSearchDoc is SearchProjection<Pet> {
+				passport?: PetPassportSearchDoc;
+				passprot?: PetPassportSearchDoc;
+			}
+
+			${READS}
+		`);
+
+		const reported = withCode(diagnostics, "join-field-ambiguous");
+		assert.equal(reported.length, 1);
+		assert.match(reported[0].message, /passport, passprot/);
+
+		const petCare = runner.program
+			.getGlobalNamespaceType()
+			.models.get("PetCareSearchDoc");
+		assert.equal(reported[0].target, petCare);
+	});
+
+	it("reports join-field-arity when a discovery join fills a single-valued field", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+			${ENTITIES}
+
+			@searchProjection
+			@indexName("pet_care_v1")
+			@dependsOn(OwnershipRecord, "inbound", OwnershipRecord.petId)
+			model PetCareSearchDoc is SearchProjection<Pet> {
+				ownershipHistory?: OwnershipRecordSearchDoc;
+			}
+
+			${READS}
+		`);
+
+		const reported = withCode(diagnostics, "join-field-arity");
+		assert.equal(reported.length, 1);
+
+		const petCare = runner.program
+			.getGlobalNamespaceType()
+			.models.get("PetCareSearchDoc");
+		assert.equal(
+			reported[0].target,
+			petCare?.properties.get("ownershipHistory"),
+		);
+	});
+
+	it("reports join-field-arity when a lookup fills an array field", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+			${ENTITIES}
+
+			@searchProjection
+			@indexName("pet_care_v1")
+			@dependsOn(PetPassport, "lookup", Pet.passportId)
+			model PetCareSearchDoc is SearchProjection<Pet> {
+				@nested passport: PetPassportSearchDoc[];
+			}
+
+			${READS}
+		`);
+
+		assert.equal(withCode(diagnostics, "join-field-arity").length, 1);
+	});
+
+	it("reports join-read-operation-missing when no read is keyed by the declared key", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+			@resolvableBy(PetPassport.passportId)
+			model PetPassport {
+				passportId: string;
+				@searchable @keyword microchipId: string;
+			}
+
+			@route("/pet-passports")
+			namespace PetPassports {
+				@restResolver @get op listPetPassports(): PetPassport[];
+			}
+		`);
+
+		const reported = withCode(diagnostics, "join-read-operation-missing");
+		assert.equal(reported.length, 1);
+
+		const passport = runner.program
+			.getGlobalNamespaceType()
+			.models.get("PetPassport");
+		assert.equal(reported[0].target, passport);
+	});
+
+	it("reports join-field-not-composed against the field, once per bound join", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(PET_CARE);
+
+		const reported = withCode(diagnostics, "join-field-not-composed");
+		assert.equal(reported.length, 2);
+
+		const petCare = runner.program
+			.getGlobalNamespaceType()
+			.models.get("PetCareSearchDoc");
+		assert.deepEqual(
+			reported.map((x) => x.target),
+			[
+				petCare?.properties.get("passport"),
+				petCare?.properties.get("ownershipHistory"),
+			],
+		);
+	});
+
+	it("drops an unresolvable declaration rather than emitting a half-formed dependency", async () => {
+		const runner = await createRunner();
+		await runner.diagnose(`
+			${ENTITIES}
+
+			@searchProjection
+			@indexName("pet_care_v1")
+			@dependsOn(PetPassport, "lookup", Pet.passportId)
+			model PetCareSearchDoc is SearchProjection<Pet> {}
+
+			${READS}
 		`);
 
 		const petCare = runner.program
@@ -332,5 +544,60 @@ describe("@resolvableBy / @dependsOn", () => {
 		assert.ok(petCare);
 
 		assert.deepEqual(resolveJoinDependencies(runner.program, petCare), []);
+	});
+});
+
+describe("projection resolution of join fields", () => {
+	it("does not report a join field as absent from the source model", async () => {
+		const runner = await createRunner();
+		await runner.diagnose(PET_CARE);
+
+		const petCare = runner.program
+			.getGlobalNamespaceType()
+			.models.get("PetCareSearchDoc");
+		assert.ok(petCare);
+
+		const before = runner.program.diagnostics.length;
+		resolveProjectionModel(runner.program, petCare);
+
+		assert.deepEqual(
+			withCode(
+				runner.program.diagnostics.slice(before),
+				"projection-field-not-on-source",
+			),
+			[],
+		);
+	});
+
+	it("still reports a field that no join accounts for", async () => {
+		const runner = await createRunner();
+		await runner.diagnose(`
+			${ENTITIES}
+
+			@searchProjection
+			@indexName("pet_care_v1")
+			@dependsOn(PetPassport, "lookup", Pet.passportId)
+			model PetCareSearchDoc is SearchProjection<Pet> {
+				passport?: PetPassportSearchDoc;
+				kennelName?: string;
+			}
+
+			${READS}
+		`);
+
+		const petCare = runner.program
+			.getGlobalNamespaceType()
+			.models.get("PetCareSearchDoc");
+		assert.ok(petCare);
+
+		const before = runner.program.diagnostics.length;
+		resolveProjectionModel(runner.program, petCare);
+
+		const reported = withCode(
+			runner.program.diagnostics.slice(before),
+			"projection-field-not-on-source",
+		);
+		assert.equal(reported.length, 1);
+		assert.equal(reported[0].target, petCare.properties.get("kennelName"));
 	});
 });

--- a/src/joins.test.ts
+++ b/src/joins.test.ts
@@ -1,0 +1,336 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { createTestHost, createTestWrapper } from "@typespec/compiler/testing";
+import { getJoinDependencies, getResolvableBy } from "./decorators.js";
+import {
+	resolveJoinDependencies,
+	toJoinDependencyManifestEntry,
+	toResolvableByManifestEntry,
+} from "./joins.js";
+import { OpenSearchEmitterTestLibrary } from "./testing/index.js";
+
+async function createRunner() {
+	const host = await createTestHost({
+		libraries: [OpenSearchEmitterTestLibrary],
+	});
+
+	return createTestWrapper(host, {
+		autoImports: ["@kattebak/typespec-opensearch-emitter"],
+		autoUsings: ["Kattebak.OpenSearch"],
+	});
+}
+
+function hasDiagnosticCode(
+	diagnosticCodes: readonly string[],
+	code: string,
+): boolean {
+	return diagnosticCodes.some((x) => x.endsWith(`/${code}`) || x === code);
+}
+
+function diagnosticsWithCode(
+	diagnostics: readonly { code: string; target: unknown }[],
+	code: string,
+) {
+	return diagnostics.filter((x) => hasDiagnosticCode([x.code], code));
+}
+
+// The pet care view from issue #194: Waffles the beagle has a passport,
+// Nugget the stray does not. Both joins are left joins.
+const PET_CARE = `
+	model Pet {
+		@searchable @keyword petId: string;
+		@searchable @keyword name: string;
+		@searchable @keyword passportId: string;
+	}
+
+	@resolvableBy(PetPassport.passportId)
+	model PetPassport {
+		passportId: string;
+		@searchable @keyword microchipId: string;
+		@searchable @keyword issuedCountry: string;
+		@searchable @keyword vaccinations: string[];
+	}
+
+	@resolvableBy(OwnershipRecord.petId, "byPetId")
+	model OwnershipRecord {
+		ownershipRecordId: string;
+		petId: string;
+		@searchable @keyword ownerName: string;
+		@searchable @filterable("range") transferredAt: utcDateTime;
+	}
+
+	model PetPassportSearchDoc is SearchProjection<PetPassport> {}
+	model OwnershipRecordSearchDoc is SearchProjection<OwnershipRecord> {}
+
+	@searchProjection
+	@indexName("pet_care_v1")
+	@dependsOn(PetPassport, "lookup", Pet.passportId)
+	@dependsOn(OwnershipRecord, "inbound", OwnershipRecord.petId)
+	model PetCareSearchDoc is SearchProjection<Pet> {
+		passport?: PetPassportSearchDoc;
+		@nested ownershipHistory: OwnershipRecordSearchDoc[];
+	}
+`;
+
+describe("@resolvableBy / @dependsOn", () => {
+	it("compiles the pet care view and lands both declarations in the state map", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(PET_CARE);
+
+		assert.deepEqual(
+			diagnostics.map((x) => x.code),
+			[],
+		);
+
+		const globals = runner.program.getGlobalNamespaceType();
+		const passport = globals.models.get("PetPassport");
+		const ownership = globals.models.get("OwnershipRecord");
+		const petCare = globals.models.get("PetCareSearchDoc");
+		assert.ok(passport && ownership && petCare);
+
+		const passportResolvable = getResolvableBy(runner.program, passport);
+		assert.equal(
+			passportResolvable?.key,
+			passport.properties.get("passportId"),
+		);
+		assert.equal(passportResolvable?.index, undefined);
+
+		const ownershipResolvable = getResolvableBy(runner.program, ownership);
+		assert.equal(ownershipResolvable?.key, ownership.properties.get("petId"));
+		assert.equal(ownershipResolvable?.index, "byPetId");
+
+		const dependencies = getJoinDependencies(runner.program, petCare);
+		assert.equal(dependencies.length, 2);
+		assert.deepEqual(
+			dependencies.map((x) => [x.entity.name, x.direction, x.joinKey.name]),
+			[
+				["PetPassport", "lookup", "passportId"],
+				["OwnershipRecord", "inbound", "petId"],
+			],
+		);
+	});
+
+	it("does not warn that a join-provided field is absent from the source model", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(PET_CARE);
+
+		assert.equal(
+			hasDiagnosticCode(
+				diagnostics.map((x) => x.code),
+				"projection-field-not-on-source",
+			),
+			false,
+		);
+	});
+
+	it("resolves dependencies into manifest entries, carrying the declared index", async () => {
+		const runner = await createRunner();
+		await runner.diagnose(PET_CARE);
+
+		const petCare = runner.program
+			.getGlobalNamespaceType()
+			.models.get("PetCareSearchDoc");
+		assert.ok(petCare);
+
+		const dependencies = resolveJoinDependencies(runner.program, petCare).map(
+			toJoinDependencyManifestEntry,
+		);
+
+		assert.deepEqual(dependencies, [
+			{ entity: "PetPassport", direction: "lookup", joinKey: "passportId" },
+			{
+				entity: "OwnershipRecord",
+				direction: "inbound",
+				joinKey: "petId",
+				index: "byPetId",
+			},
+		]);
+	});
+
+	it("resolves a resolvableBy manifest entry per entity", async () => {
+		const runner = await createRunner();
+		await runner.diagnose(PET_CARE);
+
+		const globals = runner.program.getGlobalNamespaceType();
+		const passport = globals.models.get("PetPassport");
+		const ownership = globals.models.get("OwnershipRecord");
+		const pet = globals.models.get("Pet");
+		assert.ok(passport && ownership && pet);
+
+		assert.deepEqual(toResolvableByManifestEntry(runner.program, passport), {
+			entity: "PetPassport",
+			key: "passportId",
+		});
+		assert.deepEqual(toResolvableByManifestEntry(runner.program, ownership), {
+			entity: "OwnershipRecord",
+			key: "petId",
+			index: "byPetId",
+		});
+		assert.equal(toResolvableByManifestEntry(runner.program, pet), undefined);
+	});
+
+	it("reports unknown-join-key when @resolvableBy names a key on another model", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+			model Pet {
+				petId: string;
+			}
+
+			@resolvableBy(Pet.petId)
+			model PetPassport {
+				passportId: string;
+				@searchable @keyword microchipId: string;
+			}
+		`);
+
+		const reported = diagnosticsWithCode(diagnostics, "unknown-join-key");
+		assert.equal(reported.length, 1);
+
+		const pet = runner.program.getGlobalNamespaceType().models.get("Pet");
+		assert.equal(reported[0].target, pet?.properties.get("petId"));
+	});
+
+	it("reports unknown-join-key when a lookup join key is not on the source model", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+			model Pet {
+				@searchable @keyword petId: string;
+			}
+
+			@resolvableBy(PetPassport.passportId)
+			model PetPassport {
+				passportId: string;
+				@searchable @keyword microchipId: string;
+			}
+
+			@searchProjection
+			@indexName("pet_care_v1")
+			@dependsOn(PetPassport, "lookup", PetPassport.passportId)
+			model PetCareSearchDoc is SearchProjection<Pet> {}
+		`);
+
+		const reported = diagnosticsWithCode(diagnostics, "unknown-join-key");
+		assert.equal(reported.length, 1);
+
+		const passport = runner.program
+			.getGlobalNamespaceType()
+			.models.get("PetPassport");
+		assert.equal(reported[0].target, passport?.properties.get("passportId"));
+	});
+
+	it("reports join-index-required for an inbound join whose entity declares no index", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+			model Pet {
+				@searchable @keyword petId: string;
+			}
+
+			@resolvableBy(OwnershipRecord.petId)
+			model OwnershipRecord {
+				petId: string;
+				@searchable @keyword ownerName: string;
+			}
+
+			@searchProjection
+			@indexName("pet_care_v1")
+			@dependsOn(OwnershipRecord, "inbound", OwnershipRecord.petId)
+			model PetCareSearchDoc is SearchProjection<Pet> {}
+		`);
+
+		const reported = diagnosticsWithCode(diagnostics, "join-index-required");
+		assert.equal(reported.length, 1);
+
+		const ownership = runner.program
+			.getGlobalNamespaceType()
+			.models.get("OwnershipRecord");
+		assert.equal(reported[0].target, ownership);
+	});
+
+	it("reports undeclared-join-resolution when the joined entity carries no @resolvableBy", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+			model Pet {
+				@searchable @keyword petId: string;
+				@searchable @keyword passportId: string;
+			}
+
+			model PetPassport {
+				passportId: string;
+				@searchable @keyword microchipId: string;
+			}
+
+			@searchProjection
+			@indexName("pet_care_v1")
+			@dependsOn(PetPassport, "lookup", Pet.passportId)
+			model PetCareSearchDoc is SearchProjection<Pet> {}
+		`);
+
+		const reported = diagnosticsWithCode(
+			diagnostics,
+			"undeclared-join-resolution",
+		);
+		assert.equal(reported.length, 1);
+
+		const passport = runner.program
+			.getGlobalNamespaceType()
+			.models.get("PetPassport");
+		assert.equal(reported[0].target, passport);
+	});
+
+	it("reports invalid-join-direction for a direction that is neither lookup nor inbound", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+			model Pet {
+				@searchable @keyword petId: string;
+				@searchable @keyword passportId: string;
+			}
+
+			@resolvableBy(PetPassport.passportId)
+			model PetPassport {
+				passportId: string;
+				@searchable @keyword microchipId: string;
+			}
+
+			@searchProjection
+			@indexName("pet_care_v1")
+			@dependsOn(PetPassport, "outbound", Pet.passportId)
+			model PetCareSearchDoc is SearchProjection<Pet> {}
+		`);
+
+		const reported = diagnosticsWithCode(diagnostics, "invalid-join-direction");
+		assert.equal(reported.length, 1);
+
+		const petCare = runner.program
+			.getGlobalNamespaceType()
+			.models.get("PetCareSearchDoc");
+		assert.equal(reported[0].target, petCare);
+	});
+
+	it("drops an unresolvable declaration rather than emitting a half-formed dependency", async () => {
+		const runner = await createRunner();
+		await runner.diagnose(`
+			model Pet {
+				@searchable @keyword petId: string;
+				@searchable @keyword passportId: string;
+			}
+
+			model PetPassport {
+				passportId: string;
+				@searchable @keyword microchipId: string;
+			}
+
+			@searchProjection
+			@indexName("pet_care_v1")
+			@dependsOn(PetPassport, "lookup", Pet.passportId)
+			model PetCareSearchDoc is SearchProjection<Pet> {}
+		`);
+
+		const petCare = runner.program
+			.getGlobalNamespaceType()
+			.models.get("PetCareSearchDoc");
+		assert.ok(petCare);
+
+		assert.deepEqual(resolveJoinDependencies(runner.program, petCare), []);
+	});
+});

--- a/src/joins.ts
+++ b/src/joins.ts
@@ -1,0 +1,205 @@
+import type {
+	Model,
+	ModelProperty,
+	Namespace,
+	Program,
+} from "@typespec/compiler";
+import { getJoinDependencies, getResolvableBy } from "./decorators.js";
+import { reportDiagnostic } from "./lib.js";
+import { getProjectionSourceModel } from "./projection.js";
+
+export const JOIN_DIRECTIONS = ["lookup", "inbound"] as const;
+export type JoinDirection = (typeof JOIN_DIRECTIONS)[number];
+
+export function isJoinDirection(value: string): value is JoinDirection {
+	return (JOIN_DIRECTIONS as readonly string[]).includes(value);
+}
+
+export interface ResolvableByDeclaration {
+	key: ModelProperty;
+	index?: string;
+}
+
+export interface JoinDependencyDeclaration {
+	entity: Model;
+	direction: string;
+	joinKey: ModelProperty;
+}
+
+export interface ResolvedJoinDependency {
+	entity: Model;
+	direction: JoinDirection;
+	joinKey: ModelProperty;
+	index?: string;
+}
+
+export interface ResolvableByManifestEntry {
+	entity: string;
+	key: string;
+	index?: string;
+}
+
+export interface JoinDependencyManifestEntry {
+	entity: string;
+	direction: JoinDirection;
+	joinKey: string;
+	index?: string;
+}
+
+/**
+ * The model a join key must belong to: its own model for `@resolvableBy`, the
+ * projection's source model for a `lookup` (the driving row carries the value
+ * the joined row is fetched by), and the joined entity for an `inbound` (the
+ * joined row carries the reference back).
+ */
+function expectedJoinKeyOwner(
+	declaration: JoinDependencyDeclaration,
+	sourceModel: Model,
+): Model {
+	return declaration.direction === "inbound" ? declaration.entity : sourceModel;
+}
+
+export function resolveJoinDependencies(
+	program: Program,
+	projectionModel: Model,
+): ResolvedJoinDependency[] {
+	const resolved: ResolvedJoinDependency[] = [];
+	for (const declaration of getJoinDependencies(program, projectionModel)) {
+		if (!isJoinDirection(declaration.direction)) {
+			continue;
+		}
+		const resolvable = getResolvableBy(program, declaration.entity);
+		if (!resolvable) {
+			continue;
+		}
+		resolved.push({
+			entity: declaration.entity,
+			direction: declaration.direction,
+			joinKey: declaration.joinKey,
+			...(resolvable.index ? { index: resolvable.index } : {}),
+		});
+	}
+	return resolved;
+}
+
+export function toJoinDependencyManifestEntry(
+	dependency: ResolvedJoinDependency,
+): JoinDependencyManifestEntry {
+	return {
+		entity: dependency.entity.name,
+		direction: dependency.direction,
+		joinKey: dependency.joinKey.name,
+		...(dependency.index ? { index: dependency.index } : {}),
+	};
+}
+
+export function toResolvableByManifestEntry(
+	program: Program,
+	entity: Model,
+): ResolvableByManifestEntry | undefined {
+	const resolvable = getResolvableBy(program, entity);
+	if (!resolvable) {
+		return undefined;
+	}
+	return {
+		entity: entity.name,
+		key: resolvable.key.name,
+		...(resolvable.index ? { index: resolvable.index } : {}),
+	};
+}
+
+export function validateJoinDeclarations(program: Program): void {
+	for (const model of collectModels(program)) {
+		validateResolvableBy(program, model);
+		validateDependencies(program, model);
+	}
+}
+
+function validateResolvableBy(program: Program, model: Model): void {
+	const resolvable = getResolvableBy(program, model);
+	if (!resolvable) {
+		return;
+	}
+	if (resolvable.key.model !== model) {
+		reportDiagnostic(program, {
+			code: "unknown-join-key",
+			format: { key: resolvable.key.name, model: model.name },
+			target: resolvable.key,
+		});
+	}
+}
+
+function validateDependencies(program: Program, projectionModel: Model): void {
+	const declarations = getJoinDependencies(program, projectionModel);
+	if (declarations.length === 0) {
+		return;
+	}
+	const sourceModel = getProjectionSourceModel(program, projectionModel);
+
+	for (const declaration of declarations) {
+		if (!isJoinDirection(declaration.direction)) {
+			reportDiagnostic(program, {
+				code: "invalid-join-direction",
+				format: { direction: declaration.direction },
+				target: projectionModel,
+			});
+			continue;
+		}
+
+		const resolvable = getResolvableBy(program, declaration.entity);
+		if (!resolvable) {
+			reportDiagnostic(program, {
+				code: "undeclared-join-resolution",
+				format: { entity: declaration.entity.name },
+				target: declaration.entity,
+			});
+			continue;
+		}
+
+		if (declaration.direction === "inbound" && !resolvable.index) {
+			reportDiagnostic(program, {
+				code: "join-index-required",
+				format: {
+					entity: declaration.entity.name,
+					key: resolvable.key.name,
+					suggestedIndex: `by${capitalize(resolvable.key.name)}`,
+				},
+				target: declaration.entity,
+			});
+			continue;
+		}
+
+		if (!sourceModel) {
+			continue;
+		}
+		const owner = expectedJoinKeyOwner(declaration, sourceModel);
+		if (declaration.joinKey.model !== owner) {
+			reportDiagnostic(program, {
+				code: "unknown-join-key",
+				format: { key: declaration.joinKey.name, model: owner.name },
+				target: declaration.joinKey,
+			});
+		}
+	}
+}
+
+function collectModels(program: Program): Model[] {
+	const models: Model[] = [];
+	const walk = (namespace: Namespace) => {
+		models.push(...namespace.models.values());
+		for (const child of namespace.namespaces.values()) {
+			walk(child);
+		}
+	};
+	walk(program.getGlobalNamespaceType());
+	return models;
+}
+
+function capitalize(value: string): string {
+	return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+export const __test = {
+	capitalize,
+	expectedJoinKeyOwner,
+};

--- a/src/joins.ts
+++ b/src/joins.ts
@@ -2,9 +2,16 @@ import type {
 	Model,
 	ModelProperty,
 	Namespace,
+	Operation,
 	Program,
+	Type,
 } from "@typespec/compiler";
-import { getJoinDependencies, getResolvableBy } from "./decorators.js";
+import { getHttpOperation } from "@typespec/http";
+import {
+	getJoinDependencies,
+	getResolvableBy,
+	isRestResolver,
+} from "./decorators.js";
 import { reportDiagnostic } from "./lib.js";
 import { getProjectionSourceModel } from "./projection.js";
 
@@ -30,6 +37,12 @@ export interface ResolvedJoinDependency {
 	entity: Model;
 	direction: JoinDirection;
 	joinKey: ModelProperty;
+	/**
+	 * The projection property the joined value lands in. Its declared type is
+	 * what the join resolver returns.
+	 */
+	field: ModelProperty;
+	/** Carried from the entity's `@resolvableBy`; an inbound join only. */
 	index?: string;
 }
 
@@ -43,6 +56,7 @@ export interface JoinDependencyManifestEntry {
 	entity: string;
 	direction: JoinDirection;
 	joinKey: string;
+	field: string;
 	index?: string;
 }
 
@@ -59,6 +73,57 @@ function expectedJoinKeyOwner(
 	return declaration.direction === "inbound" ? declaration.entity : sourceModel;
 }
 
+/**
+ * True when the property is declared on the model or on anything it extends.
+ * An inherited property keeps the base model in `.model`, so identity alone
+ * rejects a key a derived model legitimately owns.
+ */
+export function ownsProperty(model: Model, property: ModelProperty): boolean {
+	for (
+		let current: Model | undefined = model;
+		current;
+		current = current.baseModel
+	) {
+		if (property.model === current) {
+			return true;
+		}
+	}
+	return false;
+}
+
+export function unwrapArrayElement(type: Type): Type | undefined {
+	if (type.kind === "Model" && type.name === "Array") {
+		return type.indexer?.value;
+	}
+	return undefined;
+}
+
+/**
+ * True when the type names the joined entity, either directly or through a
+ * `SearchProjection<Entity>` document.
+ */
+function receivesEntity(program: Program, type: Type, entity: Model): boolean {
+	if (type.kind !== "Model") {
+		return false;
+	}
+	return type === entity || getProjectionSourceModel(program, type) === entity;
+}
+
+/**
+ * The projection properties a declaration could fill. A declaration fills
+ * exactly one; anything else is reported rather than guessed at.
+ */
+export function candidateJoinFields(
+	program: Program,
+	projectionModel: Model,
+	entity: Model,
+): ModelProperty[] {
+	return [...projectionModel.properties.values()].filter((property) => {
+		const element = unwrapArrayElement(property.type);
+		return receivesEntity(program, element ?? property.type, entity);
+	});
+}
+
 export function resolveJoinDependencies(
 	program: Program,
 	projectionModel: Model,
@@ -72,14 +137,39 @@ export function resolveJoinDependencies(
 		if (!resolvable) {
 			continue;
 		}
+		const candidates = candidateJoinFields(
+			program,
+			projectionModel,
+			declaration.entity,
+		);
+		if (candidates.length !== 1) {
+			continue;
+		}
+		const field = candidates[0];
+		if (!hasExpectedArity(declaration.direction, field)) {
+			continue;
+		}
 		resolved.push({
 			entity: declaration.entity,
 			direction: declaration.direction,
 			joinKey: declaration.joinKey,
-			...(resolvable.index ? { index: resolvable.index } : {}),
+			field,
+			// A lookup fetches the row the key names, so the discovery index has
+			// nothing to say about it.
+			...(declaration.direction === "inbound" && resolvable.index
+				? { index: resolvable.index }
+				: {}),
 		});
 	}
 	return resolved;
+}
+
+function hasExpectedArity(
+	direction: JoinDirection,
+	field: ModelProperty,
+): boolean {
+	const isArray = unwrapArrayElement(field.type) !== undefined;
+	return direction === "inbound" ? isArray : !isArray;
 }
 
 export function toJoinDependencyManifestEntry(
@@ -89,6 +179,7 @@ export function toJoinDependencyManifestEntry(
 		entity: dependency.entity.name,
 		direction: dependency.direction,
 		joinKey: dependency.joinKey.name,
+		field: dependency.field.name,
 		...(dependency.index ? { index: dependency.index } : {}),
 	};
 }
@@ -108,23 +199,82 @@ export function toResolvableByManifestEntry(
 	};
 }
 
+/**
+ * The read a join runs against: the `@restResolver` GET operation that returns
+ * the entity and takes its declared key as a parameter. A `listX()` returning
+ * the same model does not serve the join — nothing hands it the key.
+ */
+export function servesResolvableByRead(
+	program: Program,
+	operation: Operation,
+	entity: Model,
+	key: string,
+): boolean {
+	const [httpOperation] = getHttpOperation(program, operation);
+	if (httpOperation.verb.toLowerCase() !== "get") {
+		return false;
+	}
+	if (unwrapReadModel(operation.returnType) !== entity) {
+		return false;
+	}
+	return httpOperation.parameters.parameters.some(
+		(parameter) =>
+			(parameter.type === "path" || parameter.type === "query") &&
+			parameter.name === key,
+	);
+}
+
+/**
+ * The model a read operation returns, single or as an array.
+ */
+export function unwrapReadModel(returnType: Type): Model | undefined {
+	if (returnType.kind !== "Model") {
+		return undefined;
+	}
+	if (returnType.name === "Array") {
+		const element = returnType.indexer?.value;
+		return element?.kind === "Model" ? element : undefined;
+	}
+	return returnType;
+}
+
 export function validateJoinDeclarations(program: Program): void {
+	const operations = collectOperations(program);
 	for (const model of collectModels(program)) {
-		validateResolvableBy(program, model);
+		validateResolvableBy(program, model, operations);
 		validateDependencies(program, model);
 	}
 }
 
-function validateResolvableBy(program: Program, model: Model): void {
+function validateResolvableBy(
+	program: Program,
+	model: Model,
+	operations: Operation[],
+): void {
 	const resolvable = getResolvableBy(program, model);
 	if (!resolvable) {
 		return;
 	}
-	if (resolvable.key.model !== model) {
+
+	if (!ownsProperty(model, resolvable.key)) {
 		reportDiagnostic(program, {
 			code: "unknown-join-key",
 			format: { key: resolvable.key.name, model: model.name },
 			target: resolvable.key,
+		});
+		return;
+	}
+
+	const served = operations.some(
+		(operation) =>
+			isRestResolver(program, operation) &&
+			servesResolvableByRead(program, operation, model, resolvable.key.name),
+	);
+	if (!served) {
+		reportDiagnostic(program, {
+			code: "join-read-operation-missing",
+			format: { entity: model.name, key: resolvable.key.name },
+			target: model,
 		});
 	}
 }
@@ -134,7 +284,16 @@ function validateDependencies(program: Program, projectionModel: Model): void {
 	if (declarations.length === 0) {
 		return;
 	}
+
 	const sourceModel = getProjectionSourceModel(program, projectionModel);
+	if (!sourceModel) {
+		reportDiagnostic(program, {
+			code: "join-requires-projection",
+			format: { model: projectionModel.name },
+			target: projectionModel,
+		});
+		return;
+	}
 
 	for (const declaration of declarations) {
 		if (!isJoinDirection(declaration.direction)) {
@@ -169,18 +328,86 @@ function validateDependencies(program: Program, projectionModel: Model): void {
 			continue;
 		}
 
-		if (!sourceModel) {
-			continue;
-		}
 		const owner = expectedJoinKeyOwner(declaration, sourceModel);
-		if (declaration.joinKey.model !== owner) {
+		if (!ownsProperty(owner, declaration.joinKey)) {
 			reportDiagnostic(program, {
 				code: "unknown-join-key",
 				format: { key: declaration.joinKey.name, model: owner.name },
 				target: declaration.joinKey,
 			});
+			continue;
 		}
+
+		validateJoinField(
+			program,
+			projectionModel,
+			declaration.entity,
+			declaration.direction,
+		);
 	}
+}
+
+function validateJoinField(
+	program: Program,
+	projectionModel: Model,
+	entity: Model,
+	direction: JoinDirection,
+): void {
+	const candidates = candidateJoinFields(program, projectionModel, entity);
+	const expectedType =
+		direction === "inbound"
+			? `${entity.name}[] (or an array of its search document)`
+			: `${entity.name} (or its search document)`;
+
+	if (candidates.length === 0) {
+		reportDiagnostic(program, {
+			code: "join-field-missing",
+			format: {
+				entity: entity.name,
+				direction,
+				projection: projectionModel.name,
+				expectedType,
+			},
+			target: projectionModel,
+		});
+		return;
+	}
+
+	if (candidates.length > 1) {
+		reportDiagnostic(program, {
+			code: "join-field-ambiguous",
+			format: {
+				entity: entity.name,
+				direction,
+				projection: projectionModel.name,
+				fields: candidates.map((x) => x.name).join(", "),
+			},
+			target: projectionModel,
+		});
+		return;
+	}
+
+	const field = candidates[0];
+	if (!hasExpectedArity(direction, field)) {
+		const isArray = unwrapArrayElement(field.type) !== undefined;
+		reportDiagnostic(program, {
+			code: "join-field-arity",
+			format: {
+				field: field.name,
+				direction,
+				actual: isArray ? "an array" : "a single value",
+				expected: isArray ? "a single row" : "many rows",
+			},
+			target: field,
+		});
+		return;
+	}
+
+	reportDiagnostic(program, {
+		code: "join-field-not-composed",
+		format: { field: field.name, entity: entity.name, direction },
+		target: field,
+	});
 }
 
 function collectModels(program: Program): Model[] {
@@ -195,6 +422,21 @@ function collectModels(program: Program): Model[] {
 	return models;
 }
 
+function collectOperations(program: Program): Operation[] {
+	const operations: Operation[] = [];
+	const walk = (namespace: Namespace) => {
+		operations.push(...namespace.operations.values());
+		for (const iface of namespace.interfaces.values()) {
+			operations.push(...iface.operations.values());
+		}
+		for (const child of namespace.namespaces.values()) {
+			walk(child);
+		}
+	};
+	walk(program.getGlobalNamespaceType());
+	return operations;
+}
+
 function capitalize(value: string): string {
 	return value.charAt(0).toUpperCase() + value.slice(1);
 }
@@ -202,4 +444,5 @@ function capitalize(value: string): string {
 export const __test = {
 	capitalize,
 	expectedJoinKeyOwner,
+	hasExpectedArity,
 };

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -224,6 +224,42 @@ export const $lib = createTypeSpecLibrary({
 				default: paramMessage`Decorator @dependsOn received unsupported direction "${"direction"}". Allowed directions: lookup, inbound.`,
 			},
 		},
+		"join-requires-projection": {
+			severity: "error",
+			messages: {
+				default: paramMessage`Model "${"model"}" carries @dependsOn but is not a SearchProjection<T>, so there is no document for a join to compose into and no source model to resolve a lookup key against.`,
+			},
+		},
+		"join-field-missing": {
+			severity: "error",
+			messages: {
+				default: paramMessage`@dependsOn(${"entity"}, "${"direction"}", ...) has no field to fill. Declare one property on "${"projection"}" typed ${"expectedType"} — a join states where the joined value lands in the document, not just that it exists.`,
+			},
+		},
+		"join-field-ambiguous": {
+			severity: "error",
+			messages: {
+				default: paramMessage`@dependsOn(${"entity"}, "${"direction"}", ...) matches more than one field on "${"projection"}": ${"fields"}. A declaration fills exactly one field, so nothing decides which of these the join composes into. Drop the surplus fields, or give each its own entity.`,
+			},
+		},
+		"join-field-arity": {
+			severity: "error",
+			messages: {
+				default: paramMessage`Field "${"field"}" is typed ${"actual"}, but a "${"direction"}" join resolves ${"expected"}. A lookup fetches the one row the key names; an inbound discovers every row referencing the driving entity.`,
+			},
+		},
+		"join-field-not-composed": {
+			severity: "warning",
+			messages: {
+				default: paramMessage`Field "${"field"}" is filled by the @dependsOn(${"entity"}, "${"direction"}", ...) join, which the emitter declares but does not yet compose. The field is absent from the emitted document type, mapping and SDL; the join-resolver interface and the manifest's dependencies[] carry the contract in the meantime.`,
+			},
+		},
+		"join-read-operation-missing": {
+			severity: "warning",
+			messages: {
+				default: paramMessage`@resolvableBy(${"entity"}.${"key"}) names no read to run against: no @restResolver GET operation returns "${"entity"}" and takes a "${"key"}" parameter, so the manifest carries no resolvableBy block for it and a consumer has nothing to call.`,
+			},
+		},
 		"searchfilter-name-collision": {
 			severity: "error",
 			messages: {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -200,6 +200,30 @@ export const $lib = createTypeSpecLibrary({
 				union: paramMessage`Field "${"field"}" is a union with no scalar or string variant, so the OpenSearch mapping cannot express it. Emitting it would map the field as "object", which OpenSearch rejects at index time and which silently drops every filter, sort and aggregation on the field. Replace the union with a model whose members are optional, or with a union of scalars.`,
 			},
 		},
+		"unknown-join-key": {
+			severity: "error",
+			messages: {
+				default: paramMessage`Join key "${"key"}" is not a property of model "${"model"}". A join key names a property on the model that owns it: @resolvableBy takes a key on its own model, a "lookup" dependency takes a key on the projection's source model, and an "inbound" dependency takes a key on the joined entity.`,
+			},
+		},
+		"join-index-required": {
+			severity: "error",
+			messages: {
+				default: paramMessage`@dependsOn(${"entity"}, "inbound", ...) discovers every row referencing the driving entity, and that read needs an index to run against. Model "${"entity"}" declares @resolvableBy without one, so it can only be fetched a single row at a time by its own key. Add the index name to that declaration — @resolvableBy(${"entity"}.${"key"}, "${"suggestedIndex"}").`,
+			},
+		},
+		"undeclared-join-resolution": {
+			severity: "error",
+			messages: {
+				default: paramMessage`@dependsOn names model "${"entity"}", which carries no @resolvableBy, so nothing states how a row of it is fetched. Declare @resolvableBy(${"entity"}.<key>) on that model, adding an index name when the join discovers many rows.`,
+			},
+		},
+		"invalid-join-direction": {
+			severity: "error",
+			messages: {
+				default: paramMessage`Decorator @dependsOn received unsupported direction "${"direction"}". Allowed directions: lookup, inbound.`,
+			},
+		},
 		"searchfilter-name-collision": {
 			severity: "error",
 			messages: {
@@ -255,6 +279,14 @@ export const $lib = createTypeSpecLibrary({
 		graphqlId: {
 			description:
 				"Opt-in marker — the string property surfaces as GraphQL ID instead of String in REST SDL output (issue #136)",
+		},
+		resolvableBy: {
+			description:
+				"How a joined entity is fetched — the key a row is read by, and the index that discovers many rows by that key (issue #194)",
+		},
+		dependsOn: {
+			description:
+				"Cross-domain view joins declared on a projection — one entry per joined entity, with its direction and join key (issue #194)",
 		},
 	},
 	emitter: {

--- a/src/projection-source.ts
+++ b/src/projection-source.ts
@@ -1,0 +1,32 @@
+import type { Model, Program, Type } from "@typespec/compiler";
+
+export function isSearchProjectionModel(
+	program: Program,
+	model: Model,
+): boolean {
+	return !!getProjectionSourceModel(program, model);
+}
+
+export function getProjectionSourceModel(
+	_program: Program,
+	projectionModel: Model,
+): Model | undefined {
+	if (projectionModel.name === "SearchProjection") {
+		return undefined;
+	}
+
+	const isSource = projectionModel.sourceModels.find(
+		(x) => x.usage === "is" && x.model.name === "SearchProjection",
+	);
+	if (!isSource) {
+		return undefined;
+	}
+
+	// The instantiated SearchProjection<T> model carries a templateMapper
+	// whose first arg is the resolved source model T.
+	const sourceModel = isSource.model as Model & {
+		templateMapper?: { args?: readonly Type[] };
+	};
+	const sourceType = sourceModel.templateMapper?.args?.[0];
+	return sourceType?.kind === "Model" ? sourceType : undefined;
+}

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -43,9 +43,15 @@ function isReachable(
 	return !!typeModel && isSearchInfer(program, typeModel);
 }
 
-import type { ResolvedJoinDependency } from "./joins.js";
+import { candidateJoinFields, type ResolvedJoinDependency } from "./joins.js";
 import { reportDiagnostic } from "./lib.js";
+import {
+	getProjectionSourceModel,
+	isSearchProjectionModel,
+} from "./projection-source.js";
 import { isDateScalarName } from "./utils.js";
+
+export { getProjectionSourceModel, isSearchProjectionModel };
 
 export interface ResolvedProjectionField {
 	name: string;
@@ -67,38 +73,20 @@ export interface ResolvedProjectionField {
 }
 
 /**
- * True when the projection field is filled by a declared join rather than by
- * the source model — its type is a joined entity, or a projection of one
- * (issue #194). Composition of the joined value into the document lands with
- * the join emitter.
+ * True when the property is the field a declared join fills (issue #194).
+ * `join-field-not-composed` states the same thing to the author; the emitter
+ * only needs to know the field is accounted for, not missing from the source.
  */
 function isJoinProvidedField(
 	program: Program,
 	projectionModel: Model,
-	fieldType: Type,
+	property: ModelProperty,
 ): boolean {
-	const declarations = getJoinDependencies(program, projectionModel);
-	if (declarations.length === 0) {
-		return false;
-	}
-
-	const joined = unwrapJoinedType(fieldType);
-	if (joined?.kind !== "Model") {
-		return false;
-	}
-
-	const joinedSource = getProjectionSourceModel(program, joined);
-	return declarations.some(
-		(declaration) =>
-			declaration.entity === joined || declaration.entity === joinedSource,
+	return getJoinDependencies(program, projectionModel).some((declaration) =>
+		candidateJoinFields(program, projectionModel, declaration.entity).includes(
+			property,
+		),
 	);
-}
-
-function unwrapJoinedType(type: Type): Type | undefined {
-	if (type.kind === "Model" && type.name === "Array") {
-		return type.indexer?.value;
-	}
-	return type;
 }
 
 export interface ResolvedProjection {
@@ -124,37 +112,6 @@ export interface ResolvedProjection {
  * top-level emission: Query field, resolver, mapping, manifest entry.
  */
 export type TopLevelProjection = ResolvedProjection & { indexName: string };
-
-export function isSearchProjectionModel(
-	program: Program,
-	model: Model,
-): boolean {
-	return !!getProjectionSourceModel(program, model);
-}
-
-export function getProjectionSourceModel(
-	_program: Program,
-	projectionModel: Model,
-): Model | undefined {
-	if (projectionModel.name === "SearchProjection") {
-		return undefined;
-	}
-
-	const isSource = projectionModel.sourceModels.find(
-		(x) => x.usage === "is" && x.model.name === "SearchProjection",
-	);
-	if (!isSource) {
-		return undefined;
-	}
-
-	// The instantiated SearchProjection<T> model carries a templateMapper
-	// whose first arg is the resolved source model T.
-	const sourceModel = isSource.model as Model & {
-		templateMapper?: { args?: readonly Type[] };
-	};
-	const sourceType = sourceModel.templateMapper?.args?.[0];
-	return sourceType?.kind === "Model" ? sourceType : undefined;
-}
 
 export function resolveProjectionModel(
 	program: Program,
@@ -271,7 +228,7 @@ export function resolveProjectionModel(
 			const subProj = resolveSubProjectionFromType(program, projProp.type);
 			if (
 				(!subProj || !sourceProp) &&
-				!isJoinProvidedField(program, projectionModel, projProp.type)
+				!isJoinProvidedField(program, projectionModel, projProp)
 			) {
 				reportDiagnostic(program, {
 					code: "projection-field-not-on-source",

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -9,6 +9,7 @@ import {
 	getIgnoreAbove,
 	getIndexName,
 	getIndexSettings,
+	getJoinDependencies,
 	getSearchAs,
 	hasAggregatable,
 	hasFilterable,
@@ -42,6 +43,7 @@ function isReachable(
 	return !!typeModel && isSearchInfer(program, typeModel);
 }
 
+import type { ResolvedJoinDependency } from "./joins.js";
 import { reportDiagnostic } from "./lib.js";
 import { isDateScalarName } from "./utils.js";
 
@@ -64,6 +66,41 @@ export interface ResolvedProjectionField {
 	subProjection?: ResolvedProjection;
 }
 
+/**
+ * True when the projection field is filled by a declared join rather than by
+ * the source model — its type is a joined entity, or a projection of one
+ * (issue #194). Composition of the joined value into the document lands with
+ * the join emitter.
+ */
+function isJoinProvidedField(
+	program: Program,
+	projectionModel: Model,
+	fieldType: Type,
+): boolean {
+	const declarations = getJoinDependencies(program, projectionModel);
+	if (declarations.length === 0) {
+		return false;
+	}
+
+	const joined = unwrapJoinedType(fieldType);
+	if (joined?.kind !== "Model") {
+		return false;
+	}
+
+	const joinedSource = getProjectionSourceModel(program, joined);
+	return declarations.some(
+		(declaration) =>
+			declaration.entity === joined || declaration.entity === joinedSource,
+	);
+}
+
+function unwrapJoinedType(type: Type): Type | undefined {
+	if (type.kind === "Model" && type.name === "Array") {
+		return type.indexer?.value;
+	}
+	return type;
+}
+
 export interface ResolvedProjection {
 	projectionModel: Model;
 	sourceModel: Model;
@@ -74,6 +111,12 @@ export interface ResolvedProjection {
 	indexName?: string;
 	indexSettings?: Record<string, unknown>;
 	fields: ResolvedProjectionField[];
+	/**
+	 * Cross-domain joins declared with `@dependsOn` (issue #194). Filled by
+	 * `resolveJoinDependencies` after the projection resolves, so a projection
+	 * carries the joins that survived validation.
+	 */
+	joins?: ResolvedJoinDependency[];
 }
 
 /**
@@ -226,7 +269,10 @@ export function resolveProjectionModel(
 		if (!sourceProp || !isReachable(program, sourceProp, inferOnModel)) {
 			// Allow sub-projection fields that reference a valid source field
 			const subProj = resolveSubProjectionFromType(program, projProp.type);
-			if (!subProj || !sourceProp) {
+			if (
+				(!subProj || !sourceProp) &&
+				!isJoinProvidedField(program, projectionModel, projProp.type)
+			) {
 				reportDiagnostic(program, {
 					code: "projection-field-not-on-source",
 					format: { name: projProp.name, sourceModel: sourceModel.name },

--- a/src/rest-operations.ts
+++ b/src/rest-operations.ts
@@ -8,6 +8,10 @@ import type {
 } from "@typespec/compiler";
 import { getHttpOperation } from "@typespec/http";
 import { isRestResolver } from "./decorators.js";
+import {
+	type ResolvableByManifestEntry,
+	toResolvableByManifestEntry,
+} from "./joins.js";
 
 /**
  * Discovery + resolution for `@restResolver` operations (issue #134). This is
@@ -64,6 +68,11 @@ export interface ResolvedRestOperation extends RestOperationShape {
 	bodyModel?: Model;
 	/** The operation's declared return type. */
 	returnType: Type;
+	/**
+	 * Set when the operation reads a model carrying `@resolvableBy` — the read
+	 * a cross-domain join runs against (issue #194).
+	 */
+	resolvableBy?: ResolvableByManifestEntry;
 }
 
 export function collectRestOperations(
@@ -136,9 +145,16 @@ export function resolveRestOperation(
 		? (body?.property?.name ?? "input")
 		: undefined;
 
+	const typeName = toRestGraphQLTypeName(httpOperation.verb);
+	const readModel =
+		typeName === "Query" ? unwrapReadModel(operation.returnType) : undefined;
+	const resolvableBy = readModel
+		? toResolvableByManifestEntry(program, readModel)
+		: undefined;
+
 	return {
 		fieldName: operation.name,
-		typeName: toRestGraphQLTypeName(httpOperation.verb),
+		typeName,
 		httpMethod: httpOperation.verb.toUpperCase(),
 		path: httpOperation.path,
 		pathParams,
@@ -146,6 +162,22 @@ export function resolveRestOperation(
 		bodyParamName,
 		bodyModel,
 		returnType: operation.returnType,
+		...(resolvableBy ? { resolvableBy } : {}),
 		operation,
 	};
+}
+
+/**
+ * The model a read operation returns, single or as an array — the entity whose
+ * `@resolvableBy` declaration, if any, the operation serves.
+ */
+function unwrapReadModel(returnType: Type): Model | undefined {
+	if (returnType.kind !== "Model") {
+		return undefined;
+	}
+	if (returnType.name === "Array") {
+		const element = returnType.indexer?.value;
+		return element?.kind === "Model" ? element : undefined;
+	}
+	return returnType;
 }

--- a/src/rest-operations.ts
+++ b/src/rest-operations.ts
@@ -7,10 +7,12 @@ import type {
 	Type,
 } from "@typespec/compiler";
 import { getHttpOperation } from "@typespec/http";
-import { isRestResolver } from "./decorators.js";
+import { getResolvableBy, isRestResolver } from "./decorators.js";
 import {
 	type ResolvableByManifestEntry,
+	servesResolvableByRead,
 	toResolvableByManifestEntry,
+	unwrapReadModel,
 } from "./joins.js";
 
 /**
@@ -146,11 +148,7 @@ export function resolveRestOperation(
 		: undefined;
 
 	const typeName = toRestGraphQLTypeName(httpOperation.verb);
-	const readModel =
-		typeName === "Query" ? unwrapReadModel(operation.returnType) : undefined;
-	const resolvableBy = readModel
-		? toResolvableByManifestEntry(program, readModel)
-		: undefined;
+	const resolvableBy = resolveJoinRead(program, operation);
 
 	return {
 		fieldName: operation.name,
@@ -168,16 +166,27 @@ export function resolveRestOperation(
 }
 
 /**
- * The model a read operation returns, single or as an array — the entity whose
- * `@resolvableBy` declaration, if any, the operation serves.
+ * The `resolvableBy` block for the one read a join runs against (issue #194):
+ * the GET returning a `@resolvableBy` model and taking its declared key. A
+ * sibling `listX()` over the same model is not that read — nothing hands it
+ * the key — so it carries no block.
  */
-function unwrapReadModel(returnType: Type): Model | undefined {
-	if (returnType.kind !== "Model") {
+function resolveJoinRead(
+	program: Program,
+	operation: Operation,
+): ResolvableByManifestEntry | undefined {
+	const entity = unwrapReadModel(operation.returnType);
+	if (!entity) {
 		return undefined;
 	}
-	if (returnType.name === "Array") {
-		const element = returnType.indexer?.value;
-		return element?.kind === "Model" ? element : undefined;
+	const resolvable = getResolvableBy(program, entity);
+	if (!resolvable) {
+		return undefined;
 	}
-	return returnType;
+	if (
+		!servesResolvableByRead(program, operation, entity, resolvable.key.name)
+	) {
+		return undefined;
+	}
+	return toResolvableByManifestEntry(program, entity);
 }

--- a/test/pet-care-example.js
+++ b/test/pet-care-example.js
@@ -1,11 +1,13 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
 import { readFile, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 import test from "node:test";
 import { promisify } from "node:util";
 import Ajv2020 from "ajv/dist/2020.js";
 
 const execFileAsync = promisify(execFile);
+const require = createRequire(import.meta.url);
 
 // Issue #194 — the pet care view. Waffles the beagle has a passport, Nugget
 // the stray does not, so his document carries no passport and no ownership
@@ -42,11 +44,17 @@ test("projection manifest carries dependencies[], one entry per declaration", as
 
 	assert.ok(petCare);
 	assert.deepEqual(petCare.dependencies, [
-		{ entity: "PetPassport", direction: "lookup", joinKey: "passportId" },
+		{
+			entity: "PetPassport",
+			direction: "lookup",
+			joinKey: "passportId",
+			field: "passport",
+		},
 		{
 			entity: "OwnershipRecord",
 			direction: "inbound",
 			joinKey: "petId",
+			field: "ownershipHistory",
 			index: "byPetId",
 		},
 	]);
@@ -61,19 +69,38 @@ test("dependencies[] validates against the published schema", async () => {
 	}
 });
 
-test("the dependencies schema rejects a discovery join with no index", () => {
-	assert.equal(
-		validateDependencies([
-			{ entity: "OwnershipRecord", direction: "inbound", joinKey: "petId" },
-		]),
-		false,
-	);
-	assert.equal(
-		validateDependencies([
-			{ entity: "PetPassport", direction: "sideways", joinKey: "passportId" },
-		]),
-		false,
-	);
+test("the dependencies schema holds the rules the diagnostics enforce", () => {
+	const inboundNoIndex = {
+		entity: "OwnershipRecord",
+		direction: "inbound",
+		joinKey: "petId",
+		field: "ownershipHistory",
+	};
+	assert.equal(validateDependencies([inboundNoIndex]), false);
+
+	const lookupWithIndex = {
+		entity: "PetPassport",
+		direction: "lookup",
+		joinKey: "passportId",
+		field: "passport",
+		index: "byPassportId",
+	};
+	assert.equal(validateDependencies([lookupWithIndex]), false);
+
+	const unboundField = {
+		entity: "PetPassport",
+		direction: "lookup",
+		joinKey: "passportId",
+	};
+	assert.equal(validateDependencies([unboundField]), false);
+
+	const strayDirection = {
+		entity: "PetPassport",
+		direction: "sideways",
+		joinKey: "passportId",
+		field: "passport",
+	};
+	assert.equal(validateDependencies([strayDirection]), false);
 });
 
 test("each read operation's manifest entry carries its resolvableBy block", async () => {
@@ -130,12 +157,12 @@ test("a projection with dependencies gets a typed join-resolver interface", asyn
 
 	assert.ok(
 		source.includes(
-			"lookupPetPassport(passportId: string): Promise<PetPassportSearchDoc | undefined>;",
+			"lookupPassport(passportId: string): Promise<PetPassportSearchDoc | undefined>;",
 		),
 	);
 	assert.ok(
 		source.includes(
-			"discoverOwnershipRecord(petId: string): Promise<OwnershipRecordSearchDoc[]>;",
+			"discoverOwnershipHistory(petId: string): Promise<OwnershipRecordSearchDoc[]>;",
 		),
 	);
 
@@ -167,4 +194,30 @@ test("the emitted join-resolver interface compiles", async () => {
 	);
 
 	await execFileAsync("npx", ["tsc", "-p", `${EMIT_DIR}/tsconfig.json`]);
+});
+
+test("the schemas resolve through the package exports map", async () => {
+	for (const fileName of [
+		"resolvable-by.schema.json",
+		"dependencies.schema.json",
+	]) {
+		const specifier = `@kattebak/typespec-opensearch-emitter/schema/${fileName}`;
+		const resolved = require.resolve(specifier);
+
+		assert.equal(
+			await readFile(resolved, "utf8"),
+			await readFile(`schema/${fileName}`, "utf8"),
+			`${specifier} resolves to a different file than schema/${fileName}`,
+		);
+	}
+});
+
+test("a sibling read over the same entity carries no resolvableBy block", async () => {
+	const manifest = await readJson("graphql-resolvers.json");
+
+	const listPassports = manifest.resolvers.find(
+		(x) => x.fieldName === "listPetPassports",
+	);
+	assert.ok(listPassports);
+	assert.equal(listPassports.resolvableBy, undefined);
 });

--- a/test/pet-care-example.js
+++ b/test/pet-care-example.js
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { readFile, writeFile } from "node:fs/promises";
+import test from "node:test";
+import { promisify } from "node:util";
+import Ajv2020 from "ajv/dist/2020.js";
+
+const execFileAsync = promisify(execFile);
+
+// Issue #194 — the pet care view. Waffles the beagle has a passport, Nugget
+// the stray does not, so his document carries no passport and no ownership
+// history; rehoming Waffles writes an OwnershipRecord and re-indexes him.
+// `npm run test:emit:joins` compiles test/pet-care/main.tsp into
+// build/pet-care-emit.
+const EMIT_DIR = "build/pet-care-emit";
+
+const ajv = new Ajv2020({ strict: true });
+
+async function compileSchema(fileName) {
+	return ajv.compile(JSON.parse(await readFile(`schema/${fileName}`, "utf8")));
+}
+
+const validateDependencies = await compileSchema("dependencies.schema.json");
+const validateResolvableBy = await compileSchema("resolvable-by.schema.json");
+
+async function readJson(fileName) {
+	return JSON.parse(await readFile(`${EMIT_DIR}/${fileName}`, "utf8"));
+}
+
+function assertValid(validate, value) {
+	assert.ok(
+		validate(value),
+		`${JSON.stringify(value)} violates the schema: ${ajv.errorsText(validate.errors)}`,
+	);
+}
+
+test("projection manifest carries dependencies[], one entry per declaration", async () => {
+	const manifest = await readJson("opensearch-projections.json");
+	const petCare = manifest.projections.find(
+		(x) => x.name === "PetCareSearchDoc",
+	);
+
+	assert.ok(petCare);
+	assert.deepEqual(petCare.dependencies, [
+		{ entity: "PetPassport", direction: "lookup", joinKey: "passportId" },
+		{
+			entity: "OwnershipRecord",
+			direction: "inbound",
+			joinKey: "petId",
+			index: "byPetId",
+		},
+	]);
+});
+
+test("dependencies[] validates against the published schema", async () => {
+	const manifest = await readJson("opensearch-projections.json");
+
+	for (const projection of manifest.projections) {
+		if (!projection.dependencies) continue;
+		assertValid(validateDependencies, projection.dependencies);
+	}
+});
+
+test("the dependencies schema rejects a discovery join with no index", () => {
+	assert.equal(
+		validateDependencies([
+			{ entity: "OwnershipRecord", direction: "inbound", joinKey: "petId" },
+		]),
+		false,
+	);
+	assert.equal(
+		validateDependencies([
+			{ entity: "PetPassport", direction: "sideways", joinKey: "passportId" },
+		]),
+		false,
+	);
+});
+
+test("each read operation's manifest entry carries its resolvableBy block", async () => {
+	const manifest = await readJson("graphql-resolvers.json");
+
+	const getPassport = manifest.resolvers.find(
+		(x) => x.fieldName === "getPetPassport",
+	);
+	assert.deepEqual(getPassport.resolvableBy, {
+		entity: "PetPassport",
+		key: "passportId",
+	});
+
+	const listOwnership = manifest.resolvers.find(
+		(x) => x.fieldName === "listOwnershipRecords",
+	);
+	assert.deepEqual(listOwnership.resolvableBy, {
+		entity: "OwnershipRecord",
+		key: "petId",
+		index: "byPetId",
+	});
+});
+
+test("resolvableBy blocks validate against the published schema", async () => {
+	const manifest = await readJson("graphql-resolvers.json");
+
+	const blocks = manifest.resolvers
+		.map((x) => x.resolvableBy)
+		.filter((x) => x !== undefined);
+
+	assert.equal(blocks.length, 2);
+	for (const block of blocks) {
+		assertValid(validateResolvableBy, block);
+	}
+});
+
+test("the resolvableBy schema rejects a block with no key", () => {
+	assert.equal(validateResolvableBy({ entity: "PetPassport" }), false);
+	assert.equal(
+		validateResolvableBy({
+			entity: "PetPassport",
+			key: "passportId",
+			extra: true,
+		}),
+		false,
+	);
+});
+
+test("a projection with dependencies gets a typed join-resolver interface", async () => {
+	const source = await readFile(
+		`${EMIT_DIR}/pet-care-search-doc-join-resolver.ts`,
+		"utf8",
+	);
+
+	assert.ok(
+		source.includes(
+			"lookupPetPassport(passportId: string): Promise<PetPassportSearchDoc | undefined>;",
+		),
+	);
+	assert.ok(
+		source.includes(
+			"discoverOwnershipRecord(petId: string): Promise<OwnershipRecordSearchDoc[]>;",
+		),
+	);
+
+	const barrel = await readFile(`${EMIT_DIR}/index.ts`, "utf8");
+	assert.ok(
+		barrel.includes(
+			'export type { PetCareSearchDocJoinResolver } from "./pet-care-search-doc-join-resolver.js";',
+		),
+	);
+});
+
+test("the emitted join-resolver interface compiles", async () => {
+	await writeFile(
+		`${EMIT_DIR}/tsconfig.json`,
+		JSON.stringify(
+			{
+				compilerOptions: {
+					module: "NodeNext",
+					moduleResolution: "NodeNext",
+					target: "ES2020",
+					strict: true,
+					noEmit: true,
+				},
+				include: ["*.ts"],
+			},
+			null,
+			2,
+		),
+	);
+
+	await execFileAsync("npx", ["tsc", "-p", `${EMIT_DIR}/tsconfig.json`]);
+});

--- a/test/pet-care/main.tsp
+++ b/test/pet-care/main.tsp
@@ -46,6 +46,10 @@ model PetCareSearchDoc is SearchProjection<Pet> {
 @route("/pet-passports")
 namespace PetPassports {
 	@restResolver @get op getPetPassport(@path passportId: string): PetPassport;
+
+	// Returns the same entity, but nothing hands it the join key, so it is not
+	// the read the join runs against and carries no resolvableBy block.
+	@restResolver @get op listPetPassports(@query issuedCountry?: string): PetPassport[];
 }
 
 @route("/ownership-records")

--- a/test/pet-care/main.tsp
+++ b/test/pet-care/main.tsp
@@ -1,0 +1,56 @@
+import "@typespec/http";
+import "@kattebak/typespec-opensearch-emitter";
+
+using TypeSpec.Http;
+using Kattebak.OpenSearch;
+
+model Pet {
+	@searchable @keyword petId: string;
+	@searchable @keyword name: string;
+	@searchable @keyword species: string;
+	@searchable @keyword passportId: string;
+}
+
+@resolvableBy(PetPassport.passportId)
+model PetPassport {
+	passportId: string;
+
+	@searchable @keyword microchipId: string;
+	@searchable @keyword issuedCountry: string;
+	@searchable @keyword vaccinations: string[];
+}
+
+@resolvableBy(OwnershipRecord.petId, "byPetId")
+model OwnershipRecord {
+	ownershipRecordId: string;
+	petId: string;
+
+	@searchable @keyword ownerName: string;
+	@searchable @filterable("range") transferredAt: utcDateTime;
+}
+
+model PetPassportSearchDoc is SearchProjection<PetPassport> {}
+
+model OwnershipRecordSearchDoc is SearchProjection<OwnershipRecord> {}
+
+@searchProjection
+@indexName("pet_care_v1")
+@dependsOn(PetPassport, "lookup", Pet.passportId)
+@dependsOn(OwnershipRecord, "inbound", OwnershipRecord.petId)
+model PetCareSearchDoc is SearchProjection<Pet> {
+	passport?: PetPassportSearchDoc;
+
+	@nested ownershipHistory: OwnershipRecordSearchDoc[];
+}
+
+@route("/pet-passports")
+namespace PetPassports {
+	@restResolver @get op getPetPassport(@path passportId: string): PetPassport;
+}
+
+@route("/ownership-records")
+namespace OwnershipRecords {
+	@restResolver
+	@get
+	op listOwnershipRecords(@query petId: string): OwnershipRecord[];
+}

--- a/test/pet-care/tspconfig.yaml
+++ b/test/pet-care/tspconfig.yaml
@@ -1,0 +1,7 @@
+emit:
+  - "@kattebak/typespec-opensearch-emitter"
+options:
+  "@kattebak/typespec-opensearch-emitter":
+    emitter-output-dir: "{cwd}/build/pet-care-emit"
+    graphql:
+      emit: true

--- a/tsp/main.tsp
+++ b/tsp/main.tsp
@@ -22,5 +22,12 @@ extern dec graphqlDirectives(target: Model, ...directives: valueof string[]);
 extern dec searchProjection(target: Model);
 extern dec restResolver(target: Operation);
 extern dec graphqlId(target: ModelProperty);
+extern dec resolvableBy(target: Model, key: ModelProperty, index?: valueof string);
+extern dec dependsOn(
+  target: Model,
+  entity: Model,
+  direction: valueof string,
+  joinKey: ModelProperty
+);
 
 model SearchProjection<T> {}


### PR DESCRIPTION
Adds `@resolvableBy` / `@dependsOn`, the `resolvableBy` and `dependencies[]` manifest blocks with their JSON schemas, the emitted join-resolver interface, and the join diagnostics.

A projection resolves fields from one source model, so a field owned by another spec cannot enter the document and no manifest key says a write over there should re-index anything here.

Each declaration binds to exactly one projection field — singular for a `lookup`, an array for an `inbound` — so `dependencies[]` also carries `field`, `index` appears on an `inbound` entry only, and `resolvableBy` lands on the one GET that takes the declared key. `test/pet-care` is the pet care view from the issue.

Contract only, closes #194. The emitter that composes the joined values into the document is #195; until then `join-field-not-composed` warns on every bound field.