### PR TITLE
fix(joins)!: compose a joined entity in full, depend on it transitively

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,6 +618,8 @@ Field-name conventions in the generated `*SearchAggregations` type (singular for
 
 A field inside a sub-projection is addressed by its path in the document and named for it: `address.country` aggregates on `address.country` and surfaces as `byAddressCountry`. A `@nested` sub-projection wraps its aggregations in a `nested` aggregation on that path; a plain object sub-projection needs no wrapper.
 
+Two fields can reach the same name that way — a top-level `addressCountry` alongside a nested `address.country` — and the generated type carries one field per name. That reports `aggregation-name-collision`: rename one of the fields, or give one a distinct `@searchAs` name.
+
 `date_histogram` requires `interval` (one of `year`, `quarter`, `month`, `week`, `day`, `hour` — defaults to `month` if omitted) and takes an optional `bounds` — see [Bounding a date_histogram](#bounding-a-date_histogram). `range` requires `ranges` (array of `{ from?, to?, key? }`; each entry must set at least one of `from` / `to`). `terms` `sub` allows numeric metric sub-aggregations (`sum`/`avg`/`min`/`max`/`cardinality`) keyed by output bucket field name.
 
 #### Bounding a `date_histogram`
@@ -775,7 +777,9 @@ Both joins are left joins. Waffles the beagle has a passport; Nugget, a stray, d
 
 A declaration says where the joined value lands, not only that it exists. Each `@dependsOn` binds to **exactly one** projection field — the one typed as the entity or as its search document. A `lookup` fills a single-valued field, an `inbound` fills an array. That binding is what names the resolver method and what `dependencies[].field` carries.
 
-A field typed as the entity itself, rather than as its search document, composes from that model's `@searchable` properties — or from the whole model when it carries `@searchInfer`. A model offering neither has nothing to contribute and reports `join-field-not-composed`.
+A field typed as the entity itself, rather than as its search document, composes from the properties that model declares with `@searchable`, `@filterable` or `@aggregatable` — or from the whole model when it carries `@searchInfer`. Either way the joined document is composed the same: response shape, mapping, filters and facets alike. A model declaring nothing, or a `SearchProjection<T>` that resolves no field, has nothing to contribute and reports `join-field-not-composed`.
+
+A join field takes a document key of its own. One whose name is already resolved from the source model reports `join-field-collision`, and one composing a model already being composed reports `join-cycle` — a document cannot contain itself, and each hop would re-index the one before it without ever settling.
 
 ### What a bound field composes into
 
@@ -837,7 +841,7 @@ The read operation's `graphql-resolvers.json` entry carries a `resolvableBy` blo
 }
 ```
 
-The projection's `opensearch-projections.json` entry carries `dependencies[]`, one object per declaration:
+The projection's `opensearch-projections.json` entry carries `dependencies[]`, one object per declaration the document is composed from:
 
 ```json
 {
@@ -862,6 +866,19 @@ The projection's `opensearch-projections.json` entry carries `dependencies[]`, o
 ```
 
 `index` appears on an `inbound` entry only: a lookup fetches the row its key names, so the discovery index has nothing to say about it.
+
+`field` is the key path the joined value lands at in the composed document, projected names throughout — a `@searchAs` rename moves the key, and the entry follows it.
+
+The list is a transitive closure. A joined document carrying its own `@dependsOn` puts that entity's rows in this document too, so its writes re-index this one just the same, and it gets an entry here. Those entries stay flat and are told apart by their path:
+
+```json
+{
+  "entity": "Vet",
+  "direction": "lookup",
+  "joinKey": "vetId",
+  "field": "passport.vet"
+}
+```
 
 Both blocks ship a JSON schema, exported from the package as `./schema/resolvable-by.schema.json` and `./schema/dependencies.schema.json`. Each key is omitted when nothing declares it, so a spec with no joins emits an unchanged manifest.
 
@@ -936,6 +953,7 @@ A composed document is a snapshot: it is only as fresh as the last compose, and 
 | The driving entity | Its own document |
 | An entity reached by `lookup` | Every document whose join key names it |
 | An entity reached by `inbound` | The document its join key names |
+| An entity reached through another join | The same, one hop further out |
 
 An `inbound` declaration is what makes a write in the joined domain a trigger at all, which is why it requires a `@resolvableBy` index: discovering affected documents is a query by the join key, not a fetch. Recompose the whole document rather than patching the changed field — the compose is a pure function of the driving row's id, so a replay or a reordered trigger converges on the same document.
 
@@ -951,7 +969,9 @@ An `inbound` declaration is what makes a write in the joined domain a trigger at
 | `join-field-missing` | error | No projection field is typed to receive the declared entity. |
 | `join-field-ambiguous` | error | More than one field could receive it, so nothing decides which. |
 | `join-field-arity` | error | A `lookup` bound to an array field, or an `inbound` bound to a single-valued one. |
-| `join-field-not-composed` | error | The bound field names a model that states nothing about what enters the document — no `SearchProjection<T>`, no `@searchInfer`, no `@searchable` property — so composing it would emit an empty object. |
+| `join-field-not-composed` | error | The bound field names a model that states nothing about what enters the document — no `@searchInfer`, no `@searchable`/`@filterable`/`@aggregatable` property, or a `SearchProjection<T>` resolving no field — so composing it would emit an empty object. |
+| `join-field-collision` | error | The bound field's name is already resolved from the projection's source model, so two fields would claim one document key. |
+| `join-cycle` | error | A join composes a document already being composed, directly or through another join. |
 | `join-read-operation-missing` | warning | No `@restResolver` GET returns the entity and takes its declared key, so the join has nothing to call. |
 
 

--- a/schema/dependencies.schema.json
+++ b/schema/dependencies.schema.json
@@ -2,7 +2,7 @@
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"$id": "https://kattebak.github.io/typespec-opensearch-emitter/schema/dependencies.schema.json",
 	"title": "dependencies",
-	"description": "Cross-domain joins a projection composes its document from. Emitted on the opensearch-projections.json entry of the projection, one object per @dependsOn declaration.",
+	"description": "Cross-domain joins a projection composes its document from, closed over transitive joins: one object per @dependsOn declaration reached from the projection, including those declared on a joined document. Emitted on the opensearch-projections.json entry of the projection.",
 	"type": "array",
 	"items": {
 		"type": "object",
@@ -24,9 +24,10 @@
 				"minLength": 1
 			},
 			"field": {
-				"description": "Property of the projection the joined value lands in. A lookup fills a single-valued field, an inbound an array.",
+				"description": "Key path the joined value lands at in the composed document, projected names throughout — dotted when the join is declared on a joined document rather than on this one. A lookup fills a single-valued key, an inbound an array.",
 				"type": "string",
-				"minLength": 1
+				"minLength": 1,
+				"pattern": "^[^.]+(\\.[^.]+)*$"
 			},
 			"index": {
 				"description": "Index the joined rows are discovered by, carried from the entity's resolvableBy declaration. An inbound join only.",

--- a/src/aggregations.test.ts
+++ b/src/aggregations.test.ts
@@ -1,13 +1,19 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import type { Type } from "@typespec/compiler";
+import { createTestHost, createTestWrapper } from "@typespec/compiler/testing";
 import {
 	__test,
 	aggregationsTypeName,
 	collectAggregations,
 	hasAggregations,
+	reportAggregationNameCollisions,
 } from "./aggregations.js";
-import type { ResolvedProjection } from "./projection.js";
+import {
+	type ResolvedProjection,
+	resolveProjectionModel,
+} from "./projection.js";
+import { OpenSearchEmitterTestLibrary } from "./testing/index.js";
 
 const {
 	aggregationFieldName,
@@ -582,5 +588,85 @@ describe("isTextField", () => {
 			),
 			false,
 		);
+	});
+});
+
+describe("reportAggregationNameCollisions", () => {
+	async function createRunner() {
+		const host = await createTestHost({
+			libraries: [OpenSearchEmitterTestLibrary],
+		});
+
+		return createTestWrapper(host, {
+			autoImports: ["@kattebak/typespec-opensearch-emitter"],
+			autoUsings: ["Kattebak.OpenSearch"],
+		});
+	}
+
+	async function resolve(runner: Awaited<ReturnType<typeof createRunner>>) {
+		const projectionModel = runner.program
+			.getGlobalNamespaceType()
+			.models.get("CounterpartySearchDoc");
+		assert.ok(projectionModel);
+		const resolved = resolveProjectionModel(runner.program, projectionModel);
+		assert.ok(resolved);
+		return resolved;
+	}
+
+	it("reports two fields deriving the same aggregation name", async () => {
+		const runner = await createRunner();
+		await runner.diagnose(`
+			@searchInfer
+			model Address {
+				@searchable @keyword country: string;
+			}
+
+			model Counterparty {
+				@searchable @keyword @aggregatable("terms") addressCountry: string;
+				@searchable address: Address;
+			}
+
+			@indexName("counterparties_v1")
+			model CounterpartySearchDoc is SearchProjection<Counterparty> {}
+		`);
+
+		const resolved = await resolve(runner);
+		const aggregations = collectAggregations(resolved);
+		assert.deepEqual(
+			aggregations.map((x) => x.aggName),
+			["byAddressCountry", "byAddressCountry"],
+		);
+
+		const before = runner.program.diagnostics.length;
+		reportAggregationNameCollisions(runner.program, aggregations);
+
+		const reported = runner.program.diagnostics
+			.slice(before)
+			.filter((x) => x.code.endsWith("aggregation-name-collision"));
+		assert.equal(reported.length, 1);
+		assert.match(reported[0].message, /byAddressCountry/);
+	});
+
+	it("stays quiet when the same aggregation is reached twice", async () => {
+		const runner = await createRunner();
+		await runner.diagnose(`
+			model Counterparty {
+				@searchable @keyword @aggregatable("terms") country: string;
+			}
+
+			@indexName("counterparties_v1")
+			model CounterpartySearchDoc is SearchProjection<Counterparty> {}
+		`);
+
+		const resolved = await resolve(runner);
+		const aggregations = collectAggregations(resolved);
+
+		const before = runner.program.diagnostics.length;
+		reportAggregationNameCollisions(runner.program, [
+			...aggregations,
+			...aggregations,
+		]);
+
+		assert.deepEqual(runner.program.diagnostics.slice(before), []);
 	});
 });

--- a/src/aggregations.ts
+++ b/src/aggregations.ts
@@ -1,5 +1,6 @@
-import type { Type } from "@typespec/compiler";
+import { NoTarget, type Program, type Type } from "@typespec/compiler";
 import type { AggregationKind, AggregationOptions } from "./decorators.js";
+import { reportDiagnostic } from "./lib.js";
 import type {
 	ResolvedProjection,
 	ResolvedProjectionField,
@@ -94,6 +95,51 @@ function collectAggregationsRecursive(
 
 function joinNestedPath(parent: string | undefined, segment: string): string {
 	return parent ? `${parent}.${segment}` : segment;
+}
+
+/**
+ * Two fields can derive the same aggregation name — `addressCountry` and a
+ * nested `address.country` both reach `byAddressCountry`, and singularizing a
+ * path segment widens the overlap. Assembly keeps the first and drops the
+ * rest, so the second aggregation would silently never run: say so instead.
+ */
+export function reportAggregationNameCollisions(
+	program: Program,
+	aggregations: readonly AggregationEntry[],
+): void {
+	const claimed = new Map<string, AggregationEntry>();
+	const reported = new Set<string>();
+
+	for (const entry of aggregations) {
+		const prior = claimed.get(entry.aggName);
+		if (!prior) {
+			claimed.set(entry.aggName, entry);
+			continue;
+		}
+		if (
+			prior.kind === entry.kind &&
+			prior.openSearchField === entry.openSearchField &&
+			prior.nestedPath === entry.nestedPath
+		) {
+			continue;
+		}
+		if (reported.has(entry.aggName)) {
+			continue;
+		}
+		reported.add(entry.aggName);
+		reportDiagnostic(program, {
+			code: "aggregation-name-collision",
+			format: {
+				aggName: entry.aggName,
+				first: prior.openSearchField,
+				second: entry.openSearchField,
+			},
+			target:
+				entry.field.projectionProperty ??
+				entry.field.sourceProperty ??
+				NoTarget,
+		});
+	}
 }
 
 export function hasAggregations(projection: ResolvedProjection): boolean {

--- a/src/emit-doc-type.test.ts
+++ b/src/emit-doc-type.test.ts
@@ -402,6 +402,45 @@ describe("doc type emitter", () => {
 		);
 	});
 
+	it("imports only the sub-projections its own interface names", async () => {
+		const emitted = await emitFor(
+			`
+			model Vet {
+				@searchable @keyword clinic: string;
+			}
+
+			model VetSearchDoc is SearchProjection<Vet> {}
+
+			model Tag {
+				@searchable @keyword name: string;
+				@searchable vet: Vet;
+			}
+
+			model TagSearchDoc is SearchProjection<Tag> {
+				vet: VetSearchDoc;
+			}
+
+			model Pet {
+				@searchable name: string;
+				@searchable @nested tags: Tag[];
+			}
+
+			@indexName("pets_v1")
+			model PetSearchDoc is SearchProjection<Pet> {
+				tags: TagSearchDoc[];
+			}
+			`,
+			"PetSearchDoc",
+		);
+
+		assert.ok(
+			emitted.content.includes(
+				'import type { TagSearchDoc } from "./tag-search-doc.js";',
+			),
+		);
+		assert.ok(!emitted.content.includes("VetSearchDoc"));
+	});
+
 	it("renders enum field as string literal union", async () => {
 		const emitted = await emitFor(
 			`

--- a/src/emit-doc-type.ts
+++ b/src/emit-doc-type.ts
@@ -45,21 +45,33 @@ export function collectSubProjections(
 	return result;
 }
 
+function directSubProjectionNames(projection: ResolvedProjection): string[] {
+	const names: string[] = [];
+	for (const field of projection.fields) {
+		const name = field.subProjection?.projectionModel.name;
+		if (!name || name === projection.projectionModel.name) {
+			continue;
+		}
+		if (!names.includes(name)) {
+			names.push(name);
+		}
+	}
+	return names;
+}
+
 export function emitDocType(
 	program: Program,
 	projection: ResolvedProjection,
 ): EmittedDocTypeFile {
 	const fileName = toDocTypeFileName(projection.projectionModel.name);
 
-	// Collect sub-projection imports needed
-	const subProjections = collectSubProjections(projection);
-	const imports = subProjections
-		.map((sp) => {
-			const subFile = toDocTypeFileName(sp.projectionModel.name).replace(
-				/\.ts$/,
-				".js",
-			);
-			return `import type { ${sp.projectionModel.name} } from "./${subFile}";`;
+	// Only the sub-projections this interface names: a deeper one is named by
+	// its own parent's file, and importing it here leaves an unused import
+	// behind (issue #197).
+	const imports = directSubProjectionNames(projection)
+		.map((name) => {
+			const subFile = toDocTypeFileName(name).replace(/\.ts$/, ".js");
+			return `import type { ${name} } from "./${subFile}";`;
 		})
 		.join("\n");
 

--- a/src/emit-graphql-sdl.ts
+++ b/src/emit-graphql-sdl.ts
@@ -10,6 +10,7 @@ import {
 	aggregationsTypeName,
 	collectAggregations,
 	hasAggregations,
+	reportAggregationNameCollisions,
 } from "./aggregations.js";
 import {
 	getGraphqlDirectives,
@@ -137,6 +138,7 @@ export function emitGraphQLSdl(
 	}
 
 	const aggEntries = collectAggregations(projection);
+	reportAggregationNameCollisions(program, aggEntries);
 	if (aggEntries.length > 0) {
 		lines.push(
 			renderAggregationTypes(typeName, aggEntries, projectionDirectives),

--- a/src/emit-index.test.ts
+++ b/src/emit-index.test.ts
@@ -49,6 +49,40 @@ describe("index emitter", () => {
 		);
 	});
 
+	it("exports the join-resolver interface of a joined document too", () => {
+		const projections = [
+			{
+				projectionModel: { name: "PetCareSearchDoc" },
+				sourceModel: { name: "Pet" },
+				indexName: "pet_care_v1",
+				fields: [
+					{
+						name: "passport",
+						subProjection: {
+							projectionModel: { name: "PetPassportSearchDoc" },
+							sourceModel: { name: "PetPassport" },
+							fields: [],
+							joins: [{ entity: { name: "Vet" } }],
+						},
+					},
+				],
+				joins: [{ entity: { name: "PetPassport" } }],
+			},
+		] as unknown as ResolvedProjection[];
+
+		const emitted = emitIndex(projections);
+		assert.ok(
+			emitted.content.includes(
+				'export type { PetPassportSearchDocJoinResolver } from "./pet-passport-search-doc-join-resolver.js";',
+			),
+		);
+		assert.ok(
+			emitted.content.includes(
+				'export type { PetCareSearchDocJoinResolver } from "./pet-care-search-doc-join-resolver.js";',
+			),
+		);
+	});
+
 	it("derives constant names from projection model names", () => {
 		assert.equal(
 			toIndexConstantName("CounterpartySearchDoc"),

--- a/src/emit-index.ts
+++ b/src/emit-index.ts
@@ -43,6 +43,10 @@ export function emitIndex(projections: TopLevelProjection[]): EmittedIndexFile {
 		lines.push(
 			`export type { ${sp.projectionModel.name} } from "./${docTypeFile}";`,
 		);
+		// A joined document carrying its own `@dependsOn` gets a join-resolver
+		// module too (issue #197). Emitting it without exporting it leaves the
+		// consumer nothing to implement the transitive read against.
+		lines.push(...joinResolverExport(sp));
 	}
 
 	for (const projection of sorted) {
@@ -55,20 +59,24 @@ export function emitIndex(projections: TopLevelProjection[]): EmittedIndexFile {
 		lines.push(
 			`export const ${toIndexConstantName(projection.projectionModel.name)} = "${projection.indexName}";`,
 		);
-		if (projection.joins && projection.joins.length > 0) {
-			const joinResolverFile = toJoinResolverFileName(
-				projection.projectionModel.name,
-			).replace(/\.ts$/, ".js");
-			lines.push(
-				`export type { ${toJoinResolverInterfaceName(projection.projectionModel.name)} } from "./${joinResolverFile}";`,
-			);
-		}
+		lines.push(...joinResolverExport(projection));
 	}
 
 	return {
 		fileName: "index.ts",
 		content: `${lines.join("\n")}\n`,
 	};
+}
+
+function joinResolverExport(projection: ResolvedProjection): string[] {
+	if (!projection.joins || projection.joins.length === 0) {
+		return [];
+	}
+	const name = projection.projectionModel.name;
+	const file = toJoinResolverFileName(name).replace(/\.ts$/, ".js");
+	return [
+		`export type { ${toJoinResolverInterfaceName(name)} } from "./${file}";`,
+	];
 }
 
 export function toIndexConstantName(projectionModelName: string): string {

--- a/src/emitter.test.ts
+++ b/src/emitter.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import type { Model } from "@typespec/compiler";
+import type { Model, Program } from "@typespec/compiler";
 import { createTestHost, createTestWrapper } from "@typespec/compiler/testing";
 import {
 	emitResolverBarrel,
@@ -124,7 +124,10 @@ describe("emitter model collection", () => {
 				],
 			},
 		] as unknown as ResolvedProjection[];
-		const serialized = __test.serializeProjections(projections);
+		const serialized = __test.serializeProjections(
+			{} as unknown as Program,
+			projections,
+		);
 
 		assert.deepEqual(serialized, {
 			projections: [

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -44,8 +44,8 @@ import {
 	sdlModuleSpecifier,
 } from "./emit-string-module.js";
 import {
+	collectJoinDependencies,
 	type ResolvableByManifestEntry,
-	toJoinDependencyManifestEntry,
 } from "./joins.js";
 import { type OpenSearchEmitterOptions, reportDiagnostic } from "./lib.js";
 import {
@@ -179,7 +179,7 @@ export async function $onEmit(
 
 		await emitFile(context.program, {
 			path: resolvePath(context.emitterOutputDir, outputFile),
-			content: `${JSON.stringify(serializeProjections(topLevel), null, 2)}\n`,
+			content: `${JSON.stringify(serializeProjections(context.program, topLevel), null, 2)}\n`,
 		});
 	}
 
@@ -442,35 +442,41 @@ function isTemplateDeclaration(model: Model): boolean {
 	return false;
 }
 
-function serializeProjections(resolved: TopLevelProjection[]) {
+function serializeProjections(
+	program: Program,
+	resolved: TopLevelProjection[],
+) {
 	return {
-		projections: resolved.map((projection) => ({
-			name: projection.projectionModel.name,
-			sourceModel: projection.sourceModel.name,
-			indexName: projection.indexName,
-			...(projection.indexSettings
-				? { indexSettings: projection.indexSettings }
-				: {}),
-			// `dependencies` (issue #194) is omitted when a projection declares
-			// no `@dependsOn`, so an unjoined spec emits an unchanged manifest.
-			...(projection.joins && projection.joins.length > 0
-				? {
-						dependencies: projection.joins.map(toJoinDependencyManifestEntry),
-					}
-				: {}),
-			fields: projection.fields.map((field) => ({
-				name: field.name,
-				...(field.projectedName ? { projectedName: field.projectedName } : {}),
-				optional: field.optional,
-				keyword: field.keyword,
-				nested: field.nested,
-				analyzer: field.analyzer,
-				boost: field.boost,
-				...(field.aggregations && field.aggregations.length > 0
-					? { aggregations: field.aggregations.map((d) => d.kind) }
+		projections: resolved.map((projection) => {
+			// `dependencies` (issue #194) is omitted when a projection composes
+			// nothing from another domain, so an unjoined spec emits an unchanged
+			// manifest. It closes over transitive joins (issue #197) — a write to
+			// an entity a joined document depends on re-indexes this one too.
+			const dependencies = collectJoinDependencies(program, projection);
+			return {
+				name: projection.projectionModel.name,
+				sourceModel: projection.sourceModel.name,
+				indexName: projection.indexName,
+				...(projection.indexSettings
+					? { indexSettings: projection.indexSettings }
 					: {}),
-			})),
-		})),
+				...(dependencies.length > 0 ? { dependencies } : {}),
+				fields: projection.fields.map((field) => ({
+					name: field.name,
+					...(field.projectedName
+						? { projectedName: field.projectedName }
+						: {}),
+					optional: field.optional,
+					keyword: field.keyword,
+					nested: field.nested,
+					analyzer: field.analyzer,
+					boost: field.boost,
+					...(field.aggregations && field.aggregations.length > 0
+						? { aggregations: field.aggregations.map((d) => d.kind) }
+						: {}),
+				})),
+			};
+		}),
 	};
 }
 
@@ -714,6 +720,14 @@ function generateTsConfig(
 			const subFileName = toDocTypeFileName(subProj.projectionModel.name);
 			if (!tsFiles.includes(subFileName)) {
 				tsFiles.push(subFileName);
+			}
+			if (subProj.joins && subProj.joins.length > 0) {
+				const subJoinFile = toJoinResolverFileName(
+					subProj.projectionModel.name,
+				);
+				if (!tsFiles.includes(subJoinFile)) {
+					tsFiles.push(subJoinFile);
+				}
 			}
 		}
 	}

--- a/src/filters.test.ts
+++ b/src/filters.test.ts
@@ -190,6 +190,35 @@ describe("collectFilterables", () => {
 			assert.equal(entry.openSearchField, "tags.name");
 		}
 	});
+
+	it("deepens the document path through a plain object sub-projection", () => {
+		const subProjection = {
+			projectionModel: { name: "Address" },
+			sourceModel: { name: "Address" },
+			fields: [
+				makeField({
+					name: "country",
+					keyword: true,
+					filterables: ["term"],
+				}),
+			],
+		} as unknown as ResolvedProjection;
+
+		const projection = makeProjection({
+			fields: [
+				makeField({
+					name: "address",
+					subProjection,
+					type: { kind: "Model", name: "Address" } as unknown as Type,
+				}),
+			],
+		});
+
+		const entries = collectFilterables(projection);
+		assert.equal(entries.length, 1);
+		assert.equal(entries[0].openSearchField, "address.country");
+		assert.equal(entries[0].nestedPath, undefined);
+	});
 });
 
 describe("hasFilterables", () => {

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -41,12 +41,19 @@ const RANGE_BOUND_SUFFIX: Record<RangeBound, string> = {
 export function collectFilterables(
 	projection: ResolvedProjection,
 ): FilterableEntry[] {
-	return collectFilterablesRecursive(projection, undefined);
+	return collectFilterablesRecursive(projection, undefined, undefined);
 }
 
+/**
+ * `documentPath` is where the field sits in the document; `nestedPath` is the
+ * `nested` wrapper the filter runs inside, which only a `@nested` field opens.
+ * A plain object sub-projection deepens the first and leaves the second alone,
+ * matching what the emitted filter spec already threads (issue #98).
+ */
 function collectFilterablesRecursive(
 	projection: ResolvedProjection,
 	nestedPath: string | undefined,
+	documentPath: string | undefined,
 ): FilterableEntry[] {
 	const entries: FilterableEntry[] = [];
 
@@ -56,15 +63,22 @@ function collectFilterablesRecursive(
 
 	for (const field of projection.fields) {
 		if (field.filterables && field.filterables.length > 0) {
-			entries.push(...filterableEntriesForField(field, nestedPath));
+			entries.push(
+				...filterableEntriesForField(field, nestedPath, documentPath),
+			);
 		}
 
 		if (field.subProjection) {
-			const childPath = field.nested
-				? joinNestedPath(nestedPath, field.projectedName ?? field.name)
-				: nestedPath;
+			const childPath = joinNestedPath(
+				documentPath,
+				field.projectedName ?? field.name,
+			);
 			entries.push(
-				...collectFilterablesRecursive(field.subProjection, childPath),
+				...collectFilterablesRecursive(
+					field.subProjection,
+					field.nested ? childPath : nestedPath,
+					childPath,
+				),
 			);
 		}
 	}
@@ -75,6 +89,7 @@ function collectFilterablesRecursive(
 function filterableEntriesForField(
 	field: ResolvedProjectionField,
 	nestedPath: string | undefined,
+	documentPath: string | undefined = nestedPath,
 ): FilterableEntry[] {
 	const entries: FilterableEntry[] = [];
 	const projectedName = field.projectedName ?? field.name;
@@ -88,8 +103,8 @@ function filterableEntriesForField(
 			!isAnalyzedKind(kind) && needsKeywordSuffix(field)
 				? `${projectedName}.keyword`
 				: projectedName;
-		const openSearchField = nestedPath
-			? `${nestedPath}.${fieldPart}`
+		const openSearchField = documentPath
+			? `${documentPath}.${fieldPart}`
 			: fieldPart;
 
 		if (kind === "range") {

--- a/src/joins.test.ts
+++ b/src/joins.test.ts
@@ -8,6 +8,7 @@ import { collectAggregations } from "./aggregations.js";
 import { getJoinDependencies, getResolvableBy } from "./decorators.js";
 import { buildSearchFilterShape } from "./filters.js";
 import {
+	collectJoinDependencies,
 	resolveJoinDependencies,
 	toJoinDependencyManifestEntry,
 	toResolvableByManifestEntry,
@@ -140,8 +141,8 @@ describe("@resolvableBy / @dependsOn", () => {
 		assert.ok(petCare);
 
 		assert.deepEqual(
-			resolveJoinDependencies(runner.program, petCare).map(
-				toJoinDependencyManifestEntry,
+			resolveJoinDependencies(runner.program, petCare).map((x) =>
+				toJoinDependencyManifestEntry(runner.program, x),
 			),
 			[
 				{
@@ -685,6 +686,231 @@ describe("projection resolution of join fields", () => {
 		);
 	});
 
+	it("reports join-cycle when a projection joins itself, instead of recursing forever", async () => {
+		const runner = await createRunner();
+		await runner.diagnose(`
+			@resolvableBy(Pet.petId)
+			model Pet {
+				@searchable @keyword petId: string;
+				@searchable @keyword name: string;
+				@searchable @keyword parentId: string;
+			}
+
+			@searchProjection
+			@indexName("pet_care_v1")
+			@dependsOn(Pet, "lookup", Pet.parentId)
+			model PetSearchDoc is SearchProjection<Pet> {
+				parent?: PetSearchDoc;
+			}
+
+			@route("/pets")
+			namespace Pets {
+				@restResolver @get op getPet(@path petId: string): Pet;
+			}
+		`);
+
+		const pet = runner.program
+			.getGlobalNamespaceType()
+			.models.get("PetSearchDoc");
+		assert.ok(pet);
+
+		const before = runner.program.diagnostics.length;
+		const resolved = resolveProjectionModel(runner.program, pet);
+		assert.ok(resolved);
+
+		const reported = withCode(
+			runner.program.diagnostics.slice(before),
+			"join-cycle",
+		);
+		assert.equal(reported.length, 1);
+		assert.equal(reported[0].target, pet.properties.get("parent"));
+
+		// The cycle takes the whole declaration with it: an entity the document
+		// does not carry must not name a re-index trigger either.
+		assert.deepEqual(
+			resolved.fields.map((x) => x.name),
+			["petId", "name", "parentId"],
+		);
+		assert.deepEqual(resolved.joins, []);
+	});
+
+	it("reports join-cycle when two projections compose each other", async () => {
+		const runner = await createRunner();
+		await runner.diagnose(`
+			@resolvableBy(Owner.ownerId)
+			model Owner {
+				@searchable @keyword ownerId: string;
+				@searchable @keyword petId: string;
+			}
+
+			@resolvableBy(Pet.petId)
+			model Pet {
+				@searchable @keyword petId: string;
+				@searchable @keyword ownerId: string;
+			}
+
+			@dependsOn(Owner, "lookup", Pet.ownerId)
+			model PetSearchDoc is SearchProjection<Pet> {
+				owner?: OwnerSearchDoc;
+			}
+
+			@searchProjection
+			@indexName("owners_v1")
+			@dependsOn(Pet, "lookup", Owner.petId)
+			model OwnerSearchDoc is SearchProjection<Owner> {
+				pet?: PetSearchDoc;
+			}
+
+			@route("/pets")
+			namespace Pets {
+				@restResolver @get op getPet(@path petId: string): Pet;
+			}
+
+			@route("/owners")
+			namespace Owners {
+				@restResolver @get op getOwner(@path ownerId: string): Owner;
+			}
+		`);
+
+		const owner = runner.program
+			.getGlobalNamespaceType()
+			.models.get("OwnerSearchDoc");
+		assert.ok(owner);
+
+		const before = runner.program.diagnostics.length;
+		const resolved = resolveProjectionModel(runner.program, owner);
+		assert.ok(resolved);
+
+		const reported = withCode(
+			runner.program.diagnostics.slice(before),
+			"join-cycle",
+		);
+		assert.equal(reported.length, 1);
+
+		const pet = resolved.fields.find((x) => x.name === "pet");
+		assert.ok(pet);
+		assert.deepEqual(
+			pet.subProjection?.fields.map((x) => x.name),
+			["petId", "ownerId"],
+		);
+		assert.deepEqual(pet.subProjection?.joins, []);
+	});
+
+	it("reports join-field-collision when a join field is already resolved from the source", async () => {
+		const runner = await createRunner();
+		await runner.diagnose(`
+			model Pet {
+				@searchable @keyword petId: string;
+				@searchable @keyword passport: string;
+			}
+
+			@resolvableBy(PetPassport.passportId)
+			model PetPassport {
+				passportId: string;
+				@searchable @keyword microchipId: string;
+			}
+
+			model PetPassportSearchDoc is SearchProjection<PetPassport> {}
+
+			@searchProjection
+			@indexName("pet_care_v1")
+			@dependsOn(PetPassport, "lookup", Pet.petId)
+			model PetCareSearchDoc is SearchProjection<Pet> {
+				passport?: PetPassportSearchDoc;
+			}
+
+			@route("/pet-passports")
+			namespace PetPassports {
+				@restResolver @get op getPetPassport(@path passportId: string): PetPassport;
+			}
+		`);
+
+		const petCare = runner.program
+			.getGlobalNamespaceType()
+			.models.get("PetCareSearchDoc");
+		assert.ok(petCare);
+
+		const before = runner.program.diagnostics.length;
+		const resolved = resolveProjectionModel(runner.program, petCare);
+		assert.ok(resolved);
+
+		const reported = withCode(
+			runner.program.diagnostics.slice(before),
+			"join-field-collision",
+		);
+		assert.equal(reported.length, 1);
+		assert.equal(reported[0].target, petCare.properties.get("passport"));
+
+		assert.deepEqual(
+			resolved.fields.map((x) => x.name),
+			["petId", "passport"],
+		);
+		assert.deepEqual(resolved.joins, []);
+	});
+
+	it("composes an entity declaring only @filterable and @aggregatable", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+			model Pet {
+				@searchable @keyword petId: string;
+				@searchable @keyword passportId: string;
+			}
+
+			@resolvableBy(PetPassport.passportId)
+			model PetPassport {
+				passportId: string;
+				@keyword @filterable("term") @aggregatable("terms") issuedCountry: string;
+			}
+
+			@searchProjection
+			@indexName("pet_care_v1")
+			@dependsOn(PetPassport, "lookup", Pet.passportId)
+			model PetCareSearchDoc is SearchProjection<Pet> {
+				passport?: PetPassport;
+			}
+
+			@route("/pet-passports")
+			namespace PetPassports {
+				@restResolver @get op getPetPassport(@path passportId: string): PetPassport;
+			}
+		`);
+
+		assert.deepEqual(diagnostics.map(shortCode), []);
+	});
+
+	it("reports join-field-not-composed for a search document that resolves no field", async () => {
+		const runner = await createRunner();
+		const diagnostics = await runner.diagnose(`
+			model Pet {
+				@searchable @keyword petId: string;
+				@searchable @keyword passportId: string;
+			}
+
+			@resolvableBy(PetPassport.passportId)
+			model PetPassport {
+				passportId: string;
+				microchipId: string;
+			}
+
+			model PetPassportSearchDoc is SearchProjection<PetPassport> {}
+
+			@searchProjection
+			@indexName("pet_care_v1")
+			@dependsOn(PetPassport, "lookup", Pet.passportId)
+			model PetCareSearchDoc is SearchProjection<Pet> {
+				passport?: PetPassportSearchDoc;
+			}
+
+			@route("/pet-passports")
+			namespace PetPassports {
+				@restResolver @get op getPetPassport(@path passportId: string): PetPassport;
+			}
+		`);
+
+		const reported = withCode(diagnostics, "join-field-not-composed");
+		assert.equal(reported.length, 1);
+	});
+
 	it("still reports a field that no join accounts for", async () => {
 		const runner = await createRunner();
 		await runner.diagnose(`
@@ -715,5 +941,159 @@ describe("projection resolution of join fields", () => {
 		);
 		assert.equal(reported.length, 1);
 		assert.equal(reported[0].target, petCare.properties.get("kennelName"));
+	});
+
+	it("carries the filter and aggregation contract of an entity-typed join field", async () => {
+		const runner = await createRunner();
+		await runner.diagnose(`
+			model Pet {
+				@searchable @keyword petId: string;
+				@searchable @keyword passportId: string;
+			}
+
+			@resolvableBy(PetPassport.passportId)
+			model PetPassport {
+				passportId: string;
+				@searchable @keyword @filterable("term") @aggregatable("terms") issuedCountry: string;
+				notInTheDocument: string;
+			}
+
+			@searchProjection
+			@indexName("pet_care_v1")
+			@dependsOn(PetPassport, "lookup", Pet.passportId)
+			model PetCareSearchDoc is SearchProjection<Pet> {
+				passport?: PetPassport;
+			}
+
+			@route("/pet-passports")
+			namespace PetPassports {
+				@restResolver @get op getPetPassport(@path passportId: string): PetPassport;
+			}
+		`);
+
+		const petCare = runner.program
+			.getGlobalNamespaceType()
+			.models.get("PetCareSearchDoc");
+		assert.ok(petCare);
+
+		const resolved = resolveProjectionModel(runner.program, petCare);
+		assert.ok(resolved);
+
+		const passport = resolved.fields.find((x) => x.name === "passport");
+		assert.deepEqual(
+			passport?.subProjection?.fields.map((x) => x.name),
+			["issuedCountry"],
+		);
+
+		assert.deepEqual(
+			collectAggregations(resolved).map((x) => [x.aggName, x.openSearchField]),
+			[["byPassportIssuedCountry", "passport.issuedCountry"]],
+		);
+
+		assert.deepEqual(
+			buildSearchFilterShape(resolved)?.nodes.map((x) => [x.inputName, x.kind]),
+			[["passport", "object"]],
+		);
+	});
+});
+
+describe("join dependency manifest entries", () => {
+	it("closes over a transitive join, keyed by its path in the composed document", async () => {
+		const runner = await createRunner();
+		await runner.diagnose(`
+			model Pet {
+				@searchable @keyword petId: string;
+				@searchable @keyword passportId: string;
+			}
+
+			@resolvableBy(PetPassport.passportId)
+			model PetPassport {
+				passportId: string;
+				@searchable @keyword vetId: string;
+			}
+
+			@resolvableBy(Vet.vetId)
+			model Vet {
+				vetId: string;
+				@searchable @keyword clinic: string;
+			}
+
+			model VetSearchDoc is SearchProjection<Vet> {}
+
+			@dependsOn(Vet, "lookup", PetPassport.vetId)
+			model PetPassportSearchDoc is SearchProjection<PetPassport> {
+				vet?: VetSearchDoc;
+			}
+
+			@searchProjection
+			@indexName("pet_care_v1")
+			@dependsOn(PetPassport, "lookup", Pet.passportId)
+			model PetCareSearchDoc is SearchProjection<Pet> {
+				passport?: PetPassportSearchDoc;
+			}
+
+			@route("/pet-passports")
+			namespace PetPassports {
+				@restResolver @get op getPetPassport(@path passportId: string): PetPassport;
+			}
+
+			@route("/vets")
+			namespace Vets {
+				@restResolver @get op getVet(@path vetId: string): Vet;
+			}
+		`);
+
+		const petCare = runner.program
+			.getGlobalNamespaceType()
+			.models.get("PetCareSearchDoc");
+		assert.ok(petCare);
+
+		const resolved = resolveProjectionModel(runner.program, petCare);
+		assert.ok(resolved);
+
+		assert.deepEqual(collectJoinDependencies(runner.program, resolved), [
+			{
+				entity: "PetPassport",
+				direction: "lookup",
+				joinKey: "passportId",
+				field: "passport",
+			},
+			{
+				entity: "Vet",
+				direction: "lookup",
+				joinKey: "vetId",
+				field: "passport.vet",
+			},
+		]);
+	});
+
+	it("names the document key a @searchAs rename moves the joined value to", async () => {
+		const runner = await createRunner();
+		await runner.diagnose(`
+			${ENTITIES}
+
+			@searchProjection
+			@indexName("pet_care_v1")
+			@dependsOn(PetPassport, "lookup", Pet.passportId)
+			model PetCareSearchDoc is SearchProjection<Pet> {
+				@searchAs("travelDocument")
+				passport?: PetPassportSearchDoc;
+			}
+
+			${READS}
+		`);
+
+		const petCare = runner.program
+			.getGlobalNamespaceType()
+			.models.get("PetCareSearchDoc");
+		assert.ok(petCare);
+
+		const resolved = resolveProjectionModel(runner.program, petCare);
+		assert.ok(resolved);
+
+		assert.deepEqual(
+			collectJoinDependencies(runner.program, resolved).map((x) => x.field),
+			["travelDocument"],
+		);
 	});
 });

--- a/src/joins.ts
+++ b/src/joins.ts
@@ -10,6 +10,9 @@ import { getHttpOperation } from "@typespec/http";
 import {
 	getJoinDependencies,
 	getResolvableBy,
+	getSearchAs,
+	hasAggregatable,
+	hasFilterable,
 	isRestResolver,
 	isSearchable,
 	isSearchInfer,
@@ -17,7 +20,7 @@ import {
 import { reportDiagnostic } from "./lib.js";
 import {
 	getProjectionSourceModel,
-	isSearchProjectionModel,
+	type ResolvedProjection,
 } from "./projection.js";
 
 export const JOIN_DIRECTIONS = ["lookup", "inbound"] as const;
@@ -130,11 +133,38 @@ export function candidateJoinFields(
 }
 
 /**
+ * True when a property lands in the composed document. `@searchable` puts it in
+ * the response shape; `@filterable` and `@aggregatable` put it in the index for
+ * query-time use. Any of the three is a statement about what the document
+ * carries, so all three admit the field the same way projection resolution
+ * does.
+ */
+function contributesToDocument(
+	program: Program,
+	property: ModelProperty,
+): boolean {
+	return (
+		isSearchable(program, property) ||
+		hasFilterable(program, property) ||
+		hasAggregatable(program, property)
+	);
+}
+
+function declaresDocumentContent(program: Program, model: Model): boolean {
+	if (isSearchInfer(program, model)) {
+		return model.properties.size > 0;
+	}
+	return [...model.properties.values()].some((property) =>
+		contributesToDocument(program, property),
+	);
+}
+
+/**
  * True when something states which of the joined entity enters the document
- * (issue #195): a `SearchProjection<T>` document, a `@searchInfer` model whose
- * fields the emitter derives, or a plain model with `@searchable` properties.
- * A model offering none of the three composes into an empty object, which the
- * mapping and the SDL cannot express.
+ * (issue #195): a `SearchProjection<T>` document that resolves at least one
+ * field, a `@searchInfer` model whose fields the emitter derives, or a plain
+ * model declaring what it contributes. A model offering none of the three
+ * composes into an empty object, which the mapping and the SDL cannot express.
  */
 export function composesIntoDocument(
 	program: Program,
@@ -144,15 +174,16 @@ export function composesIntoDocument(
 	if (joined.kind !== "Model") {
 		return false;
 	}
-	if (
-		isSearchProjectionModel(program, joined) ||
-		isSearchInfer(program, joined)
-	) {
-		return true;
+	const sourceModel = getProjectionSourceModel(program, joined);
+	if (sourceModel) {
+		if (getJoinDependencies(program, joined).length > 0) {
+			return true;
+		}
+		return isSearchInfer(program, joined)
+			? sourceModel.properties.size > 0
+			: declaresDocumentContent(program, sourceModel);
 	}
-	return [...joined.properties.values()].some((property) =>
-		isSearchable(program, property),
-	);
+	return declaresDocumentContent(program, joined);
 }
 
 export function resolveJoinDependencies(
@@ -206,14 +237,85 @@ function hasExpectedArity(
 	return direction === "inbound" ? isArray : !isArray;
 }
 
+/**
+ * Every entity a document is composed from, the ones reached through another
+ * join included (issue #197). A joined document carrying its own `@dependsOn`
+ * puts that entity's rows in the driving document, so a write there re-indexes
+ * it just the same — a manifest listing only the first hop names fewer triggers
+ * than the document actually has.
+ *
+ * The closure is flat: `field` carries the joined value's key path in the
+ * composed document, dotted for a transitive entry, which is where a consumer
+ * places the value and how two hops over the same entity stay apart.
+ */
+export function collectJoinDependencies(
+	program: Program,
+	projection: ResolvedProjection,
+): JoinDependencyManifestEntry[] {
+	const entries: JoinDependencyManifestEntry[] = [];
+	const seen = new Set<string>();
+
+	const walk = (current: ResolvedProjection, prefix: string | undefined) => {
+		for (const dependency of current.joins ?? []) {
+			const entry = toJoinDependencyManifestEntry(
+				program,
+				dependency,
+				documentKeyPath(program, dependency.field, prefix),
+			);
+			const key = JSON.stringify(entry);
+			if (seen.has(key)) {
+				continue;
+			}
+			seen.add(key);
+			entries.push(entry);
+		}
+
+		for (const field of current.fields) {
+			if (!field.subProjection) {
+				continue;
+			}
+			walk(
+				field.subProjection,
+				documentKeyPath(
+					program,
+					field.sourceProperty,
+					prefix,
+					field.projectedName,
+				),
+			);
+		}
+	};
+
+	walk(projection, undefined);
+	return entries;
+}
+
+function documentKeyPath(
+	program: Program,
+	property: ModelProperty,
+	prefix: string | undefined,
+	projectedName?: string,
+): string {
+	const key = projectedName ?? getSearchAs(program, property) ?? property.name;
+	return prefix ? `${prefix}.${key}` : key;
+}
+
+/**
+ * `field` names the document key the joined value lands in, so it carries the
+ * projected name — a `@searchAs` rename moves the key, and a consumer placing
+ * the value by the TypeSpec property name would write a key the mapping does
+ * not declare.
+ */
 export function toJoinDependencyManifestEntry(
+	program: Program,
 	dependency: ResolvedJoinDependency,
+	field = documentKeyPath(program, dependency.field, undefined),
 ): JoinDependencyManifestEntry {
 	return {
 		entity: dependency.entity.name,
 		direction: dependency.direction,
 		joinKey: dependency.joinKey.name,
-		field: dependency.field.name,
+		field,
 		...(dependency.index ? { index: dependency.index } : {}),
 	};
 }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -251,7 +251,25 @@ export const $lib = createTypeSpecLibrary({
 		"join-field-not-composed": {
 			severity: "error",
 			messages: {
-				default: paramMessage`Field "${"field"}" is bound to a join over "${"entity"}", but nothing states which of that model enters the document: it is neither a SearchProjection<${"entity"}> nor a @searchInfer model, and carries no @searchable property. Composing it would emit an empty object, which the mapping and the SDL cannot express. Type the field as a SearchProjection<${"entity"}> document, or declare on "${"entity"}" what the document carries.`,
+				default: paramMessage`Field "${"field"}" is bound to a join over "${"entity"}", but nothing states which of that model enters the document: it is neither a @searchInfer model nor a SearchProjection<${"entity"}> resolving at least one field, and carries no @searchable, @filterable or @aggregatable property. Composing it would emit an empty object, which the mapping and the SDL cannot express. Type the field as a SearchProjection<${"entity"}> document, or declare on "${"entity"}" what the document carries.`,
+			},
+		},
+		"join-cycle": {
+			severity: "error",
+			messages: {
+				default: paramMessage`Field "${"field"}" composes "${"entity"}" into "${"projection"}", which is already being composed — a document cannot contain itself, and each hop would re-index the one before it without ever settling. Break the cycle by pointing one side at a document that carries no join back.`,
+			},
+		},
+		"join-field-collision": {
+			severity: "error",
+			messages: {
+				default: paramMessage`Join field "${"name"}" collides with a field already resolved from source model "${"sourceModel"}". A join fills a field of its own; rename either the joined field or the source property so each one names a distinct document key.`,
+			},
+		},
+		"aggregation-name-collision": {
+			severity: "error",
+			messages: {
+				default: paramMessage`Two different aggregations both resolve to the name "${"aggName"}": "${"first"}" and "${"second"}". The generated aggregations type carries one field per name, so the second would silently never run. Rename one of the fields, or give one of them a distinct @searchAs name.`,
 			},
 		},
 		"join-read-operation-missing": {

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -47,6 +47,7 @@ import {
 	candidateJoinFields,
 	type ResolvedJoinDependency,
 	resolveJoinDependencies,
+	unwrapArrayElement,
 } from "./joins.js";
 import { reportDiagnostic } from "./lib.js";
 import {
@@ -128,6 +129,8 @@ export function resolveProjectionModel(
 	}
 
 	const inferOnModel = isSearchInfer(program, projectionModel);
+	// Composition path: a model already on it cannot be composed into itself.
+	const visited: ReadonlySet<string> = new Set([projectionModel.name]);
 
 	const fields: ResolvedProjectionField[] = [];
 	for (const sourceProperty of sourceModel.properties.values()) {
@@ -150,6 +153,7 @@ export function resolveProjectionModel(
 			const subProj = resolveSubProjectionFromType(
 				program,
 				projectionProperty.type,
+				visited,
 			);
 			if (subProj) {
 				field.subProjection = subProj;
@@ -165,11 +169,7 @@ export function resolveProjectionModel(
 			!isSearchSkip(program, sourceProperty) &&
 			shouldVirtualRecurse(program, field.type, inferOnModel)
 		) {
-			const virtual = buildVirtualSubProjection(
-				program,
-				field.type,
-				new Set([projectionModel.name]),
-			);
+			const virtual = buildVirtualSubProjection(program, field.type, visited);
 			if (virtual) {
 				field.subProjection = virtual;
 			}
@@ -218,7 +218,11 @@ export function resolveProjectionModel(
 			);
 
 			// Check for sub-projection on the projection property
-			const subProj = resolveSubProjectionFromType(program, projProp.type);
+			const subProj = resolveSubProjectionFromType(
+				program,
+				projProp.type,
+				visited,
+			);
 			if (subProj) {
 				field.subProjection = subProj;
 			}
@@ -229,10 +233,11 @@ export function resolveProjectionModel(
 		}
 
 		if (!sourceProp || !isReachable(program, sourceProp, inferOnModel)) {
-			// Allow sub-projection fields that reference a valid source field
-			const subProj = resolveSubProjectionFromType(program, projProp.type);
+			// Allow sub-projection fields that reference a valid source field.
+			// Naming one is all this asks — resolving it here would report its
+			// diagnostics a second time.
 			if (
-				(!subProj || !sourceProp) &&
+				(!namesSubProjection(program, projProp.type) || !sourceProp) &&
 				!isJoinProvidedField(program, projectionModel, projProp)
 			) {
 				reportDiagnostic(program, {
@@ -244,10 +249,15 @@ export function resolveProjectionModel(
 		}
 	}
 
-	const joins = resolveJoinDependencies(program, projectionModel);
-	for (const join of joins) {
-		fields.push(resolveJoinField(program, projectionModel, join, inferOnModel));
-	}
+	const joins = composeJoinFields(
+		program,
+		projectionModel,
+		sourceModel,
+		inferOnModel,
+		visited,
+		fields,
+		resolvedFieldNames,
+	);
 
 	return {
 		projectionModel,
@@ -257,6 +267,50 @@ export function resolveProjectionModel(
 		fields,
 		joins,
 	};
+}
+
+/**
+ * Appends the fields a projection's `@dependsOn` declarations fill, dropping
+ * any declaration that cannot take its place in the document: one composing a
+ * model already on the composition path, and one whose field name is already
+ * taken by the source model. Both are reported, and neither reaches `joins` —
+ * a dependency the document does not carry would name a re-index trigger for a
+ * field that is not there.
+ */
+function composeJoinFields(
+	program: Program,
+	projectionModel: Model,
+	sourceModel: Model,
+	inferOnModel: boolean,
+	visited: ReadonlySet<string>,
+	fields: ResolvedProjectionField[],
+	resolvedFieldNames: Set<string>,
+): ResolvedJoinDependency[] {
+	const joins: ResolvedJoinDependency[] = [];
+	for (const join of resolveJoinDependencies(program, projectionModel)) {
+		const field = resolveJoinField(
+			program,
+			projectionModel,
+			join,
+			inferOnModel,
+			visited,
+		);
+		if (!field) {
+			continue;
+		}
+		if (resolvedFieldNames.has(field.name)) {
+			reportDiagnostic(program, {
+				code: "join-field-collision",
+				format: { name: field.name, sourceModel: sourceModel.name },
+				target: join.field,
+			});
+			continue;
+		}
+		resolvedFieldNames.add(field.name);
+		fields.push(field);
+		joins.push(join);
+	}
+	return joins;
 }
 
 /**
@@ -270,22 +324,40 @@ function resolveJoinField(
 	projectionModel: Model,
 	join: ResolvedJoinDependency,
 	inferOnModel: boolean,
-): ResolvedProjectionField {
+	visited: ReadonlySet<string>,
+): ResolvedProjectionField | undefined {
+	const joined = unwrapArrayElement(join.field.type) ?? join.field.type;
+	if (joined.kind === "Model" && visited.has(joined.name)) {
+		reportDiagnostic(program, {
+			code: "join-cycle",
+			format: {
+				field: join.field.name,
+				entity: joined.name,
+				projection: projectionModel.name,
+			},
+			target: join.field,
+		});
+		return undefined;
+	}
+
 	const field = resolveProjectionField(
 		program,
 		join.field,
 		join.field,
 		inferOnModel,
 	);
+	// A joined field composes whether or not the type is a SearchProjection<T>:
+	// an entity typed directly still owes the document its filter and
+	// aggregation contract, so it gets a sub-projection over what it declares
+	// rather than a bare object the specs silently skip (issue #197).
 	const subProjection =
-		resolveSubProjectionFromType(program, field.type) ??
-		(shouldVirtualRecurse(program, field.type, inferOnModel)
-			? buildVirtualSubProjection(
-					program,
-					field.type,
-					new Set([projectionModel.name]),
-				)
-			: undefined);
+		resolveSubProjectionFromType(program, field.type, visited) ??
+		buildVirtualSubProjection(
+			program,
+			field.type,
+			visited,
+			shouldVirtualRecurse(program, field.type, inferOnModel),
+		);
 
 	return { ...field, searchable: true, subProjection };
 }
@@ -556,10 +628,17 @@ function unwrapStructModel(type: Type): Model | undefined {
 	return undefined;
 }
 
+/**
+ * `infer` is off when the model states its own contribution field by field —
+ * a joined entity typed directly (issue #197). Then only the properties a
+ * decorator admits compose, and their explicit directives are all that carries,
+ * matching what the document type and the mapping already emit for it.
+ */
 function buildVirtualSubProjection(
 	program: Program,
 	type: Type,
-	visited: Set<string>,
+	visited: ReadonlySet<string>,
+	infer = true,
 ): ResolvedProjection | undefined {
 	let model: Model | undefined;
 	if (type.kind === "Model") {
@@ -590,8 +669,12 @@ function buildVirtualSubProjection(
 	const fields: ResolvedProjectionField[] = [];
 	for (const prop of model.properties.values()) {
 		if (isSearchSkip(program, prop)) continue;
-		const field = resolveProjectionField(program, prop, undefined, true);
-		if (!field.subProjection) {
+		if (!infer && !isReachable(program, prop, false)) continue;
+		const field = resolveProjectionField(program, prop, undefined, infer);
+		if (
+			!field.subProjection &&
+			shouldVirtualRecurse(program, field.type, infer)
+		) {
 			const nestedVirtual = buildVirtualSubProjection(
 				program,
 				field.type,
@@ -618,17 +701,27 @@ function buildVirtualSubProjection(
  * Given a Type, check if it is (or is an array of) a SearchProjection model,
  * and if so resolve it recursively.
  */
+function namesSubProjection(program: Program, type: Type): boolean {
+	if (type.kind !== "Model") {
+		return false;
+	}
+	const element = unwrapArrayElement(type);
+	const model = element?.kind === "Model" ? element : type;
+	return !!getProjectionSourceModel(program, model);
+}
+
 function resolveSubProjectionFromType(
 	program: Program,
 	type: Type,
+	visited: ReadonlySet<string>,
 ): ResolvedProjection | undefined {
 	// Handle direct model reference: TagSearchDoc
 	if (type.kind === "Model") {
 		// Handle Array<TagSearchDoc> — e.g. TagSearchDoc[]
 		if (type.name === "Array" && type.indexer?.value?.kind === "Model") {
-			return resolveSubProjectionModel(program, type.indexer.value);
+			return resolveSubProjectionModel(program, type.indexer.value, visited);
 		}
-		return resolveSubProjectionModel(program, type);
+		return resolveSubProjectionModel(program, type, visited);
 	}
 	return undefined;
 }
@@ -636,11 +729,19 @@ function resolveSubProjectionFromType(
 function resolveSubProjectionModel(
 	program: Program,
 	model: Model,
+	parentVisited: ReadonlySet<string>,
 ): ResolvedProjection | undefined {
 	const sourceModel = getProjectionSourceModel(program, model);
 	if (!sourceModel) {
 		return undefined;
 	}
+
+	// Already being composed further up the path: stop rather than recurse
+	// forever. A join into the cycle reports join-cycle and drops the field.
+	if (parentVisited.has(model.name)) {
+		return undefined;
+	}
+	const visited: ReadonlySet<string> = new Set(parentVisited).add(model.name);
 
 	const inferOnModel = isSearchInfer(program, model);
 
@@ -662,6 +763,7 @@ function resolveSubProjectionModel(
 			const subProj = resolveSubProjectionFromType(
 				program,
 				projectionProperty.type,
+				visited,
 			);
 			if (subProj) {
 				field.subProjection = subProj;
@@ -676,11 +778,7 @@ function resolveSubProjectionModel(
 			!isSearchSkip(program, sourceProperty) &&
 			shouldVirtualRecurse(program, field.type, inferOnModel)
 		) {
-			const virtual = buildVirtualSubProjection(
-				program,
-				field.type,
-				new Set([model.name]),
-			);
+			const virtual = buildVirtualSubProjection(program, field.type, visited);
 			if (virtual) {
 				field.subProjection = virtual;
 			}
@@ -689,10 +787,15 @@ function resolveSubProjectionModel(
 		fields.push(field);
 	}
 
-	const joins = resolveJoinDependencies(program, model);
-	for (const join of joins) {
-		fields.push(resolveJoinField(program, model, join, inferOnModel));
-	}
+	const joins = composeJoinFields(
+		program,
+		model,
+		sourceModel,
+		inferOnModel,
+		visited,
+		fields,
+		new Set(fields.map((x) => x.name)),
+	);
 
 	return {
 		projectionModel: model,

--- a/test/pet-care-example.js
+++ b/test/pet-care-example.js
@@ -3,6 +3,7 @@ import { execFile } from "node:child_process";
 import { readFile, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import test from "node:test";
+import { pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 import Ajv2020 from "ajv/dist/2020.js";
 
@@ -219,6 +220,28 @@ test("a joined field filters and facets like any other field of its type", async
 	assert.ok(resolver.includes('field: "passport.issuedCountry"'));
 });
 
+// Faceting the inbound side means aggregating inside the `nested` wrapper the
+// mapping opens for it, which no other case in the suite exercises.
+test("an aggregation on the @nested inbound side runs inside its nested path", async () => {
+	const sdl = await readFile(`${EMIT_DIR}/pet-care-search-doc.graphql`, "utf8");
+	assert.match(sdl, /^ {2}byOwnershipHistoryOwnerName: \[TermBucket!\]!$/m);
+
+	const resolver = await readFile(
+		`${EMIT_DIR}/pet-care-search-doc-resolver.js`,
+		"utf8",
+	);
+	assert.ok(
+		resolver.includes(
+			'{n:"byOwnershipHistoryOwnerName",g:"_ownershipHistory",p:"ownershipHistory"',
+		),
+	);
+	assert.ok(
+		resolver.includes(
+			"byOwnershipHistoryOwnerName: (_a_ownershipHistory.byOwnershipHistoryOwnerName?.buckets ?? [])",
+		),
+	);
+});
+
 test("the manifest's fields[] carries the joined fields alongside the source ones", async () => {
 	const manifest = await readJson("opensearch-projections.json");
 	const petCare = manifest.projections.find(
@@ -308,6 +331,94 @@ export const nugget: PetCareSearchDoc = {
 	);
 
 	await execFileAsync("npx", ["tsc", "-p", `${EMIT_DIR}/tsconfig.json`]);
+});
+
+// The type says the key may be absent; this runs the compose and checks it
+// actually is. A left join that wrote `passport: undefined` would satisfy the
+// type and still put an unmapped null in the index.
+test("an unresolved lookup leaves the key off the composed document", async () => {
+	await writeFile(
+		`${EMIT_DIR}/left-join-compose.ts`,
+		`import type { PetCareSearchDoc } from "./pet-care-search-doc.js";
+import type { PetCareSearchDocJoinResolver } from "./pet-care-search-doc-join-resolver.js";
+
+interface Pet {
+	petId: string;
+	name: string;
+	species: string;
+	passportId: string;
+}
+
+export async function compose(
+	pet: Pet,
+	resolver: PetCareSearchDocJoinResolver,
+): Promise<PetCareSearchDoc> {
+	const passport = await resolver.lookupPassport(pet.passportId);
+	const ownershipHistory = await resolver.discoverOwnershipHistory(pet.petId);
+
+	return {
+		...pet,
+		...(passport ? { passport } : {}),
+		ownershipHistory,
+	};
+}
+`,
+	);
+
+	await writeFile(
+		`${EMIT_DIR}/tsconfig.compose.json`,
+		JSON.stringify(
+			{
+				compilerOptions: {
+					module: "NodeNext",
+					moduleResolution: "NodeNext",
+					target: "ES2020",
+					strict: true,
+					outDir: "./dist",
+				},
+				include: ["*.ts"],
+			},
+			null,
+			2,
+		),
+	);
+
+	await execFileAsync("npx", [
+		"tsc",
+		"-p",
+		`${EMIT_DIR}/tsconfig.compose.json`,
+	]);
+
+	const { compose } = await import(
+		pathToFileURL(`${EMIT_DIR}/dist/left-join-compose.js`).href
+	);
+
+	const nugget = await compose(
+		{ petId: "nugget", name: "Nugget", species: "cat", passportId: "" },
+		{
+			lookupPassport: async () => undefined,
+			discoverOwnershipHistory: async () => [],
+		},
+	);
+
+	assert.equal("passport" in nugget, false);
+	assert.deepEqual(nugget.ownershipHistory, []);
+
+	const waffles = await compose(
+		{ petId: "waffles", name: "Waffles", species: "dog", passportId: "NL-01" },
+		{
+			lookupPassport: async () => ({
+				microchipId: "982000123456789",
+				issuedCountry: "NL",
+				vaccinations: ["rabies"],
+			}),
+			discoverOwnershipHistory: async () => [
+				{ ownerName: "Iris", transferredAt: "2026-03-01T00:00:00Z" },
+			],
+		},
+	);
+
+	assert.equal(waffles.passport.issuedCountry, "NL");
 });
 
 test("the schemas resolve through the package exports map", async () => {

--- a/test/pet-care/main.tsp
+++ b/test/pet-care/main.tsp
@@ -31,7 +31,7 @@ model OwnershipRecord {
 	ownershipRecordId: string;
 	petId: string;
 
-	@searchable @keyword @filterable("term") ownerName: string;
+	@searchable @keyword @filterable("term") @aggregatable("terms") ownerName: string;
 	@searchable @filterable("range") transferredAt: utcDateTime;
 }
 


### PR DESCRIPTION
A joined entity now composes the same whichever way it is typed, and every entity a document is composed from — transitive ones included — appears in its dependencies.

Seven defects from the post-merge review of #198: a join cycle crashed, an entity-typed field lost its filter and aggregation contract, a name collision emitted twice, and the manifest named fewer re-index triggers than the document actually had.

Each fix carries a regression test; the pet-care example gains an aggregation on the inbound nested side and a runtime check that an unresolved lookup leaves the key off.

Closes #199